### PR TITLE
Add `names` argument to vector constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -209,6 +209,10 @@ See below for a complete list of changes.
   all classes are present in order and `inherits_only()` checks that
   the class vectors are identical.
 
+* The vector constructors such as `new_integer()`,
+  `new_double_along()` etc gain a `names` argument. In the case of the
+  `_along` family it defaults to the names of the input vector.
+
 
 ## Bugfixes
 

--- a/R/attr.R
+++ b/R/attr.R
@@ -227,13 +227,16 @@ has_name <- function(x, name) {
 #' # `...` is passed to the function:
 #' set_names(head(mtcars), paste0, "_foo")
 set_names <- function(x, nm = x, ...) {
+  set_names_impl(x, x, nm, ...)
+}
+set_names_impl <- function(x, mold, nm, ...) {
   if (!is_vector(x)) {
     abort("`x` must be a vector")
   }
 
   if (is_function(nm) || is_formula(nm)) {
     nm <- as_function(nm)
-    nm <- nm(names2(x), ...)
+    nm <- nm(names2(mold), ...)
   } else if (!is_null(nm)) {
     if (dots_n(...)) {
       nm <- as.character(c(nm, ...))

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -488,40 +488,40 @@ list_len <- function(.n) {
 #' @rdname vector-old-ctors
 #' @export
 lgl_along <- function(.x) {
-  new_logical_along(.x)
+  new_logical_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 int_along <- function(.x) {
-  new_integer_along(.x)
+  new_integer_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 dbl_along <- function(.x) {
-  new_double_along(.x)
+  new_double_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 chr_along <- function(.x) {
-  new_character_along(.x)
+  new_character_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 cpl_along <- function(.x) {
-  new_complex_along(.x)
+  new_complex_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 raw_along <- function(.x) {
-  new_raw_along(.x)
+  new_raw_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 bytes_along <- function(.x) {
-  new_raw_along(.x)
+  new_raw_along(.x, NULL)
 }
 #' @rdname vector-old-ctors
 #' @export
 list_along <- function(.x) {
-  new_list_along(.x)
+  new_list_along(.x, NULL)
 }

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -147,8 +147,7 @@ ll <- function(...) {
 #' zero-filled vectors.
 #'
 #' @param n The vector length.
-#' @param names Names for the new vector. This is passed to
-#'   [set_names()] and thus supports renaming functions.
+#' @param names Names for the new vector.
 #' @keywords internal
 #' @examples
 #' new_list(10)
@@ -203,8 +202,7 @@ new_list <- function(n, names = NULL) {
 #' @param x,.x A vector.
 #' @param .y Values to repeat.
 #' @param names Names for the new vector. Defaults to the names of
-#'   `x`. This is passed to [set_names()] and thus supports renaming
-#'   functions.
+#'   `x`.
 #' @keywords internal
 #' @examples
 #' x <- 0:5

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -147,6 +147,8 @@ ll <- function(...) {
 #' zero-filled vectors.
 #'
 #' @param n The vector length.
+#' @param names Names for the new vector. This is passed to
+#'   [set_names()] and thus supports renaming functions.
 #' @keywords internal
 #' @examples
 #' new_list(10)
@@ -157,38 +159,38 @@ NULL
 
 #' @rdname new-vector
 #' @export
-new_logical <- function(n) {
-  rep_len(na_lgl, n)
+new_logical <- function(n, names = NULL) {
+  set_names(rep_len(na_lgl, n), names)
 }
 #' @rdname new-vector
 #' @export
-new_integer <- function(n) {
-  rep_len(na_int, n)
+new_integer <- function(n, names = NULL) {
+  set_names(rep_len(na_int, n), names)
 }
 #' @rdname new-vector
 #' @export
-new_double <- function(n) {
-  rep_len(na_dbl, n)
+new_double <- function(n, names = NULL) {
+  set_names(rep_len(na_dbl, n), names)
 }
 #' @rdname new-vector
 #' @export
-new_character <- function(n) {
-  rep_len(na_chr, n)
+new_character <- function(n, names = NULL) {
+  set_names(rep_len(na_chr, n), names)
 }
 #' @rdname new-vector
 #' @export
-new_complex <- function(n) {
-  rep_len(na_cpl, n)
+new_complex <- function(n, names = NULL) {
+  set_names(rep_len(na_cpl, n), names)
 }
 #' @rdname new-vector
 #' @export
-new_raw <- function(n) {
-  vector("raw", n)
+new_raw <- function(n, names = NULL) {
+  set_names(vector("raw", n), names)
 }
 #' @rdname new-vector
 #' @export
-new_list <- function(n) {
-  vector("list", n)
+new_list <- function(n, names = NULL) {
+  set_names(vector("list", n), names)
 }
 
 #' Create vectors matching the length of a given vector

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -200,53 +200,59 @@ new_list <- function(n, names = NULL) {
 #' Except for `new_list_along()` and `new_raw_along()`, the empty
 #' vectors are filled with typed `missing` values.
 #'
-#' @inheritParams set_attrs
 #' @param x,.x A vector.
 #' @param .y Values to repeat.
+#' @param names Names for the new vector. Defaults to the names of
+#'   `x`. This is passed to [set_names()] and thus supports renaming
+#'   functions.
 #' @keywords internal
 #' @examples
 #' x <- 0:5
 #' rep_along(x, 1:2)
 #' rep_along(x, 1)
 #' new_list_along(x)
+#'
+#' # The default names are picked up from the input vector
+#' x <- c(a = "foo", b = "bar")
+#' new_character_along(x)
 #' @name new-vector-along
 #' @seealso new-vector
 NULL
 
 #' @export
 #' @rdname new-vector-along
-new_logical_along <- function(x) {
-  rep_len(na_lgl, length(x))
+new_logical_along <- function(x, names = base::names(x)) {
+  set_names(rep_len(na_lgl, length(x)), names)
 }
 #' @export
 #' @rdname new-vector-along
-new_integer_along <- function(x) {
-  rep_len(na_int, length(x))
+new_integer_along <- function(x, names = base::names(x)) {
+  set_names(rep_len(na_int, length(x)), names)
 }
 #' @export
 #' @rdname new-vector-along
-new_double_along <- function(x) {
-  rep_len(na_dbl, length(x))
+new_double_along <- function(x, names = base::names(x)) {
+  set_names(rep_len(na_dbl, length(x)), names)
 }
 #' @export
 #' @rdname new-vector-along
-new_character_along <- function(x) {
-  rep_len(na_chr, length(x))
+new_character_along <- function(x, names = base::names(x)) {
+  set_names(rep_len(na_chr, length(x)), names)
 }
 #' @export
 #' @rdname new-vector-along
-new_complex_along <- function(x) {
-  rep_len(na_cpl, length(x))
+new_complex_along <- function(x, names = base::names(x)) {
+  set_names(rep_len(na_cpl, length(x)), names)
 }
 #' @export
 #' @rdname new-vector-along
-new_raw_along <- function(x) {
-  vector("raw", length(x))
+new_raw_along <- function(x, names = base::names(x)) {
+  set_names(vector("raw", length(x)), names)
 }
 #' @export
 #' @rdname new-vector-along
-new_list_along <- function(x) {
-  vector("list", length(x))
+new_list_along <- function(x, names = base::names(x)) {
+  set_names(vector("list", length(x)), names)
 }
 
 #' @export

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -202,7 +202,8 @@ new_list <- function(n, names = NULL) {
 #' @param x,.x A vector.
 #' @param .y Values to repeat.
 #' @param names Names for the new vector. Defaults to the names of
-#'   `x`.
+#'   `x`. This can be a function to apply to the names of `x` as in
+#'   [set_names()].
 #' @keywords internal
 #' @examples
 #' x <- 0:5
@@ -220,37 +221,37 @@ NULL
 #' @export
 #' @rdname new-vector-along
 new_logical_along <- function(x, names = base::names(x)) {
-  set_names(rep_len(na_lgl, length(x)), names)
+  set_names_impl(rep_len(na_lgl, length(x)), x, names)
 }
 #' @export
 #' @rdname new-vector-along
 new_integer_along <- function(x, names = base::names(x)) {
-  set_names(rep_len(na_int, length(x)), names)
+  set_names_impl(rep_len(na_int, length(x)), x, names)
 }
 #' @export
 #' @rdname new-vector-along
 new_double_along <- function(x, names = base::names(x)) {
-  set_names(rep_len(na_dbl, length(x)), names)
+  set_names_impl(rep_len(na_dbl, length(x)), x, names)
 }
 #' @export
 #' @rdname new-vector-along
 new_character_along <- function(x, names = base::names(x)) {
-  set_names(rep_len(na_chr, length(x)), names)
+  set_names_impl(rep_len(na_chr, length(x)), x, names)
 }
 #' @export
 #' @rdname new-vector-along
 new_complex_along <- function(x, names = base::names(x)) {
-  set_names(rep_len(na_cpl, length(x)), names)
+  set_names_impl(rep_len(na_cpl, length(x)), x, names)
 }
 #' @export
 #' @rdname new-vector-along
 new_raw_along <- function(x, names = base::names(x)) {
-  set_names(vector("raw", length(x)), names)
+  set_names_impl(vector("raw", length(x)), x, names)
 }
 #' @export
 #' @rdname new-vector-along
 new_list_along <- function(x, names = base::names(x)) {
-  set_names(vector("list", length(x)), names)
+  set_names_impl(vector("list", length(x)), x, names)
 }
 
 #' @export

--- a/man/new-vector-along.Rd
+++ b/man/new-vector-along.Rd
@@ -32,8 +32,7 @@ rep_along(.x, .y)
 \item{x, .x}{A vector.}
 
 \item{names}{Names for the new vector. Defaults to the names of
-\code{x}. This is passed to \code{\link[=set_names]{set_names()}} and thus supports renaming
-functions.}
+\code{x}.}
 
 \item{.y}{Values to repeat.}
 }

--- a/man/new-vector-along.Rd
+++ b/man/new-vector-along.Rd
@@ -12,24 +12,28 @@
 \alias{rep_along}
 \title{Create vectors matching the length of a given vector}
 \usage{
-new_logical_along(x)
+new_logical_along(x, names = base::names(x))
 
-new_integer_along(x)
+new_integer_along(x, names = base::names(x))
 
-new_double_along(x)
+new_double_along(x, names = base::names(x))
 
-new_character_along(x)
+new_character_along(x, names = base::names(x))
 
-new_complex_along(x)
+new_complex_along(x, names = base::names(x))
 
-new_raw_along(x)
+new_raw_along(x, names = base::names(x))
 
-new_list_along(x)
+new_list_along(x, names = base::names(x))
 
 rep_along(.x, .y)
 }
 \arguments{
 \item{x, .x}{A vector.}
+
+\item{names}{Names for the new vector. Defaults to the names of
+\code{x}. This is passed to \code{\link[=set_names]{set_names()}} and thus supports renaming
+functions.}
 
 \item{.y}{Values to repeat.}
 }
@@ -44,6 +48,10 @@ x <- 0:5
 rep_along(x, 1:2)
 rep_along(x, 1)
 new_list_along(x)
+
+# The default names are picked up from the input vector
+x <- c(a = "foo", b = "bar")
+new_character_along(x)
 }
 \seealso{
 new-vector

--- a/man/new-vector-along.Rd
+++ b/man/new-vector-along.Rd
@@ -32,7 +32,8 @@ rep_along(.x, .y)
 \item{x, .x}{A vector.}
 
 \item{names}{Names for the new vector. Defaults to the names of
-\code{x}.}
+\code{x}. This can be a function to apply to the names of \code{x} as in
+\code{\link[=set_names]{set_names()}}.}
 
 \item{.y}{Values to repeat.}
 }

--- a/man/new-vector.Rd
+++ b/man/new-vector.Rd
@@ -28,8 +28,7 @@ new_list(n, names = NULL)
 \arguments{
 \item{n}{The vector length.}
 
-\item{names}{Names for the new vector. This is passed to
-\code{\link[=set_names]{set_names()}} and thus supports renaming functions.}
+\item{names}{Names for the new vector.}
 }
 \description{
 These functions construct vectors of given length, with attributes

--- a/man/new-vector.Rd
+++ b/man/new-vector.Rd
@@ -11,22 +11,25 @@
 \alias{new_list}
 \title{Create vectors matching a given length}
 \usage{
-new_logical(n)
+new_logical(n, names = NULL)
 
-new_integer(n)
+new_integer(n, names = NULL)
 
-new_double(n)
+new_double(n, names = NULL)
 
-new_character(n)
+new_character(n, names = NULL)
 
-new_complex(n)
+new_complex(n, names = NULL)
 
-new_raw(n)
+new_raw(n, names = NULL)
 
-new_list(n)
+new_list(n, names = NULL)
 }
 \arguments{
 \item{n}{The vector length.}
+
+\item{names}{Names for the new vector. This is passed to
+\code{\link[=set_names]{set_names()}} and thus supports renaming functions.}
 }
 \description{
 These functions construct vectors of given length, with attributes

--- a/tests/testthat/test-vec-new.R
+++ b/tests/testthat/test-vec-new.R
@@ -102,6 +102,17 @@ test_that("vector ctors take names arguments", {
   expect_identical(new_list(2, letters[1:2]), list(a = NULL, b = NULL))
 })
 
+test_that("vector _along() ctors pick up names", {
+  x <- list(a = NULL, b = NULL)
+  expect_identical(new_logical_along(x), c(a = NA, b = NA))
+  expect_identical(new_integer_along(x), c(a = na_int, b = na_int))
+  expect_identical(new_double_along(x), c(a = na_dbl, b = na_dbl))
+  expect_identical(new_complex_along(x), c(a = na_cpl, b = na_cpl))
+  expect_identical(new_character_along(x), c(a = na_chr, b = na_chr))
+  expect_identical(new_raw_along(x), set_names(raw(2), c("a", "b")))
+  expect_identical(new_list_along(x), list(a = NULL, b = NULL))
+})
+
 test_that("retired _len() ctors still work", {
   expect_identical(lgl_len(2), new_logical(2))
   expect_identical(int_len(2), new_integer(2))

--- a/tests/testthat/test-vec-new.R
+++ b/tests/testthat/test-vec-new.R
@@ -92,6 +92,16 @@ test_that("ll() is an alias to list2()", {
   expect_identical(ll(!!! list(1, 2)), list(1, 2))
 })
 
+test_that("vector ctors take names arguments", {
+  expect_identical(new_logical(2, letters[1:2]), c(a = NA, b = NA))
+  expect_identical(new_integer(2, letters[1:2]), c(a = na_int, b = na_int))
+  expect_identical(new_double(2, letters[1:2]), c(a = na_dbl, b = na_dbl))
+  expect_identical(new_complex(2, letters[1:2]), c(a = na_cpl, b = na_cpl))
+  expect_identical(new_character(2, letters[1:2]), c(a = na_chr, b = na_chr))
+  expect_identical(new_raw(2, letters[1:2]), set_names(raw(2), c("a", "b")))
+  expect_identical(new_list(2, letters[1:2]), list(a = NULL, b = NULL))
+})
+
 test_that("retired _len() ctors still work", {
   expect_identical(lgl_len(2), new_logical(2))
   expect_identical(int_len(2), new_integer(2))

--- a/tests/testthat/test-vec-new.R
+++ b/tests/testthat/test-vec-new.R
@@ -113,6 +113,17 @@ test_that("vector _along() ctors pick up names", {
   expect_identical(new_list_along(x), list(a = NULL, b = NULL))
 })
 
+test_that("vector _along() ctors pick up names", {
+  x <- list(a = NULL, b = NULL)
+  expect_identical(new_logical_along(x, toupper), c(A = NA, B = NA))
+  expect_identical(new_integer_along(x, toupper), c(A = na_int, B = na_int))
+  expect_identical(new_double_along(x, toupper), c(A = na_dbl, B = na_dbl))
+  expect_identical(new_complex_along(x, toupper), c(A = na_cpl, B = na_cpl))
+  expect_identical(new_character_along(x, toupper), c(A = na_chr, B = na_chr))
+  expect_identical(new_raw_along(x, toupper), set_names(raw(2), c("A", "B")))
+  expect_identical(new_list_along(x, toupper), list(A = NULL, B = NULL))
+})
+
 test_that("retired _len() ctors still work", {
   expect_identical(lgl_len(2), new_logical(2))
   expect_identical(int_len(2), new_integer(2))


### PR DESCRIPTION
Includes #403 

For the `_along` family it defaults to the names of the input vector which should be useful when pre-allocating output with `new_list_along()` etc.