### PR TITLE
testthat >= 2.0.0 is required for tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Suggests:
     crayon,
     methods,
     pillar,
-    testthat,
+    testthat >= 2.0.0,
     covr
 RoxygenNote: 6.0.1
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
This is due to the [`expect_reference` call in `test-quotation.R`](https://github.com/r-lib/rlang/blob/master/tests/testthat/test-quotation.R#L434).