### PR TITLE
Use .Call instead of .Primitive(".Call")

### DIFF
--- a/R/c-api.R
+++ b/R/c-api.R
@@ -8,7 +8,7 @@ init_c_constants <- function() {
       formals(function(...) NULL),
 
     tilde_thunk_body =
-      expr((!!.Call)(!!(rlang_tilde_eval),
+      expr((!!expr(.Call))(!!(rlang_tilde_eval),
         sys.call(),
         "data_mask_arg",
         "data_mask_top_arg",


### PR DESCRIPTION
for the tilde thunk. With this patch:

``` r
library(rlang); eval_tidy(quo(`~`))
#> function (...) 
#> .Call(list(name = "rlang_tilde_eval", address = <pointer: 0x5613a31c3030>, 
#>     dll = list(name = "rlang", path = "/home/muelleki/R/x86_64-pc-linux-gnu-library/3.4/rlang/libs/rlang.so", 
#>         dynamicLookup = FALSE, handle = <pointer: 0x5613a4e5a120>, 
#>         info = <pointer: 0x5613a20f6650>), numParameters = 4L), 
#>     sys.call(), <environment>, <environment>, environment())
#> <environment: base>
```

> Created on 2018-03-17 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).