### PR TITLE
Treat bare functions as exiting handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # rlang 0.2.0.9000
 
+* `with_handlers()` treats bare functions as exiting handlers
+  (equivalent to handlers supplied to `tryCatch()`).
+
+* `with_handlers()` now produces a cleaner stack trace.
+
 * The vector predicates have been rewritten in C for performance.
 
 * The `finite` argument of `is_integerish()` is now `NULL` by
@@ -9,8 +14,6 @@
 
 * `is_bare_integerish()` and `is_scalar_integerish()` gain a `finite`
   argument for consistency with `is_integerish()`.
-
-* `with_handlers()` now produces a cleaner stack trace.
 
 * New `calltrace()` captures the call trace, which is similar to traceback,
   but contains additional structure about the relationship between frames.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 # rlang 0.2.0.9000
 
 * `with_handlers()` treats bare functions as exiting handlers
-  (equivalent to handlers supplied to `tryCatch()`).
+  (equivalent to handlers supplied to `tryCatch()`). It also supports
+  the formula shortcut for lambda functions (as in purrr).
 
 * `with_handlers()` now produces a cleaner stack trace.
 

--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -34,7 +34,8 @@
 #' @param ... Named handlers. These should be functions of one
 #'   argument. These handlers are treated as exiting by default. Use
 #'   [inplace()] to specify an inplace handler. These dots support
-#'   [tidy dots][tidy-dots] features.
+#'   [tidy dots][tidy-dots] features and are passed to [as_function()]
+#'   to enable the formula shortcut for lambda functions.
 #' @seealso [exiting()], [inplace()].
 #' @export
 #' @examples
@@ -80,10 +81,7 @@
 #' }
 #' with_handlers(fn2(), foo = inplace(exiting_handler), foo = inplace(other_handler))
 with_handlers <- function(.expr, ...) {
-  handlers <- list2(...)
-  if (!every(handlers, is_function)) {
-    abort("All handlers should be functions")
-  }
+  handlers <- map(list2(...), as_function)
 
   is_inplace <- map_lgl(handlers, inherits, "inplace")
   inplace <- handlers[is_inplace]

--- a/man/with_handlers.Rd
+++ b/man/with_handlers.Rd
@@ -11,10 +11,10 @@ with_handlers(.expr, ...)
 handlers are established. The underscored version takes a quoted
 expression or a quoted formula.}
 
-\item{...}{Named handlers. Handlers should inherit from \code{exiting}
-or \code{inplace}. See \code{\link[=exiting]{exiting()}} and \code{\link[=inplace]{inplace()}} for constructing
-such handlers. Dots are evaluated with \link[=tidy-dots]{explicit
-splicing}.}
+\item{...}{Named handlers. These should be functions of one
+argument. These handlers are treated as exiting by default. Use
+\code{\link[=inplace]{inplace()}} to specify an inplace handler. These dots support
+\link[=tidy-dots]{tidy dots} features.}
 }
 \description{
 Condition handlers are functions established on the evaluation
@@ -65,6 +65,9 @@ h <- function() {
 # executed. Their return value is handed over:
 handler <- function(c) "handler return value"
 with_handlers(fn(), foo = exiting(handler))
+
+# Handlers are exiting by default so you can omit the adjective:
+with_handlers(fn(), foo = handler)
 
 # In place handlers are called in turn and their return value is
 # ignored. Returning just means they are declining to take charge of

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -144,6 +144,10 @@ test_that("with_handlers() establishes inplace and exiting handlers", {
   expect_output(expect_equal(with_handlers({ cnd_signal("foobar"); letters }, splice(handlers)), identity(letters)), "foobar")
 })
 
+test_that("bare functions are treated as exiting handlers", {
+  expect_identical(with_handlers(abort("foo"), error = function(cnd) "caught"), "caught")
+})
+
 test_that("set_names2() fills in empty names", {
   chr <- c("a", b = "B", "c")
   expect_equal(set_names2(chr), c(a = "a", b = "B", c = "c"))

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -148,6 +148,11 @@ test_that("bare functions are treated as exiting handlers", {
   expect_identical(with_handlers(abort("foo"), error = function(cnd) "caught"), "caught")
 })
 
+test_that("with_handlers() supports formula shortcut for lambdas", {
+  err <- with_handlers(abort("foo", "bar"), error = ~.x)
+  expect_true(inherits(err, "bar"))
+})
+
 test_that("set_names2() fills in empty names", {
   chr <- c("a", b = "B", "c")
   expect_equal(set_names2(chr), c(a = "a", b = "B", c = "c"))


### PR DESCRIPTION
So `with_handlers(expr, error = identity)` is equivalent to `tryCatch(expr, error = identity)`.

Closes #499 