### PR TITLE
Fix build and simulated interrupts on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ inst/doc
 .httr-oauth
 revdep/checks
 revdep/library
+src/config.h

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+# DO NOT CHANGE the "init" and "install" sections below
+
+# Download script file from GitHub
+init:
+  ps: |
+        $ErrorActionPreference = "Stop"
+        Invoke-WebRequest http://raw.github.com/krlmlr/r-appveyor/master/scripts/appveyor-tool.ps1 -OutFile "..\appveyor-tool.ps1"
+        Import-Module '..\appveyor-tool.ps1'
+
+install:
+  ps: Bootstrap
+
+cache:
+  - C:\RLibrary
+
+# Adapt as necessary starting from here
+
+build_script:
+  - travis-tool.sh install_deps
+
+test_script:
+  - travis-tool.sh run_tests
+
+on_failure:
+  - 7z a failure.zip *.Rcheck\*
+  - appveyor PushArtifact failure.zip
+
+artifacts:
+  - path: '*.Rcheck\**\*.log'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.out'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.fail'
+    name: Logs
+
+  - path: '*.Rcheck\**\*.Rout'
+    name: Logs
+
+  - path: '\*_*.tar.gz'
+    name: Bits
+
+  - path: '\*_*.zip'
+    name: Bits

--- a/configure
+++ b/configure
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+rm -f src/config.h
+
+# Assume all Unix platforms have Rinterface.h
+echo '#define RLANG_HAS_RINTERFACE_H 1' >> src/config.h
+
+exit 0

--- a/configure.win
+++ b/configure.win
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+rm -f src/config.h
+touch src/config.h
+
+exit 0

--- a/src/lib/cnd.c
+++ b/src/lib/cnd.c
@@ -139,10 +139,20 @@ void r_cnd_signal(sexp* cnd) {
 }
 
 
+#ifdef RLANG_HAS_RINTERFACE_H
 #include <Rinterface.h>
 void r_interrupt() {
   Rf_onintr();
+  r_abort("Internal error: Simulated interrupt not processed");
 }
+#else
+#include <Rembedded.h>
+void r_interrupt() {
+  UserBreak = 1;
+  R_CheckUserInterrupt();
+  r_abort("Internal error: Simulated interrupt not processed");
+}
+#endif
 
 enum r_condition_type r_cnd_type(sexp* cnd) {
   sexp* classes = r_get_class(cnd);

--- a/src/lib/rlang.h
+++ b/src/lib/rlang.h
@@ -8,6 +8,8 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 
+#include "../config.h"
+
 typedef struct SEXPREC sexp;
 typedef Rbyte r_byte_t;
 typedef Rcomplex r_complex_t;

--- a/tests/testthat/calltrace-print.txt
+++ b/tests/testthat/calltrace-print.txt
@@ -1,7 +1,7 @@
 █
-└─i() testthat/test-calltrace.R:16:2
-  └─j(i) testthat/test-calltrace.R:8:7
-    └─k(i) testthat/test-calltrace.R:9:21
-      └─l(i) testthat/test-calltrace.R:12:4
+└─i() testthat/test-calltrace.R:18:2
+  └─j(i) testthat/test-calltrace.R:10:7
+    └─k(i) testthat/test-calltrace.R:11:21
+      └─l(i) testthat/test-calltrace.R:14:4
 
 █

--- a/tests/testthat/test-calltrace.R
+++ b/tests/testthat/test-calltrace.R
@@ -2,6 +2,8 @@ context("calltrace.R")
 
 # This test must come first because print method includes srcrefs
 test_that("tree printing only changes deliberately", {
+  skip_on_os("windows")
+
   dir <- normalizePath(test_path(".."))
 
   e <- environment()


### PR DESCRIPTION
cc @mvkorpel

@kevinushey Is this a portable and safe way of simulating interrupts on Windows environments? Cf `r_interrupt()` in cnd.c.