### PR TITLE
Fix calltrace

### DIFF
--- a/R/calltrace.R
+++ b/R/calltrace.R
@@ -148,7 +148,7 @@ trace_as_tree <- function(x, dir = getwd()) {
   nodes <- c(0, seq_along(x$calls))
   children <- map(nodes, function(id) seq_along(x$parents)[x$parents == id])
 
-  call_text <- map_chr(as.list(x$calls), expr_name)
+  call_text <- map(x$calls, src_text)
 
   refs <- map(x$calls, attr, "srcref")
   src_locs <- map_chr(refs, src_loc, dir = dir)
@@ -159,6 +159,14 @@ trace_as_tree <- function(x, dir = getwd()) {
   tree$call <- c(trace_root(), call_text)
 
   tree
+}
+
+src_text <- function(call) {
+  srcref <- attr(call, "srcref")
+  if (!is_null(srcref)) {
+    call <- parse_expr(as.character(srcref))
+  }
+  expr_name(call)
 }
 
 src_loc <- function(srcref, dir = getwd()) {

--- a/R/calltrace.R
+++ b/R/calltrace.R
@@ -148,7 +148,7 @@ trace_as_tree <- function(x, dir = getwd()) {
   nodes <- c(0, seq_along(x$calls))
   children <- map(nodes, function(id) seq_along(x$parents)[x$parents == id])
 
-  call_text <- map(x$calls, src_text)
+  call_text <- map_chr(as.list(x$calls), expr_name)
 
   refs <- map(x$calls, attr, "srcref")
   src_locs <- map_chr(refs, src_loc, dir = dir)
@@ -159,14 +159,6 @@ trace_as_tree <- function(x, dir = getwd()) {
   tree$call <- c(trace_root(), call_text)
 
   tree
-}
-
-src_text <- function(call) {
-  srcref <- attr(call, "srcref")
-  if (!is_null(srcref)) {
-    call <- parse_expr(as.character(srcref))
-  }
-  expr_name(call)
 }
 
 src_loc <- function(srcref, dir = getwd()) {

--- a/R/calltrace.R
+++ b/R/calltrace.R
@@ -139,7 +139,7 @@ trace_simplify <- function(x) {
   path <- integer()
   id <- length(x$parents)
 
-  while (id != 0) {
+  while (id != 0L) {
     path <- c(path, id)
     id <- x$parents[id]
   }
@@ -154,8 +154,8 @@ trace_as_tree <- function(x, dir = getwd()) {
   children <- map(nodes, function(id) seq_along(x$parents)[x$parents == id])
 
   call_text <- map_chr(as.list(x$calls), expr_name)
-  src_loc <- map_chr(x$refs, src_loc, dir = dir)
-  call_text <- paste0(call_text, " ", src_loc)
+  src_locs <- map_chr(x$refs, src_loc, dir = dir)
+  call_text <- paste0(call_text, " ", src_locs)
 
   tree <- data.frame(id = as.character(nodes), stringsAsFactors = FALSE)
   tree$children <- map(children, as.character)
@@ -164,11 +164,12 @@ trace_as_tree <- function(x, dir = getwd()) {
   tree
 }
 
-src_loc <- function(x, dir = getwd()) {
-  if (is.null(x))
+src_loc <- function(srcref, dir = getwd()) {
+  if (is.null(srcref)) {
     return("")
+  }
 
-  srcfile <- attr(x, "srcfile")
+  srcfile <- attr(srcref, "srcfile")
   if (is.null(srcfile)) {
     return("")
   }
@@ -177,10 +178,7 @@ src_loc <- function(x, dir = getwd()) {
     return("")
   }
 
-  if (length(srcref) == 6L)
-    srcref <- c(srcref, srcref[c(1L, 3L)])
-
-  paste0(relish(file, dir = dir), ":", x[[1]], ":", x[[5]])
+  paste0(relish(file, dir = dir), ":", srcref[[1]], ":", srcref[[5]])
 }
 
 relish <- function(x, dir = getwd()) {
@@ -191,7 +189,13 @@ relish <- function(x, dir = getwd()) {
   gsub(dir, "", x, fixed = TRUE)
 }
 
-trace_root <- function() if (cli_is_utf8_output()) "\u2588" else "x"
+trace_root <- function() {
+  if (cli_is_utf8_output()) {
+    "\u2588"
+  } else {
+    "x"
+  }
+}
 
 # Misc --------------------------------------------------------------------
 

--- a/tests/testthat/calltrace-print.txt
+++ b/tests/testthat/calltrace-print.txt
@@ -1,6 +1,6 @@
 █
-└─x <- i() testthat/test-calltrace.R:16:2
-  └─function(i) j(i) testthat/test-calltrace.R:8:7
+└─i() testthat/test-calltrace.R:16:2
+  └─j(i) testthat/test-calltrace.R:8:7
     └─k(i) testthat/test-calltrace.R:9:21
       └─l(i) testthat/test-calltrace.R:12:4
 

--- a/tests/testthat/calltrace-print.txt
+++ b/tests/testthat/calltrace-print.txt
@@ -1,6 +1,6 @@
 █
-└─i() testthat/test-calltrace.R:16:2
-  └─j(i) testthat/test-calltrace.R:8:7
+└─x <- i() testthat/test-calltrace.R:16:2
+  └─function(i) j(i) testthat/test-calltrace.R:8:7
     └─k(i) testthat/test-calltrace.R:9:21
       └─l(i) testthat/test-calltrace.R:12:4
 

--- a/tests/testthat/calltrace-print.txt
+++ b/tests/testthat/calltrace-print.txt
@@ -1,6 +1,7 @@
 █
-└─j() testthat/test-calltrace.R:8:8
-  └─k(i) testthat/test-calltrace.R:9:8
-    └─l(i) testthat/test-calltrace.R:10:8
+└─i() testthat/test-calltrace.R:16:2
+  └─j(i) testthat/test-calltrace.R:8:7
+    └─k(i) testthat/test-calltrace.R:9:21
+      └─l(i) testthat/test-calltrace.R:12:4
 
 █

--- a/tests/testthat/test-calltrace.R
+++ b/tests/testthat/test-calltrace.R
@@ -5,11 +5,15 @@ test_that("tree printing only changes deliberately", {
   dir <- normalizePath(test_path(".."))
 
   e <- environment()
-  j <- function(i) k(i)
-  k <- function(i) l(i)
+  i <- function(i) j(i)
+  j <- function(i) { k(i) }
+  k <- function(i) {
+    NULL
+    l(i)
+  }
   l <- function(i) calltrace(e)
 
-  x <- j()
+  x <- i()
 
   expect_known_output({
     print(x, dir = dir)


### PR DESCRIPTION
With this fix the srcrefs are grabbed from the sys.calls. This way the srcrefs reference the location of the call rather than the location of the definition of the function being called.

I toyed with using the srcrefs to print the calls themselves, which would allow us to get more accurate calls in case primitive functions are involved (we could observe `x <- i()` instead of just `i()`). However I found some issues when function bodies are not wrapped in `{`. I took note of this problem in my backlog of R core issues to fix.

I find there's something odd about `calltrace()`. I feel it lacks an underscore, however I don't want to use `call_` as a prefix here. How about `backtrace()` or `trace_back()`?