### PR TITLE
Add experimental support for `.Last.error`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # rlang 0.2.0.9000
 
+* Uncaught error objects can now be recorded in `.Last.error` just
+  like `.Last.value` references the last value returned at top-level.
+  This is experimental and currently fails with errors thrown at top
+  level (i.e. from a primitive function called directly at the
+  console).
+
 * The experimental function `rst_muffle()` is now defunct. Please use
   `cnd_muffle()` instead. Unlike its predecessor `cnd_muffle()` is not
   generic. It is marked as a calling handler and thus can be passed

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -452,12 +452,17 @@ catch_cnd <- function(expr) {
 # This returns an expression that has to be evaluated at top-level
 # because the only way to add a top-level handler is from a delayed
 # binding
-enable_last_error_expr <- function() {
+enable_last_error_expr <- function(ask = TRUE) {
   expr({
-    sel <- utils::menu(
-      c("Yes", "No"),
-      title = "Would you like to enable `.Last.error` capture?"
-    )
+    if (ask) {
+      sel <- utils::menu(
+        c("Yes", "No"),
+        title = "Would you like to enable `.Last.error` capture?"
+      )
+    } else {
+      sel <- 1L
+    }
+
     if (sel == 1L) {
       get(".Internal")(.addCondHands("error", !!list(last_error_handler), globalenv(), NULL, TRUE))
       cat("Capture of uncaught errors in `.Last.error` is now enabled\n")
@@ -506,11 +511,11 @@ reset_last_error_binding <- function(...) {
     removeTaskCallback(id)
   }
 }
-set_last_error_binding <- function() {
-  env_bind_exprs(rlang_attached_env(), .Last.error = !!enable_last_error_expr())
+set_last_error_binding <- function(ask = TRUE) {
+  env_bind_exprs(rlang_attached_env(), .Last.error = !!enable_last_error_expr(ask))
 }
 
 enable_last_error <- function() {
-  reset_last_error_binding()
+  set_last_error_binding(ask = FALSE)
   cat("Now type `.Last.error` at the console to enable error recording\n")
 }

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -447,3 +447,70 @@ catch_cnd <- function(expr) {
     return(NULL)
   })
 }
+
+
+# This returns an expression that has to be evaluated at top-level
+# because the only way to add a top-level handler is from a delayed
+# binding
+enable_last_error_expr <- function() {
+  expr({
+    sel <- utils::menu(
+      c("Yes", "No"),
+      title = "Would you like to enable `.Last.error` capture?"
+    )
+    if (sel == 1L) {
+      get(".Internal")(.addCondHands("error", !!list(last_error_handler), globalenv(), NULL, TRUE))
+      cat("Capture of uncaught errors in `.Last.error` is now enabled\n")
+    } else {
+      invisible(addTaskCallback(
+        reset_last_error_binding,
+        name = "rlang_reset_last_error_binding"
+      ))
+    }
+  })
+}
+utils::globalVariables(".addCondHands")
+
+last_error_handler <- function(err) {
+  env <- rlang_attached_env()
+  env$.Last.error <- err
+
+  frames <- sys.frames()
+
+  # If there are only two frames they belong to .handleSimpleError()
+  # and this means the error was thrown from the top level
+  if (length(frames) == 2L) {
+    message("Recording of errors is now disabled, please call `rlang:::enable_last_error()`")
+    return(NULL)
+  }
+
+  # Avoid longjump from resetting the top level handler stack by
+  # returning to global frame. Need to print the error message to
+  # stderr manually.
+  if (is_null(err$call)) {
+    call <- ""
+  } else {
+    call <- paste0(" in ", expr_text(err$call))
+  }
+  msg <- sprintf("Error%s: %s\n", call, conditionMessage(err))
+  cat(msg, file = stderr())
+
+  return_from(frames[[1]], quote(invisible(NULL)))
+}
+
+reset_last_error_binding <- function(...) {
+  set_last_error_binding()
+
+  id <- match("rlang_reset_last_error_binding", getTaskCallbackNames())
+  if (!is_na(id)) {
+    removeTaskCallback(id)
+  }
+}
+set_last_error_binding <- function() {
+  env_bind_exprs(rlang_attached_env(), .Last.error = !!enable_last_error_expr())
+}
+
+enable_last_error <- function() {
+  reset_last_error_binding()
+  cat("Now type `.Last.error` at the console to enable error recording\n")
+}

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -4,7 +4,17 @@ NULL
 .onLoad <- function(lib, pkg) {
   init_c_constants()
   .Call(rlang_library_load)
+
+  while ("rlang" %in% search()) {
+    detach("rlang")
+  }
+  get("attach")(list(), name = "rlang")
+
+  set_last_error_binding()
 }
 .onUnload <- function(lib) {
   .Call(rlang_library_unload)
+  get("detach")("rlang")
 }
+
+rlang_attached_env <- function() scoped_env("rlang")


### PR DESCRIPTION
When rlang is loaded `.Last.error` is installed as a delayed binding that offers to enable error capture. If "no" is selected a taskCallback resets the active binding (Luke mentioned on r-devel that it might make sense to provide an official way of resetting delayed bindings but that was not implemented yet AFAICT --- Also an active binding wouldn't work here because top-level handlers have to be installed by top-level calls).

```r
.Last.error
#> Would you like to enable `.Last.error` capture?
#>
#> 1: Yes
#> 2: No

#> Selection: 1
#> Capture of uncaught errors in `.Last.error` is now enabled
```

Once enabled, uncaught errors are recorded in `.Last.error`:

```r
.Last.error
#> NULL

stop("bim")
#> Error: bim

.Last.error
#> <simpleError: bim>

f <- function() stop("bam")
f()
#> Error in f(): bam

.Last.error
#> <simpleError in f(): bam>
```

However errors thrown at top-level reset the calling handler stack, so users have to restore the stack manually. This requires two steps because we can only add top-level handlers from a top-level call such as triggered by a delayed binding.

```r

data[1]
#> Recording of errors is now disabled, please call `rlang:::enable_last_error()`
#> Error in data[1] : object of type 'closure' is not subsettable

.Last.error
#> <simpleError in data[1]: object of type 'closure' is not subsettable>

rlang:::enable_last_error()
#> Now type `.Last.error` at the console to enable error recording

.Last.error
#> Capture of uncaught errors in `.Last.error` is now enabled
```