### PR TITLE
Handle symbols in type_sum and env_print()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang 0.2.0.9000
 
+* `env_get()` now supports retrieving missing arguments when `inherit`
+  is `FALSE`.
+
 * The experimental function `rst_muffle()` is now defunct. Please use
   `cnd_muffle()` instead. Unlike its predecessor `cnd_muffle()` is not
   generic. It is marked as a calling handler and thus can be passed

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -407,7 +407,13 @@ env_get <- function(env = caller_env(), nm, inherit = FALSE, default) {
       return(default)
     }
   }
-  get(nm, envir = env, inherits = inherit)
+
+  # FIXME: The `inherit` case fails with missing arguments
+  if (inherit) {
+    return(get(nm, envir = env, inherits = TRUE))
+  }
+
+  .Call(rlang_env_get, env, nm)
 }
 #' @rdname env_get
 #' @export

--- a/R/env.R
+++ b/R/env.R
@@ -1001,7 +1001,7 @@ env_print <- function(env) {
   if (is_empty_env(env)) {
     parent <- "NULL"
   } else {
-    parent <- paste0("<", rlang_type_sum(env_parent(env)), ">")
+    parent <- sprintf("<environment: %s>", env_label(env_parent(env)))
   }
 
   if (env_is_locked(env)) {

--- a/R/types.R
+++ b/R/types.R
@@ -784,6 +784,12 @@ type_sum.default <- function(x) {
       environment = sprintf("env: %s", env_label(x)),
       builtin = ,
       special = "primitive",
+      symbol =
+        if (is_missing(x)) {
+          "missing"
+        } else {
+          "sym"
+        },
       typeof(x)
     )
   } else if (!isS4(x)) {

--- a/R/types.R
+++ b/R/types.R
@@ -781,7 +781,7 @@ type_sum.default <- function(x) {
       character = "chr",
       complex = "cpl",
       closure = "fn",
-      environment = sprintf("env: %s", env_label(x)),
+      environment = "env",
       builtin = ,
       special = "primitive",
       symbol =

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -89,6 +89,7 @@ extern sexp* rlang_data_mask_clean(sexp*);
 extern sexp* rlang_eval_tidy(sexp*, sexp*, sexp*);
 extern sexp* rlang_as_data_pronoun(sexp*);
 extern sexp* rlang_env_binding_are_promise(sexp*, sexp*);
+extern sexp* rlang_env_get(sexp*, sexp*);
 extern sexp* rlang_env_unlock(sexp*);
 extern sexp* rlang_interrupt();
 extern sexp* rlang_is_list(sexp*, sexp*);
@@ -217,6 +218,7 @@ static const r_callable r_callables[] = {
   {"rlang_eval_tidy",           (r_fn_ptr_t) &rlang_eval_tidy, 3},
   {"rlang_as_data_pronoun",     (r_fn_ptr_t) &rlang_as_data_pronoun, 1},
   {"rlang_env_binding_are_promise", (r_fn_ptr_t) &rlang_env_binding_are_promise, 2},
+  {"rlang_env_get",             (r_fn_ptr_t) &rlang_env_get, 2},
   {"rlang_env_unlock",          (r_fn_ptr_t) &rlang_env_unlock, 1},
   {"rlang_interrupt",           (r_fn_ptr_t) &rlang_interrupt, 0},
   {"rlang_is_list",             (r_fn_ptr_t) &rlang_is_list, 2},

--- a/src/internal/env-binding.c
+++ b/src/internal/env-binding.c
@@ -26,3 +26,19 @@ sexp* rlang_env_binding_are_promise(sexp* env, sexp* syms) {
   FREE(1);
   return out;
 }
+
+sexp* rlang_env_get(sexp* env, sexp* nm) {
+  sexp* sym = r_sym(r_c_string(nm));
+
+  // Use r_env_find() instead of r_env_get() because `nm` might
+  // reference a missing argument
+  sexp* out = r_env_find(env, sym);
+
+  // Trigger `symbol not found` error if needed
+  if (out == r_unbound_sym) {
+    r_eval(sym, r_empty_env);
+    r_abort("Internal error: `rlang_env_get()` should have failed earlier");
+  }
+
+  return out;
+}

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -207,3 +207,13 @@ test_that("can lock and unlock bindings", {
   expect_identical(env_binding_unlock(env), locked)
   expect_identical(env_binding_are_locked(env), lgl(a = FALSE, b = FALSE))
 })
+
+test_that("can pluck missing arg from environment", {
+  env <- env(x = missing_arg())
+  expect_identical(env_get(env, "x"), missing_arg())
+  expect_identical(env_get_list(env, "x"), list(x = missing_arg()))
+
+  skip("Failing")
+  child <- env(env)
+  env_get(child, "x", inherit = TRUE)
+})

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -361,3 +361,8 @@ test_that("envs printer: long lists are truncated", {
   x <- new_environments(x)
   expect_output(print(x), "empty>\n... and 5 more environments$")
 })
+
+test_that("can print environment containing missing argument", {
+  env <- env(x = missing_arg())
+  expect_output(env_print(env), "x: <symbol>")
+})

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -367,3 +367,8 @@ test_that("can print environment containing missing argument", {
   expect_output(env_print(env), "x: <missing>")
   expect_output(env_print(env), "y: <sym>")
 })
+
+test_that("parent environment is printed with full header", {
+  env <- env(global_env())
+  expect_output(env_print(env), "parent: <environment: global>")
+})

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -363,6 +363,7 @@ test_that("envs printer: long lists are truncated", {
 })
 
 test_that("can print environment containing missing argument", {
-  env <- env(x = missing_arg())
-  expect_output(env_print(env), "x: <symbol>")
+  env <- env(x = missing_arg(), y = quote(foo))
+  expect_output(env_print(env), "x: <missing>")
+  expect_output(env_print(env), "y: <sym>")
 })


### PR DESCRIPTION
So that symbols are printed as `<sym>` and missing arguments as `<missing>`.

```r
env <- env(
  x = missing_arg(),
  y = quote(foo)
)

env_print(env)
#> <environment: 0x7fbf9972ecc8>
#>   parent: <environment: global>
#>   bindings:
#>    * x: <missing>
#>    * y: <sym>
```