### PR TITLE
Fix typo in docs.

### DIFF
--- a/R/quasiquotation.R
+++ b/R/quasiquotation.R
@@ -16,7 +16,7 @@
 #'   immediately in the surrounding context.
 #'
 #' - The `!!!` operator unquotes and splices its argument. The
-#'   argument should represents a list or a vector. Each element will
+#'   argument should represent a list or a vector. Each element will
 #'   be embedded in the surrounding call, i.e. each element is
 #'   inserted as an argument. If the vector is named, the names are
 #'   used as argument names.


### PR DESCRIPTION
Hello!

There's also "quasiquotation lets you build a complex expressions" in `R/quotation.R` to fix. But I'm hesitating between "... build a complex expression" and "... build complex expressions" (either would work).

Best,
Marianne