### PR TITLE
Use get_env() in env_print()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * `env_get()` now evaluates promises and active bindings since these are
   internal objects which should not be exposed at the R level (#554)
 
+* `env_print()` calls `get_env()` on its argument, making it easier to 
+  see the environment of closures and quosures (#567).
+
 * You can now unquote quosured symbols as LHS of `:=`. The symbol is
   automatically unwrapped from the quosure.
 

--- a/R/env.R
+++ b/R/env.R
@@ -994,10 +994,13 @@ env_label <- function(env) {
 #'
 #' * Locked bindings get a `[L]` tag
 #'
-#' @param env An environment.
+#' @param env An environment, or object that can be converted to an
+#'   environment by [get_env()].
 #'
 #' @export
 env_print <- function(env) {
+  env <- get_env(env)
+
   if (is_empty_env(env)) {
     parent <- "NULL"
   } else {

--- a/man/env_print.Rd
+++ b/man/env_print.Rd
@@ -7,7 +7,8 @@
 env_print(env)
 }
 \arguments{
-\item{env}{An environment.}
+\item{env}{An environment, or object that can be converted to an
+environment by \code{\link[=get_env]{get_env()}}.}
 }
 \description{
 This prints:

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -290,6 +290,12 @@ test_that("can unlock environments", {
   expect_no_error(env_bind(env, a = 1))
 })
 
+test_that("env_print() has flexible input", {
+  # because it's primarily used interactively
+  f <- function() 1
+  expect_output(env_print(f), "environment: ")
+})
+
 test_that("active and promise bindings are pretty-printed", {
   env <- env()
   env_bind_exprs(env, a = "foo")


### PR DESCRIPTION
To make interactive exploration easier

Fixes #567