### PR TITLE
Fix handling of indent_status in deparse()

### DIFF
--- a/R/deparse.R
+++ b/R/deparse.R
@@ -159,10 +159,10 @@ new_lines <- function(width = peek_option("width"),
       status <- node_car(self$indent_status)
 
       if (self$next_indent_sticky) {
-        node_poke_cdr(status, inc(node_cdr(status)))
+        node_poke_cadr(status, inc(node_cadr(status)))
       } else {
         self$indent <- self$indent + 2L
-        self$indent_status <- new_node(new_node(FALSE, 0L), self$indent_status)
+        self$indent_status <- new_node(new_node(FALSE, new_node(0L, NULL)), self$indent_status)
         self$next_indent_sticky <- TRUE
       }
 
@@ -176,7 +176,7 @@ new_lines <- function(width = peek_option("width"),
       }
 
       reset <- node_car(status)
-      n_sticky <- node_cdr(status)
+      n_sticky <- node_cadr(status)
 
       # Decrease indent level only once for all the openers that were
       # on a single line
@@ -187,7 +187,7 @@ new_lines <- function(width = peek_option("width"),
       }
 
       if (n_sticky >= 1L) {
-        node_poke_cdr(status, dec(n_sticky))
+        node_poke_cadr(status, dec(n_sticky))
       } else {
         self$indent_status <- node_cdr(self$indent_status)
         self$next_indent_sticky <- FALSE


### PR DESCRIPTION
The increase_indent() function was actually creating an invalid
object via the expression `new_node(FALSE, 0L)`.

The `new_node` function is a wrapper for the `cons()` function, which
expects two arguments:

* car: the value of the node to be created
* tail (or cdr): a pairlist (or NULL) which continues the list after the  new node created

The expression `new_node(FALSE, 0L)` then actually passes an integer vector
as the cdr or tail instead of a pairlist, creating an illegal object.

You can verify this by evaluating the following expressions:

     x <- new_node(FALSE, 0L)
     length(x[[1]])

Which will crash your R session.

The code does work at the moment because GNU R does not actually check
that the cdr argument to the cons() function is valid, and the value is
only accessed via the CDR macros, which also do not verify the expression.

Other interpreters (e.g. Renjin) are not so forgiving however.