### PR TITLE
Add parentheses to call CAR when printing if required (#581)

### DIFF
--- a/R/deparse.R
+++ b/R/deparse.R
@@ -430,8 +430,67 @@ args_deparse <- function(x, lines = new_lines()) {
   lines$get_lines()
 }
 call_deparse <- function(x, lines = new_lines()) {
-  lines$deparse(node_car(x))
+  car <- node_car(x)
+  if (car_needs_parens(car)) {
+    car <- call("(", car)
+  }
+  lines$deparse(car)
   args_deparse(node_cdr(x), lines)
+}
+
+car_needs_parens <- function(x) {
+  if (typeof(x) != "language") {
+    return(FALSE)
+  }
+
+  op <- which_operator(x)
+  switch (op,
+    `function` = ,
+    `while` = ,
+    `for` = ,
+    `repeat` = ,
+    `if` = ,
+    `?` = ,
+    `<-` = ,
+    `<<-` = ,
+    `=` = ,
+    `:=` = ,
+    `~` = ,
+    `|` = ,
+    `||` = ,
+    `&` = ,
+    `&&` = ,
+    `>` = ,
+    `>=` = ,
+    `<` = ,
+    `<=` = ,
+    `==` = ,
+    `!=` = ,
+    `+` = ,
+    `-` = ,
+    `*` = ,
+    `/` = ,
+    `%%` = ,
+    `special` = ,
+    `:` = ,
+    `^` = TRUE,
+    `$` = ,
+    `@` = ,
+    `::` = ,
+    `:::` = FALSE,
+    `?unary` = ,
+    `~unary` = ,
+    `!` = ,
+    `!!!` = ,
+    `!!` = ,
+    `+unary` = ,
+    `-unary` =  TRUE,
+    `[` = ,
+    `[[` = ,
+    `(` = ,
+    `{` = FALSE,
+    abort("Internal error: Unexpected operator while deparsing")
+  )
 }
 
 op_deparse <- function(op, x, lines) {

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -431,7 +431,7 @@ args_deparse <- function(x, lines = new_lines()) {
 }
 call_deparse <- function(x, lines = new_lines()) {
   car <- node_car(x)
-  if (car_needs_parens(car)) {
+  if (car_needs_parens(x)) {
     car <- call("(", car)
   }
   lines$deparse(car)
@@ -439,11 +439,15 @@ call_deparse <- function(x, lines = new_lines()) {
 }
 
 car_needs_parens <- function(x) {
-  if (typeof(x) != "language") {
+  car <- node_car(x)
+  if (typeof(car) != "language") {
     return(FALSE)
   }
 
-  op <- which_operator(x)
+  op <- which_operator(car)
+  if (op == "") {
+    return(FALSE)
+  }
   switch (op,
     `function` = ,
     `while` = ,

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -178,12 +178,28 @@ test_that("call_deparse() handles multi-line arguments", {
   expect_identical(sexp_deparse(quote(foo(one = 1, two = nested(one = 1, two = 2))), ctxt), c("foo(one = 1, two = nested(", "  one = 1, two = 2))"))
 })
 
-test_that("call_deparse() adds parentheses to call CAR when needed", {
-  call <- as.call(c(quote(function(x) x + 1), quote(x)))
-  expect_identical(call_deparse(call), "(function(x) x + 1)(x)")
+test_that("call_deparse() delimits CAR when needed", {
+  call <- expr((!!quote(function() x + 1))())
+  expect_identical(call_deparse(call), "(function() x + 1)()")
 
-  call <- as.call(c(quote(f + g), quote(x)))
-  expect_identical(call_deparse(call), "(f + g)(x)")
+  # Only equal because of the extra parentheses
+  expect_equal(parse_expr(expr_deparse(call)), call)
+
+  call <- expr((!!quote(f + g))(x))
+  expect_identical(call_deparse(call), "`+`(f, g)(x)")
+  expect_identical(parse_expr(expr_deparse(call)), call)
+
+  call <- expr((!!quote(+f))(x))
+  expect_identical(call_deparse(call), "`+`(f)(x)")
+  expect_identical(parse_expr(expr_deparse(call)), call)
+
+  call <- expr((!!quote(while (TRUE) NULL))(x))
+  expect_identical(call_deparse(call), "`while`(TRUE, NULL)(x)")
+  expect_identical(parse_expr(expr_deparse(call)), call)
+
+  call <- expr(foo::bar(x))
+  expect_identical(call_deparse(call), "foo::bar(x)")
+  expect_identical(parse_expr(expr_deparse(call)), call)
 })
 
 test_that("literal functions are deparsed", {

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -178,6 +178,14 @@ test_that("call_deparse() handles multi-line arguments", {
   expect_identical(sexp_deparse(quote(foo(one = 1, two = nested(one = 1, two = 2))), ctxt), c("foo(one = 1, two = nested(", "  one = 1, two = 2))"))
 })
 
+test_that("call_deparse() adds parentheses to call CAR when needed", {
+  call <- as.call(c(quote(function(x) x + 1), quote(x)))
+  expect_identical(call_deparse(call), "(function(x) x + 1)(x)")
+
+  call <- as.call(c(quote(f + g), quote(x)))
+  expect_identical(call_deparse(call), "(f + g)(x)")
+})
+
 test_that("literal functions are deparsed", {
   expect_identical_(sexp_deparse(function(a) 1), "<function(a) 1>")
   expect_identical_(sexp_deparse(expr(foo(!!function(a) 1))), "foo(<function(a) 1>)")


### PR DESCRIPTION
Fixes #581 by adding a check to `call_deparse()` to see if the expression in the CAR slot of the call should be wrapped in parentheses for printing.

I picked the expressions that should have parentheses using the switch statement from `op_deparse()` and eyeballing which ops should have parentheses and which not.