### PR TITLE
Lifecycle of UQE() and namespaced UQ()/UQS() calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,23 @@
 
 # rlang 0.2.2.9000
 
+* Calling `UQ()` and `UQS()` with the rlang namespace qualifier is
+  deprecated as of rlang 0.3.0. Just use the unqualified forms
+  instead:
+
+  ```
+  # Bad
+  rlang::expr(mean(rlang::UQ(var) * 100))
+
+  # Ok
+  rlang::expr(mean(UQ(var) * 100))
+
+  # Good
+  rlang::expr(mean(!!var * 100))
+  ```
+
+  Although soft-deprecated since rlang 0.2.0, `UQ()` and `UQS()` can still be used for now.
+
 * `new_data_mask()` now throws an error when `bottom` is not a child of `top` (#551).
 
 * `env_clone()` no longer forces promises and recreates active bindings correctly.

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -611,3 +611,5 @@ conditionMessage.rlang_error <- function(c) {
 
   lines
 }
+
+deprecation_env <- new.env(parent = emptyenv())

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -154,7 +154,6 @@
 #'
 #' **Retired in rlang 0.2.0:**
 #'
-#' * [UQE()]
 #' * [is_quosureish()], [as_quosureish()]
 #'
 #'
@@ -162,20 +161,13 @@
 #'
 #' \badgedefunct
 #'
-#' **Retired in rlang 0.3.0:**
+#' **Defunct as of rlang 0.3.0:**
 #'
 #' * [cnd()], [error_cnd()], [warning_cnd()] and [message_cnd()]:
 #'   `.msg` => `message`.
 #' * [cnd_signal()]: `.msg` and `.call`.
 #' * `cnd_inform()`, `cnd_warn()` and `cnd_abort()`
-#'
-#'
-#' **Renamed in rlang 0.2.0**
-#'
-#' * `new_cnd()` => [cnd()]
-#' * `cnd_message()` => [message_cnd()]
-#' * `cnd_warning()` => [warning_cnd()]
-#' * `cnd_error()` => [error_cnd()]
+#' * [UQE()]
 #'
 #'
 #' **Renamed in rlang 0.3.0:**
@@ -184,6 +176,13 @@
 #'   has not been implemented in `calling()` and is now defunct.
 #' * `rst_muffle()` => [cnd_muffle()]
 #'
+#'
+#' **Renamed in rlang 0.2.0**
+#'
+#' * `new_cnd()` => [cnd()]
+#' * `cnd_message()` => [message_cnd()]
+#' * `cnd_warning()` => [warning_cnd()]
+#' * `cnd_error()` => [error_cnd()]
 #'
 #' @name lifecycle
 NULL

--- a/R/quasiquotation.R
+++ b/R/quasiquotation.R
@@ -70,12 +70,23 @@
 #' @section Life cycle:
 #'
 #' * Calling `UQ()` and `UQS()` with the rlang namespace qualifier is
-#'   soft-deprecated as of rlang 0.2.0. Just use the unqualified forms
-#'   instead.
+#'   deprecated as of rlang 0.3.0. Just use the unqualified forms
+#'   instead:
+#'
+#'   ```
+#'   # Bad
+#'   rlang::expr(mean(rlang::UQ(var) * 100))
+#'
+#'   # Ok
+#'   rlang::expr(mean(UQ(var) * 100))
+#'
+#'   # Good
+#'   rlang::expr(mean(!!var * 100))
+#'   ```
 #'
 #'   Supporting namespace qualifiers complicates the implementation of
 #'   unquotation and is misleading as to the nature of unquoting
-#'   operators (these are syntactic operators that operates at
+#'   operators (which are syntactic operators that operates at
 #'   quotation-time rather than function calls at evaluation-time).
 #'
 #' * `UQ()` and `UQS()` were soft-deprecated in rlang 0.2.0 in order

--- a/R/quasiquotation.R
+++ b/R/quasiquotation.R
@@ -112,9 +112,9 @@
 #'   operation. The operator form makes it clearer that unquoting is
 #'   special.
 #'
-#' * `UQE()` was deprecated in rlang 0.2.0 in order to simplify the
+#' * `UQE()` is defunct as of rlang 0.3.0 in order to simplify the
 #'   quasiquotation syntax. You can replace its use by a combination
-#'   of `!!` and `get_expr()`: `!! get_expr(x)` is equivalent to
+#'   of `!!` and `get_expr()`: `!!get_expr(x)` is equivalent to
 #'   `UQE(x)`.
 #'
 #' @param x An expression to unquote.
@@ -202,7 +202,7 @@ UQ <- function(x) {
 #' @usage NULL
 #' @export
 UQE <- function(x) {
-  warn("`UQE()` is deprecated. Please use `!! get_expr(x)`")
+  .Defunct(msg = "`UQE()` is defunct. Please use `!!get_expr(x)`")
   abort("`UQE()` can only be used within a quasiquoted argument")
 }
 #' @rdname quasiquotation

--- a/man/lifecycle.Rd
+++ b/man/lifecycle.Rd
@@ -149,7 +149,6 @@ Since rlang 0.2.0:
 
 \strong{Retired in rlang 0.2.0:}
 \itemize{
-\item \code{\link[=UQE]{UQE()}}
 \item \code{\link[=is_quosureish]{is_quosureish()}}, \code{\link[=as_quosureish]{as_quosureish()}}
 }
 }
@@ -159,12 +158,20 @@ Since rlang 0.2.0:
 
 \badgedefunct
 
-\strong{Retired in rlang 0.3.0:}
+\strong{Defunct as of rlang 0.3.0:}
 \itemize{
 \item \code{\link[=cnd]{cnd()}}, \code{\link[=error_cnd]{error_cnd()}}, \code{\link[=warning_cnd]{warning_cnd()}} and \code{\link[=message_cnd]{message_cnd()}}:
 \code{.msg} => \code{message}.
 \item \code{\link[=cnd_signal]{cnd_signal()}}: \code{.msg} and \code{.call}.
 \item \code{cnd_inform()}, \code{cnd_warn()} and \code{cnd_abort()}
+\item \code{\link[=UQE]{UQE()}}
+}
+
+\strong{Renamed in rlang 0.3.0:}
+\itemize{
+\item \code{inplace()} => \code{\link[=calling]{calling()}}. The \code{muffle} argument of \code{inplace()}
+has not been implemented in \code{calling()} and is now defunct.
+\item \code{rst_muffle()} => \code{\link[=cnd_muffle]{cnd_muffle()}}
 }
 
 \strong{Renamed in rlang 0.2.0}
@@ -173,13 +180,6 @@ Since rlang 0.2.0:
 \item \code{cnd_message()} => \code{\link[=message_cnd]{message_cnd()}}
 \item \code{cnd_warning()} => \code{\link[=warning_cnd]{warning_cnd()}}
 \item \code{cnd_error()} => \code{\link[=error_cnd]{error_cnd()}}
-}
-
-\strong{Renamed in rlang 0.3.0:}
-\itemize{
-\item \code{inplace()} => \code{\link[=calling]{calling()}}. The \code{muffle} argument of \code{inplace()}
-has not been implemented in \code{calling()} and is now defunct.
-\item \code{rst_muffle()} => \code{\link[=cnd_muffle]{cnd_muffle()}}
 }
 }
 

--- a/man/quasiquotation.Rd
+++ b/man/quasiquotation.Rd
@@ -132,9 +132,9 @@ by the tidy eval parser interpreting \code{rlang::UQ()} as \code{!!}. In
 reality unquoting is \emph{not} a function call, it is a syntactic
 operation. The operator form makes it clearer that unquoting is
 special.
-\item \code{UQE()} was deprecated in rlang 0.2.0 in order to simplify the
+\item \code{UQE()} is defunct as of rlang 0.3.0 in order to simplify the
 quasiquotation syntax. You can replace its use by a combination
-of \code{!!} and \code{get_expr()}: \code{!! get_expr(x)} is equivalent to
+of \code{!!} and \code{get_expr()}: \code{!!get_expr(x)} is equivalent to
 \code{UQE(x)}.
 }
 }

--- a/man/quasiquotation.Rd
+++ b/man/quasiquotation.Rd
@@ -95,12 +95,20 @@ and
 
 \itemize{
 \item Calling \code{UQ()} and \code{UQS()} with the rlang namespace qualifier is
-soft-deprecated as of rlang 0.2.0. Just use the unqualified forms
-instead.
+deprecated as of rlang 0.3.0. Just use the unqualified forms
+instead:\preformatted{# Bad
+rlang::expr(mean(rlang::UQ(var) * 100))
+
+# Ok
+rlang::expr(mean(UQ(var) * 100))
+
+# Good
+rlang::expr(mean(!!var * 100))
+}
 
 Supporting namespace qualifiers complicates the implementation of
 unquotation and is misleading as to the nature of unquoting
-operators (these are syntactic operators that operates at
+operators (which are syntactic operators that operates at
 quotation-time rather than function calls at evaluation-time).
 \item \code{UQ()} and \code{UQS()} were soft-deprecated in rlang 0.2.0 in order
 to make the syntax of quasiquotation more consistent. The prefix

--- a/src/export/exported-tests.c
+++ b/src/export/exported-tests.c
@@ -1,12 +1,20 @@
 #include <rlang.h>
 
+sexp* rlang_r_string(sexp* str) {
+  return STRING_ELT(str, 0);
+}
+
+
+// cnd.c
+
 sexp* rlang_test_r_warn(sexp* x) {
   r_warn(CHAR(STRING_ELT(x, 0)));
   return r_null;
 }
 
-sexp* rlang_r_string(sexp* str) {
-  return STRING_ELT(str, 0);
+sexp* rlang_test_warn_deprecated_once(sexp* id, sexp* msg) {
+  r_warn_deprecated_once(r_c_string(id), r_c_string(msg));
+  return r_null;
 }
 
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -124,6 +124,7 @@ extern sexp* r_current_frame();
 extern sexp* rlang_test_node_list_clone_until(sexp*, sexp*);
 extern sexp* rlang_test_sys_frame(sexp*);
 extern sexp* rlang_test_sys_call(sexp*);
+extern sexp* rlang_test_warn_deprecated_once(sexp*, sexp*);
 
 static const r_callable r_callables[] = {
   {"rlang_library_load",        (r_fn_ptr_t) &rlang_library_load, 0},
@@ -194,6 +195,7 @@ static const r_callable r_callables[] = {
   {"rlang_test_set_attribute",  (r_fn_ptr_t) &r_set_attribute, 3},
   {"rlang_test_sys_frame",      (r_fn_ptr_t) &rlang_test_sys_frame, 1},
   {"rlang_test_sys_call",       (r_fn_ptr_t) &rlang_test_sys_call, 1},
+  {"rlang_test_warn_deprecated_once", (r_fn_ptr_t) &rlang_test_warn_deprecated_once, 2},
   {"rlang_r_string",            (r_fn_ptr_t) &rlang_r_string, 1},
   {"rlang_exprs_interp",        (r_fn_ptr_t) &rlang_exprs_interp, 4},
   {"rlang_quos_interp",         (r_fn_ptr_t) &rlang_quos_interp, 4},

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -72,15 +72,33 @@ void signal_uqs_soft_deprecation() {
 }
 
 void signal_namespaced_uq_deprecation() {
-  signal_soft_deprecation(
-    "Prefixing `UQ()` with a namespace is soft-deprecated as of rlang 0.2.0. "
-    "Please use the unprefixed form instead."
+  r_warn(
+    "Prefixing `UQ()` with the rlang namespace is deprecated as of rlang 0.3.0.\n"
+    "Please use the non-prefixed form or `!!` instead.\n"
+    "\n"
+    "  # Bad:\n"
+    "  rlang::expr(mean(rlang::UQ(var) * 100))\n"
+    "\n"
+    "  # Ok:\n"
+    "  rlang::expr(mean(UQ(var) * 100))\n"
+    "\n"
+    "  # Good:\n"
+    "  rlang::expr(mean(!!var * 100))\n"
   );
 }
 void signal_namespaced_uqs_deprecation() {
-  signal_soft_deprecation(
-    "Prefixing `UQS()` with a namespace is soft-deprecated as of rlang 0.2.0. "
-    "Please use the unprefixed form instead."
+  r_warn(
+    "Prefixing `UQS()` with the rlang namespace is deprecated as of rlang 0.3.0.\n"
+    "Please use the non-prefixed form or `!!!` instead.\n"
+    "\n"
+    "  # Bad:\n"
+    "  rlang::expr(mean(rlang::UQS(args)))\n"
+    "\n"
+    "  # Ok:\n"
+    "  rlang::expr(mean(UQS(args)))\n"
+    "\n"
+    "  # Good:\n"
+    "  rlang::expr(mean(!!!args))\n"
   );
 }
 

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -72,7 +72,7 @@ void signal_uqs_soft_deprecation() {
 }
 
 void signal_namespaced_uq_deprecation() {
-  r_warn(
+  r_warn_deprecated_once("namespaced rlang::UQ()",
     "Prefixing `UQ()` with the rlang namespace is deprecated as of rlang 0.3.0.\n"
     "Please use the non-prefixed form or `!!` instead.\n"
     "\n"
@@ -84,10 +84,12 @@ void signal_namespaced_uq_deprecation() {
     "\n"
     "  # Good:\n"
     "  rlang::expr(mean(!!var * 100))\n"
+    "\n"
+    "This warning is only displayed once per session."
   );
 }
 void signal_namespaced_uqs_deprecation() {
-  r_warn(
+  r_warn_deprecated_once("namespaced rlang::UQS()",
     "Prefixing `UQS()` with the rlang namespace is deprecated as of rlang 0.3.0.\n"
     "Please use the non-prefixed form or `!!!` instead.\n"
     "\n"
@@ -99,6 +101,8 @@ void signal_namespaced_uqs_deprecation() {
     "\n"
     "  # Good:\n"
     "  rlang::expr(mean(!!!args))\n"
+    "\n"
+    "This warning is only displayed once per session."
   );
 }
 

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -307,10 +307,10 @@ sexp* call_interp(sexp* x, sexp* env)  {
 
 sexp* call_interp_impl(sexp* x, sexp* env, struct expansion_info info) {
   if (info.op && r_node_cdr(x) == r_null) {
-    r_abort("`UQ()`, `UQE()` and `UQS()` must be called with an argument");
+    r_abort("`UQ()` and `UQS()` must be called with an argument");
   }
   if (info.op == OP_EXPAND_UQE) {
-    r_warn("`UQE()` is deprecated. Please use `!! get_expr(x)`");
+    r_abort_defunct("`UQE()` is defunct. Please use `!!get_expr(x)`");
   }
 
   switch (info.op) {

--- a/src/lib/cnd.c
+++ b/src/lib/cnd.c
@@ -53,17 +53,47 @@ sexp* r_interp_str(const char* fmt, ...) {
   return r_scalar_chr(buf);
 }
 
+static void signal_retirement(const char* source, char* buf);
+static sexp* deprecated_env = NULL;
+
+void r_warn_deprecated(const char* fmt, ...) {
+  char buf[BUFSIZE];
+  INTERP(buf, fmt, ...);
+
+  signal_retirement(".Deprecated(msg = msg)", buf);
+}
+void r_warn_deprecated_once(const char* id, const char* fmt, ...) {
+  sexp* id_ = r_sym(id);
+
+  // Warn once per session
+  if (r_env_has(deprecated_env, id_)) {
+    return;
+  }
+  r_env_poke(deprecated_env, id_, r_shared_true);
+
+  char buf[BUFSIZE];
+  INTERP(buf, fmt, ...);
+
+  signal_retirement(".Deprecated(msg = msg)", buf);
+}
+
 void r_abort_defunct(const char* fmt, ...) {
   char buf[BUFSIZE];
   INTERP(buf, fmt, ...);
 
-  sexp* call = KEEP(r_parse(".Defunct(msg = msg)"));
+  signal_retirement(".Defunct(msg = msg)", buf);
+
+  r_abort("Internal error: Unexpected return after `.Defunct()`");
+}
+
+static void signal_retirement(const char* source, char* buf) {
+  sexp* call = KEEP(r_parse(source));
   sexp* env = KEEP(r_new_environment(r_base_env, 1));
   r_env_poke(env, r_sym("msg"), KEEP(r_scalar_chr(buf)));
 
   r_eval(call, env);
 
-  while (1); // No return
+  FREE(3);
 }
 
 static sexp* new_condition_names(sexp* data) {
@@ -237,4 +267,6 @@ void r_init_library_cnd() {
 
   r_mark_precious(cnd_signal_call);
   FREE(5);
+
+  deprecated_env = rlang_ns_get("deprecation_env");
 }

--- a/src/lib/cnd.c
+++ b/src/lib/cnd.c
@@ -53,6 +53,20 @@ sexp* r_interp_str(const char* fmt, ...) {
   return r_scalar_chr(buf);
 }
 
+void r_abort_defunct(const char* fmt, ...) {
+  char buf[BUFSIZE];
+  INTERP(buf, fmt, ...);
+
+  sexp* args = KEEP(r_new_node_list(
+    KEEP(r_scalar_chr(buf)))
+  );
+  r_node_poke_tag(args, r_sym("msg"));
+  sexp* call = KEEP(r_new_call(r_sym(".Defunct"), args));
+  r_eval(call, r_base_env);
+
+  while (1); // No return
+}
+
 static sexp* new_condition_names(sexp* data) {
   if (!r_is_named(data)) {
     r_abort("Conditions must have named data fields");

--- a/src/lib/cnd.c
+++ b/src/lib/cnd.c
@@ -57,12 +57,11 @@ void r_abort_defunct(const char* fmt, ...) {
   char buf[BUFSIZE];
   INTERP(buf, fmt, ...);
 
-  sexp* args = KEEP(r_new_node_list(
-    KEEP(r_scalar_chr(buf)))
-  );
-  r_node_poke_tag(args, r_sym("msg"));
-  sexp* call = KEEP(r_new_call(r_sym(".Defunct"), args));
-  r_eval(call, r_base_env);
+  sexp* call = KEEP(r_parse(".Defunct(msg = msg)"));
+  sexp* env = KEEP(r_new_environment(r_base_env, 1));
+  r_env_poke(env, r_sym("msg"), KEEP(r_scalar_chr(buf)));
+
+  r_eval(call, env);
 
   while (1); // No return
 }

--- a/src/lib/cnd.h
+++ b/src/lib/cnd.h
@@ -9,6 +9,8 @@ void r_warn(const char* fmt, ...);
 void r_abort(const char* fmt, ...) __attribute__((noreturn));
 void r_interrupt();
 
+void r_warn_deprecated(const char* fmt, ...);
+void r_warn_deprecated_once(const char* id, const char* fmt, ...);
 void r_abort_defunct(const char* fmt, ...);
 
 sexp* r_interp_str(const char* fmt, ...);

--- a/src/lib/cnd.h
+++ b/src/lib/cnd.h
@@ -9,6 +9,8 @@ void r_warn(const char* fmt, ...);
 void r_abort(const char* fmt, ...) __attribute__((noreturn));
 void r_interrupt();
 
+void r_abort_defunct(const char* fmt, ...);
+
 sexp* r_interp_str(const char* fmt, ...);
 
 sexp* r_new_condition(sexp* type, sexp* msg, sexp* call, sexp* data);

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -394,3 +394,9 @@ test_that("failed parses are printed if `rlang__verbose_errors` is non-NULL", {
     ))
   expect_error(cnd_signal(err), regexp = "single expression")
 })
+
+test_that("r_warn_deprecated_once() warns once", {
+  expect_warning(.Call(rlang_test_warn_deprecated_once, "foo", "retired"), "retired")
+  expect_no_warning(.Call(rlang_test_warn_deprecated_once, "foo", "retired"))
+  expect_warning(.Call(rlang_test_warn_deprecated_once, "bar", "retired"), "retired")
+})

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -50,7 +50,7 @@ test_that("can interpolate in specific env", {
 })
 
 test_that("can qualify operators with namespace", {
-  with_non_verbose_retirement({
+  suppressWarnings({
     # Should remove prefix only if rlang-qualified:
     expect_identical(quo(rlang::UQ(toupper("a"))), new_quosure("A", empty_env()))
     expect_identical(quo(list(rlang::UQS(list(a = 1, b = 2)))), quo(list(a = 1, b = 2)))
@@ -173,14 +173,14 @@ test_that("UQ() fails if called without argument", {
     quo <- quo(UQ(NULL))
     expect_equal(quo, ~NULL)
 
-    quo <- quo(rlang::UQ(NULL))
+    quo <- suppressWarnings(quo(rlang::UQ(NULL)))
     expect_equal(quo, ~NULL)
 
     quo <- tryCatch(quo(UQ()), error = identity)
     expect_is(quo, "error")
     expect_match(quo$message, "must be called with an argument")
 
-    quo <- tryCatch(quo(rlang::UQ()), error = identity)
+    quo <- suppressWarnings(tryCatch(quo(rlang::UQ()), error = identity))
     expect_is(quo, "error")
     expect_match(quo$message, "must be called with an argument")
   })
@@ -374,7 +374,7 @@ test_that("can unquote-splice symbols", {
 test_that("can unquote symbols", {
   expect_error_(dots_values(!! quote(.)), "`!!` in a non-quoting function")
 
-  with_non_verbose_retirement(
+  suppressWarnings(
     expect_error_(dots_values(rlang::UQ(quote(.))), "`!!` in a non-quoting function")
   )
 })
@@ -414,14 +414,7 @@ test_that("Unquote operators fail when called outside quasiquoted arguments", {
 
 # Lifecycle ----------------------------------------------------------
 
-test_that("namespaced unquoting is soft-deprecated", {
-  with_non_verbose_retirement({
-    expect_no_warning_(exprs(rlang::UQS(1:2)))
-    expect_no_warning_(quo(list(rlang::UQ(1:2))))
-  })
-
-  with_verbose_retirement({
-    expect_warning_(exprs(rlang::UQS(1:2)), "`UQS()` with a namespace is soft-deprecated", fixed = TRUE)
-    expect_warning_(quo(list(rlang::UQ(1:2))), "`UQ()` with a namespace is soft-deprecated", fixed = TRUE)
-  })
+test_that("unquoting with rlang namespace is deprecated", {
+  expect_warning_(exprs(rlang::UQS(1:2)), regexp = "deprecated as of rlang 0.3.0")
+  expect_warning_(quo(list(rlang::UQ(1:2))), regexp = "deprecated as of rlang 0.3.0")
 })

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -282,25 +282,6 @@ test_that("`!!!` doesn't modify spliced inputs by reference", {
 })
 
 
-# UQE ----------------------------------------------------------------
-
-test_that("UQE() extracts right-hand side", {
-  var <- ~cyl
-  expect_warning_(expect_identical_(quo(mtcars$UQE(var)), quo(mtcars$cyl)), "deprecated")
-})
-
-test_that("UQE() throws a deprecation warning", {
-  expect_warning_(exprs(UQE("foo")), "deprecated")
-  expect_warning_(quos(UQE("foo")), "deprecated")
-  expect_warning_(expr(UQE("foo")), "deprecated")
-  expect_warning_(quo(UQE("foo")), "deprecated")
-})
-
-test_that("UQE() can't be used in by-value dots", {
-  expect_error_(dots_list(UQE("foo")), "non-quoting function")
-})
-
-
 # bang ---------------------------------------------------------------
 
 test_that("single ! is not treated as shortcut", {
@@ -404,7 +385,6 @@ test_that("`:=` chaining is detected at dots capture", {
 test_that("Unquote operators fail when called outside quasiquoted arguments", {
   expect_qq_error <- function(object) expect_error(object, regexp = "within a quasiquoted argument")
   expect_qq_error(UQ())
-  expect_warning_(expect_qq_error(UQE()), "deprecated")
   expect_qq_error(UQS())
   expect_qq_error(`!!`())
   expect_qq_error(`!!!`())
@@ -417,4 +397,9 @@ test_that("Unquote operators fail when called outside quasiquoted arguments", {
 test_that("unquoting with rlang namespace is deprecated", {
   expect_warning_(exprs(rlang::UQS(1:2)), regexp = "deprecated as of rlang 0.3.0")
   expect_warning_(quo(list(rlang::UQ(1:2))), regexp = "deprecated as of rlang 0.3.0")
+})
+
+test_that("UQE() is defunct", {
+  expect_error_(expr(foo$UQE(NULL)), "defunct")
+  expect_error_(UQE(), "defunct")
 })

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -50,15 +50,8 @@ test_that("can interpolate in specific env", {
 })
 
 test_that("can qualify operators with namespace", {
-  suppressWarnings({
-    # Should remove prefix only if rlang-qualified:
-    expect_identical(quo(rlang::UQ(toupper("a"))), new_quosure("A", empty_env()))
-    expect_identical(quo(list(rlang::UQS(list(a = 1, b = 2)))), quo(list(a = 1, b = 2)))
-
-    # Should keep prefix otherwise:
     expect_identical(quo(other::UQ(toupper("a"))), quo(other::"A"))
     expect_identical(quo(x$UQ(toupper("a"))), quo(x$"A"))
-  })
 })
 
 test_that("unquoting is frame-consistent", {
@@ -173,14 +166,7 @@ test_that("UQ() fails if called without argument", {
     quo <- quo(UQ(NULL))
     expect_equal(quo, ~NULL)
 
-    quo <- suppressWarnings(quo(rlang::UQ(NULL)))
-    expect_equal(quo, ~NULL)
-
     quo <- tryCatch(quo(UQ()), error = identity)
-    expect_is(quo, "error")
-    expect_match(quo$message, "must be called with an argument")
-
-    quo <- suppressWarnings(tryCatch(quo(rlang::UQ()), error = identity))
     expect_is(quo, "error")
     expect_match(quo$message, "must be called with an argument")
   })
@@ -354,10 +340,6 @@ test_that("can unquote-splice symbols", {
 
 test_that("can unquote symbols", {
   expect_error_(dots_values(!! quote(.)), "`!!` in a non-quoting function")
-
-  suppressWarnings(
-    expect_error_(dots_values(rlang::UQ(quote(.))), "`!!` in a non-quoting function")
-  )
 })
 
 
@@ -397,6 +379,20 @@ test_that("Unquote operators fail when called outside quasiquoted arguments", {
 test_that("unquoting with rlang namespace is deprecated", {
   expect_warning_(exprs(rlang::UQS(1:2)), regexp = "deprecated as of rlang 0.3.0")
   expect_warning_(quo(list(rlang::UQ(1:2))), regexp = "deprecated as of rlang 0.3.0")
+
+  # Old tests
+
+  expect_identical(quo(rlang::UQ(toupper("a"))), new_quosure("A", empty_env()))
+  expect_identical(quo(list(rlang::UQS(list(a = 1, b = 2)))), quo(list(a = 1, b = 2)))
+
+  quo <- quo(rlang::UQ(NULL))
+  expect_equal(quo, ~NULL)
+
+  quo <- tryCatch(quo(rlang::UQ()), error = identity)
+  expect_is(quo, "error")
+  expect_match(quo$message, "must be called with an argument")
+
+  expect_error_(dots_values(rlang::UQ(quote(.))), "`!!` in a non-quoting function")
 })
 
 test_that("UQE() is defunct", {


### PR DESCRIPTION
@hadley How about giving examples in the warning?

```r
expr(rlang::UQ("foo"))
#> [1] "foo"
#> Warning message:
#> Prefixing `UQ()` with the rlang namespace is deprecated as of rlang 0.3.0.
#> Please use the non-prefixed form or `!!` instead.
#>
#>   # Bad:
#>   rlang::expr(mean(rlang::UQ(var) * 100))
#>
#>   # Ok:
#>   rlang::expr(mean(UQ(var) * 100))
#>
#>   # Good:
#>   rlang::expr(mean(!!var * 100))
```