### PR TITLE
Update data mask API

### DIFF
--- a/R/cnd.R
+++ b/R/cnd.R
@@ -595,14 +595,14 @@ conditionMessage.rlang_error <- function(c) {
 
   if (length(parents)) {
     parents <- cli_branch(parents)
-    lines <- chr_lines(lines,
+    lines <- paste_line(lines,
       "Parents:",
       parents
     )
   }
 
   if (!is_null(trace)) {
-    lines <- chr_lines(
+    lines <- paste_line(
       lines,
       "Backtrail:",
       trace

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -616,3 +616,7 @@ warn_deprecated_once <- function(id, msg) {
   .Call(rlang_warn_deprecated_once, id, msg)
 }
 deprecation_env <- new.env(parent = emptyenv())
+
+abort_defunct <- function(msg) {
+  .Defunct(msg = msg)
+}

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -612,4 +612,7 @@ conditionMessage.rlang_error <- function(c) {
   lines
 }
 
+warn_deprecated_once <- function(id, msg) {
+  .Call(rlang_warn_deprecated_once, id, msg)
+}
 deprecation_env <- new.env(parent = emptyenv())

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -25,8 +25,8 @@
 #' @param data A data frame, or named list or vector. Alternatively, a
 #'   data mask created with [as_data_mask()] or [new_data_mask()].
 #' @param env The environment in which to evaluate `expr`. This
-#'   environment is always ignored when evaluating quosures. Quosures
-#'   are evaluated in their own environment.
+#'   environment is not applicable for quosures because they have
+#'   their own environments.
 #' @seealso [quasiquotation] for the second leg of the tidy evaluation
 #'   framework.
 #' @export
@@ -177,6 +177,16 @@ delayedAssign(".data", as_data_pronoun(list()))
 #'
 #' All these functions are now stable.
 #'
+#' **rlang 0.3.0**
+#'
+#' The `parent` argument no longer has any effect. The parent of the
+#' data mask is determined from either:
+#'
+#'   * The `env` argument of `eval_tidy()`
+#'   * Quosure environments when applicable
+#'
+#' **rlang 0.2.0**
+#'
 #' In early versions of rlang data masks were called overscopes. We
 #' think data mask is a more natural name in R. It makes reference to
 #' masking in the search path which occurs through the same mechanism
@@ -189,7 +199,10 @@ delayedAssign(".data", as_data_pronoun(list()))
 #' `as_data_mask()` and `new_data_mask()`.
 #'
 #' @param data A data frame or named vector of masking data.
-#' @param parent The parent environment of the data mask.
+#' @param parent Soft-deprecated. This argument no longer has any effect.
+#'   The parent of the data mask is determined from either:
+#'   * The `env` argument of `eval_tidy()`
+#'   * Quosure environments when applicable
 #' @return A data mask that you can supply to [eval_tidy()].
 #'
 #' @export
@@ -259,8 +272,19 @@ delayedAssign(".data", as_data_pronoun(list()))
 #' # ignored. The following does not work because `+` is defined in an
 #' # upper level:
 #' try(eval_tidy(quote(a + b), data = bottom))
-as_data_mask <- function(data, parent = base_env()) {
-  .Call(rlang_as_data_mask, data, parent)
+as_data_mask <- function(data, parent = NULL) {
+  if (!is_null(parent)) {
+    id <- "rlang::as_data_mask() - parent argument"
+    msg <- paste(sep = "\n",
+      "The `parent` argument of `as_data_mask()` is deprecated.",
+      "The parent of the data mask is determined from either:\n",
+      "  * The `env` argument of `eval_tidy()`",
+      "  * Quosure environments when applicable\n",
+      "This warning is displayed once per session."
+    )
+    warn_deprecated_once(id, msg)
+  }
+  .Call(rlang_as_data_mask, data)
 }
 #' @rdname as_data_mask
 #' @export
@@ -276,8 +300,19 @@ as_data_pronoun <- function(data) {
 #'   is only one environment deep, `top` should be the same as
 #'   `bottom`.
 #' @export
-new_data_mask <- function(bottom, top = bottom, parent = base_env()) {
-  .Call(rlang_new_data_mask, bottom, top, parent)
+new_data_mask <- function(bottom, top = bottom, parent = NULL) {
+  if (!is_null(parent)) {
+    id <- "rlang::new_data_mask() - parent argument"
+    msg <- paste(sep = "\n",
+      "The `parent` argument of `new_data_mask()` is deprecated.",
+      "The parent of the data mask is determined from either:\n",
+      "  * The `env` argument of `eval_tidy()`",
+      "  * Quosure environments when applicable\n",
+      "This warning is displayed once per session."
+    )
+    warn_deprecated_once(id, msg)
+  }
+  .Call(rlang_new_data_mask, bottom, top)
 }
 
 

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -298,11 +298,13 @@ delayedAssign(".data", as_data_pronoun(list()))
 as_data_mask <- function(data, parent = NULL) {
   if (!is_null(parent)) {
     id <- "rlang::as_data_mask() - parent argument"
-    msg <- paste(sep = "\n",
+    msg <- paste_line(
       "The `parent` argument of `as_data_mask()` is deprecated.",
-      "The parent of the data mask is determined from either:\n",
+      "The parent of the data mask is determined from either:",
+      "",
       "  * The `env` argument of `eval_tidy()`",
-      "  * Quosure environments when applicable\n",
+      "  * Quosure environments when applicable",
+      "",
       "This warning is displayed once per session."
     )
     warn_deprecated_once(id, msg)
@@ -326,11 +328,13 @@ as_data_pronoun <- function(data) {
 new_data_mask <- function(bottom, top = bottom, parent = NULL) {
   if (!is_null(parent)) {
     id <- "rlang::new_data_mask() - parent argument"
-    msg <- paste(sep = "\n",
+    msg <- paste_line(
       "The `parent` argument of `new_data_mask()` is deprecated.",
-      "The parent of the data mask is determined from either:\n",
+      "The parent of the data mask is determined from either:",
+      "",
       "  * The `env` argument of `eval_tidy()`",
-      "  * Quosure environments when applicable\n",
+      "  * Quosure environments when applicable",
+      "",
       "This warning is displayed once per session."
     )
     warn_deprecated_once(id, msg)

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -169,7 +169,7 @@ as_overscope <- function(quo, data = NULL) {
 #' @rdname as_overscope
 #' @param enclosure The `parent` argument of [new_data_mask()].
 #' @export
-new_overscope <- function(bottom, top = NULL, enclosure = base_env()) {
+new_overscope <- function(bottom, top = NULL, enclosure = NULL) {
   new_data_mask(bottom, top, enclosure)
 }
 #' @rdname as_overscope

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -181,7 +181,7 @@ overscope_clean <- function(overscope) {
 
 #' Tidy evaluation in a custom environment
 #'
-#' This function is soft-deprecated as of rlang 0.2.0.
+#' This function is defunct as of rlang 0.3.0.
 #'
 #' @inheritParams eval_tidy
 #' @inheritParams as_data_mask
@@ -189,9 +189,7 @@ overscope_clean <- function(overscope) {
 #' @keywords internal
 #' @export
 eval_tidy_ <- function(expr, bottom, top = NULL, env = caller_env()) {
-  data_mask <- new_overscope(bottom, top %||% bottom)
-  on.exit(overscope_clean(data_mask))
-  .Call(rlang_eval_tidy, expr, data_mask, environment())
+  abort_defunct("`eval_tidy_()` is defunct as of rlang 0.3.0. Use `eval_tidy()` instead.")
 }
 #' Evaluate next quosure in a data mask
 #'

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -144,7 +144,12 @@
 #'
 #' \badgedeprecated
 #'
-#' **Renamed in rlang 0.2.0.9000**
+#' **Deprecated as of rlang 0.3.0**
+#'
+#' * [as_data_mask()]: `parent` argument
+#' * [new_data_mask()]: `parent` argument
+#'
+#' **Renamed in rlang 0.3.0**
 #'
 #' * [env_tail()]: `sentinel` => `last`
 #' * [abort()], [warn()], [inform()]: `msg`, `type` and `call` =>

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -109,7 +109,6 @@
 #'
 #' **Retired in rlang 0.2.0:**
 #'
-#' * [eval_tidy_()]
 #' * [overscope_clean()]
 #' * [overscope_eval_next()] => [eval_tidy()]
 #'
@@ -168,6 +167,7 @@
 #' * [cnd_signal()]: `.msg` and `.call`.
 #' * `cnd_inform()`, `cnd_warn()` and `cnd_abort()`
 #' * [UQE()]
+#' * [eval_tidy_()]
 #'
 #'
 #' **Renamed in rlang 0.3.0:**

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,9 +82,9 @@ captureDots <- function() {
 }
 
 cat_line <- function(..., .trailing = TRUE) {
-  cat(chr_lines(..., .trailing = .trailing))
+  cat(paste_line(..., .trailing = .trailing))
 }
-chr_lines <- function(..., .trailing = FALSE) {
+paste_line <- function(..., .trailing = FALSE) {
   lines <- paste(chr(...), collapse = "\n")
   if (.trailing) {
     lines <- paste0(lines, "\n")

--- a/man/as_data_mask.Rd
+++ b/man/as_data_mask.Rd
@@ -6,16 +6,21 @@
 \alias{new_data_mask}
 \title{Create a data mask}
 \usage{
-as_data_mask(data, parent = base_env())
+as_data_mask(data, parent = NULL)
 
 as_data_pronoun(data)
 
-new_data_mask(bottom, top = bottom, parent = base_env())
+new_data_mask(bottom, top = bottom, parent = NULL)
 }
 \arguments{
 \item{data}{A data frame or named vector of masking data.}
 
-\item{parent}{The parent environment of the data mask.}
+\item{parent}{Soft-deprecated. This argument no longer has any effect.
+The parent of the data mask is determined from either:
+\itemize{
+\item The \code{env} argument of \code{eval_tidy()}
+\item Quosure environments when applicable
+}}
 
 \item{bottom}{The environment containing masking objects if the
 data mask is one environment deep. The bottom environment if the
@@ -93,6 +98,17 @@ persist in subsequent evaluations:
 
 
 All these functions are now stable.
+
+\strong{rlang 0.3.0}
+
+The \code{parent} argument no longer has any effect. The parent of the
+data mask is determined from either:
+\itemize{
+\item The \code{env} argument of \code{eval_tidy()}
+\item Quosure environments when applicable
+}
+
+\strong{rlang 0.2.0}
 
 In early versions of rlang data masks were called overscopes. We
 think data mask is a more natural name in R. It makes reference to

--- a/man/as_data_mask.Rd
+++ b/man/as_data_mask.Rd
@@ -43,55 +43,82 @@ user data.
 
 These functions let you construct a tidy eval data mask manually.
 They are meant for developers of tidy eval interfaces rather than
-for end users. Most of the time you can just call \code{\link[=eval_tidy]{eval_tidy()}}
-with user data and the data mask will be constructed automatically.
+for end users.
+}
+\section{Why build a data mask?}{
+
+
+Most of the time you can just call \code{\link[=eval_tidy]{eval_tidy()}} with a list or a
+data frame and the data mask will be constructed automatically.
 There are three main use cases for manual creation of data masks:
 \itemize{
 \item When \code{\link[=eval_tidy]{eval_tidy()}} is called with the same data in a tight loop.
-Tidy eval data masks are a bit expensive to build so it is best
-to construct it once and reuse it the other times for optimal
-performance.
-\item When several expressions should be evaluated in the same
+Because there is some overhead to creating tidy eval data masks,
+constructing the mask once and reusing it for subsequent
+evaluations may improve performance.
+\item When several expressions should be evaluated in the exact same
 environment because a quoted expression might create new objects
 that can be referred in other quoted expressions evaluated at a
-later time.
+later time. One example of this is \code{tibble::lst()} where new
+columns can refer to previous ones.
 \item When your data mask requires special features. For instance the
 data frame columns in dplyr data masks are implemented with
 \link[base:delayedAssign]{active bindings}.
 }
 }
+
 \section{Building your own data mask}{
 
 
-Creating a data mask for \code{\link[base:eval]{base::eval()}} is a simple matter of
-creating an environment containing masking objects that has the
-user context as its parent. \code{eval()} automates this task when you
-supply data as the second argument. However, a tidy eval data mask also
-needs to enable support of \link[=quotation]{quosures} and \link[=tidyeval-data]{data pronouns}. These functions allow manual construction
-of tidy eval data masks:
+Unlike \code{\link[base:eval]{base::eval()}} which takes any kind of environments as data
+mask, \code{\link[=eval_tidy]{eval_tidy()}} has specific requirements in order to support
+\link[=quotation]{quosures}. For this reason you can't supply bare
+environments.
+
+There are two ways of constructing an rlang data mask manually:
 \itemize{
-\item \code{as_data_mask()} transforms a data frame, named vector or
-environment to a data mask. If an environment, its ancestry is
-ignored. It automatically installs a data pronoun.
+\item \code{as_data_mask()} transforms a list or data frame to a data mask.
+It automatically installs the data pronoun \code{\link{.data}}.
 \item \code{new_data_mask()} is a bare bones data mask constructor for
 environments. You can supply a bottom and a top environment in
-case your data mask comprises multiple environments.
+case your data mask comprises multiple environments (see section
+below).
 
 Unlike \code{as_data_mask()} it does not install the \code{.data} pronoun
 so you need to provide one yourself. You can provide a pronoun
 constructed with \code{as_data_pronoun()} or your own pronoun class.
 }
-\itemize{
-\item \code{as_data_pronoun()} constructs a tidy eval data pronoun that
-gives more useful error messages than regular data frames or
-lists, i.e. when an object does not exist or if an user tries to
-overwrite an object.
+
+Once you have built a data mask, simply pass it to \code{\link[=eval_tidy]{eval_tidy()}} as
+the \code{data} argument. You can repeat this as many times as
+needed. Note that any objects created there (perhaps because of a
+call to \code{<-}) will persist in subsequent evaluations.
 }
 
-To use a data mask, just supply it to \code{\link[=eval_tidy]{eval_tidy()}} as the \code{data}
-argument. You can repeat this as many times as needed. Note that
-any objects created there (perhaps because of a call to \code{<-}) will
-persist in subsequent evaluations:
+\section{Top and bottom of data mask}{
+
+
+In some cases you'll need several levels in your data mask. One
+good reason is when you include functions in the mask. It's a good
+idea to keep data objects one level lower than function objects, so
+that the former cannot override the definitions of the latter (see
+examples).
+
+In that case, set up all your environments and keep track of the
+bottom child and the top parent. You'll need to pass both to
+\code{new_data_mask()}.
+
+Note that the parent of the top environment is completely
+undetermined, you shouldn't expect it to remain the same at all
+times. This parent is replaced during evaluation by \code{\link[=eval_tidy]{eval_tidy()}}
+to one of the following environments:
+\itemize{
+\item The default environment passed as the \code{env} argument of \code{eval_tidy()}.
+\item The environment of the current quosure being evaluated, if applicable.
+}
+
+Consequently, all masking data should be contained between the
+bottom and top environment of the data mask.
 }
 
 \section{Life cycle}{
@@ -100,6 +127,9 @@ persist in subsequent evaluations:
 All these functions are now stable.
 
 \strong{rlang 0.3.0}
+
+Passing environments to \code{as_data_mask()} is deprecated. Please
+build a data mask with \code{new_data_mask()}.
 
 The \code{parent} argument no longer has any effect. The parent of the
 data mask is determined from either:
@@ -180,12 +210,4 @@ mask$.data <- as_data_pronoun(bottom)
 
 # Now we can reference the values with the pronouns:
 eval_tidy(quote(.fns$c(.data$a, .data$b, .data$c)), data = mask)
-
-
-# Passing a data mask built with an explicit `top` and `bottom` is
-# not the same as passing a simple environment to `eval_tidy()`. In
-# the latter case, the ancestry of the environment is entirely
-# ignored. The following does not work because `+` is defined in an
-# upper level:
-try(eval_tidy(quote(a + b), data = bottom))
 }

--- a/man/as_overscope.Rd
+++ b/man/as_overscope.Rd
@@ -8,7 +8,7 @@
 \usage{
 as_overscope(quo, data = NULL)
 
-new_overscope(bottom, top = NULL, enclosure = base_env())
+new_overscope(bottom, top = NULL, enclosure = NULL)
 
 overscope_clean(overscope)
 }

--- a/man/eval_tidy.Rd
+++ b/man/eval_tidy.Rd
@@ -13,8 +13,8 @@ eval_tidy(expr, data = NULL, env = caller_env())
 data mask created with \code{\link[=as_data_mask]{as_data_mask()}} or \code{\link[=new_data_mask]{new_data_mask()}}.}
 
 \item{env}{The environment in which to evaluate \code{expr}. This
-environment is always ignored when evaluating quosures. Quosures
-are evaluated in their own environment.}
+environment is not applicable for quosures because they have
+their own environments.}
 }
 \description{
 \code{eval_tidy()} is a variant of \code{\link[base:eval]{base::eval()}} that powers the tidy

--- a/man/eval_tidy.Rd
+++ b/man/eval_tidy.Rd
@@ -34,6 +34,11 @@ values and throw errors if you try to access non-existent values.
 
 
 \code{eval_tidy()} is stable.
+
+\strong{rlang 0.3.0}
+
+Passing an environment to \code{data} is deprecated. Please construct an
+rlang data mask with \code{\link[=new_data_mask]{new_data_mask()}}.
 }
 
 \examples{

--- a/man/eval_tidy_.Rd
+++ b/man/eval_tidy_.Rd
@@ -18,8 +18,8 @@ is only one environment deep, \code{top} should be the same as
 \code{bottom}.}
 
 \item{env}{The environment in which to evaluate \code{expr}. This
-environment is always ignored when evaluating quosures. Quosures
-are evaluated in their own environment.}
+environment is not applicable for quosures because they have
+their own environments.}
 }
 \description{
 This function is soft-deprecated as of rlang 0.2.0.

--- a/man/eval_tidy_.Rd
+++ b/man/eval_tidy_.Rd
@@ -22,6 +22,6 @@ environment is not applicable for quosures because they have
 their own environments.}
 }
 \description{
-This function is soft-deprecated as of rlang 0.2.0.
+This function is defunct as of rlang 0.3.0.
 }
 \keyword{internal}

--- a/man/lifecycle.Rd
+++ b/man/lifecycle.Rd
@@ -139,7 +139,13 @@ Since rlang 0.2.0:
 
 \badgedeprecated
 
-\strong{Renamed in rlang 0.2.0.9000}
+\strong{Deprecated as of rlang 0.3.0}
+\itemize{
+\item \code{\link[=as_data_mask]{as_data_mask()}}: \code{parent} argument
+\item \code{\link[=new_data_mask]{new_data_mask()}}: \code{parent} argument
+}
+
+\strong{Renamed in rlang 0.3.0}
 \itemize{
 \item \code{\link[=env_tail]{env_tail()}}: \code{sentinel} => \code{last}
 \item \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}}: \code{msg}, \code{type} and \code{call} =>

--- a/man/lifecycle.Rd
+++ b/man/lifecycle.Rd
@@ -105,7 +105,6 @@ Since rlang 0.2.0:
 
 \strong{Retired in rlang 0.2.0:}
 \itemize{
-\item \code{\link[=eval_tidy_]{eval_tidy_()}}
 \item \code{\link[=overscope_clean]{overscope_clean()}}
 \item \code{\link[=overscope_eval_next]{overscope_eval_next()}} => \code{\link[=eval_tidy]{eval_tidy()}}
 \item \code{\link[=lang_head]{lang_head()}}, \code{\link[=lang_tail]{lang_tail()}}
@@ -165,6 +164,7 @@ Since rlang 0.2.0:
 \item \code{\link[=cnd_signal]{cnd_signal()}}: \code{.msg} and \code{.call}.
 \item \code{cnd_inform()}, \code{cnd_warn()} and \code{cnd_abort()}
 \item \code{\link[=UQE]{UQE()}}
+\item \code{\link[=eval_tidy_]{eval_tidy_()}}
 }
 
 \strong{Renamed in rlang 0.3.0:}

--- a/src/export/exported-tests.c
+++ b/src/export/exported-tests.c
@@ -12,11 +12,6 @@ sexp* rlang_test_r_warn(sexp* x) {
   return r_null;
 }
 
-sexp* rlang_test_warn_deprecated_once(sexp* id, sexp* msg) {
-  r_warn_deprecated_once(r_c_string(id), r_c_string(msg));
-  return r_null;
-}
-
 
 // env.c
 

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -33,6 +33,17 @@ sexp* rlang_interrupt() {
   return r_null;
 }
 
+sexp* rlang_warn_deprecated_once(sexp* id, sexp* msg) {
+  if (r_typeof(id) != r_type_character ||
+      r_length(id) != 1 ||
+      r_typeof(msg) != r_type_character ||
+      r_length(msg) != 1) {
+    r_abort("`id` and `msg` must be scalar strings");
+  }
+  r_warn_deprecated_once(r_c_string(id), r_c_string(msg));
+  return r_null;
+}
+
 
 // env.c
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -106,6 +106,7 @@ extern sexp* rlang_is_integerish(sexp*, sexp*, sexp*);
 extern sexp* rlang_is_character(sexp*, sexp*);
 extern sexp* rlang_is_raw(sexp*, sexp*);
 extern sexp* rlang_cnd_type(sexp*);
+extern sexp* rlang_warn_deprecated_once(sexp*, sexp*);
 
 // Library initialisation defined below
 sexp* rlang_library_load();
@@ -124,7 +125,6 @@ extern sexp* r_current_frame();
 extern sexp* rlang_test_node_list_clone_until(sexp*, sexp*);
 extern sexp* rlang_test_sys_frame(sexp*);
 extern sexp* rlang_test_sys_call(sexp*);
-extern sexp* rlang_test_warn_deprecated_once(sexp*, sexp*);
 
 static const r_callable r_callables[] = {
   {"rlang_library_load",        (r_fn_ptr_t) &rlang_library_load, 0},
@@ -195,7 +195,6 @@ static const r_callable r_callables[] = {
   {"rlang_test_set_attribute",  (r_fn_ptr_t) &r_set_attribute, 3},
   {"rlang_test_sys_frame",      (r_fn_ptr_t) &rlang_test_sys_frame, 1},
   {"rlang_test_sys_call",       (r_fn_ptr_t) &rlang_test_sys_call, 1},
-  {"rlang_test_warn_deprecated_once", (r_fn_ptr_t) &rlang_test_warn_deprecated_once, 2},
   {"rlang_r_string",            (r_fn_ptr_t) &rlang_r_string, 1},
   {"rlang_exprs_interp",        (r_fn_ptr_t) &rlang_exprs_interp, 4},
   {"rlang_quos_interp",         (r_fn_ptr_t) &rlang_quos_interp, 4},
@@ -242,6 +241,7 @@ static const r_callable r_callables[] = {
   {"rlang_is_character",        (r_fn_ptr_t) &rlang_is_character, 2},
   {"rlang_is_raw",              (r_fn_ptr_t) &rlang_is_raw, 2},
   {"rlang_cnd_type",            (r_fn_ptr_t) &rlang_cnd_type, 1},
+  {"rlang_warn_deprecated_once", (r_fn_ptr_t) &rlang_warn_deprecated_once, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -86,8 +86,10 @@ extern sexp* rlang_quo_set_expr(sexp*, sexp*);
 extern sexp* rlang_quo_get_env(sexp*);
 extern sexp* rlang_quo_set_env(sexp*, sexp*);
 extern sexp* rlang_which_operator(sexp*);
-extern sexp* rlang_new_data_mask(sexp*, sexp*, sexp*);
-extern sexp* rlang_as_data_mask(sexp*, sexp*);
+extern sexp* rlang_new_data_mask(sexp*, sexp*);
+extern sexp* rlang_new_data_mask_compat(sexp*, sexp*, sexp*);
+extern sexp* rlang_as_data_mask(sexp*);
+extern sexp* rlang_as_data_mask_compat(sexp*, sexp*);
 extern sexp* rlang_data_mask_clean(sexp*);
 extern sexp* rlang_eval_tidy(sexp*, sexp*, sexp*);
 extern sexp* rlang_as_data_pronoun(sexp*);
@@ -221,8 +223,8 @@ static const r_callable r_callables[] = {
   {"rlang_vec_poke_range",      (r_fn_ptr_t) &rlang_vec_poke_range, 5},
   {"rlang_which_operator",      (r_fn_ptr_t) &rlang_which_operator, 1},
   {"rlang_call_has_precedence", (r_fn_ptr_t) &rlang_call_has_precedence, 3},
-  {"rlang_new_data_mask",       (r_fn_ptr_t) &rlang_new_data_mask, 3},
-  {"rlang_as_data_mask",        (r_fn_ptr_t) &rlang_as_data_mask, 2},
+  {"rlang_new_data_mask",       (r_fn_ptr_t) &rlang_new_data_mask, 2},
+  {"rlang_as_data_mask",        (r_fn_ptr_t) &rlang_as_data_mask, 1},
   {"rlang_data_mask_clean",     (r_fn_ptr_t) &rlang_data_mask_clean, 1},
   {"rlang_eval_tidy",           (r_fn_ptr_t) &rlang_eval_tidy, 3},
   {"rlang_as_data_pronoun",     (r_fn_ptr_t) &rlang_as_data_pronoun, 1},
@@ -259,11 +261,15 @@ void R_init_rlang(r_dll_info* dll) {
 
   // The data mask functions are stable
   r_register_c_callable("rlang", "rlang_as_data_pronoun", (r_fn_ptr_t) &rlang_as_data_pronoun);
-  r_register_c_callable("rlang", "rlang_as_data_mask", (r_fn_ptr_t) &rlang_as_data_mask);
-  r_register_c_callable("rlang", "rlang_new_data_mask", (r_fn_ptr_t) &rlang_new_data_mask);
+  r_register_c_callable("rlang", "rlang_as_data_mask_3.0.0", (r_fn_ptr_t) &rlang_as_data_mask);
+  r_register_c_callable("rlang", "rlang_new_data_mask_3.0.0", (r_fn_ptr_t) &rlang_new_data_mask);
 
   // Experimental method for exporting C function pointers as actual R objects
   rlang_register_pointer("rlang", "rlang_test_is_spliceable", (r_fn_ptr_t) &rlang_is_clevel_spliceable);
+
+  // Compatibility
+  r_register_c_callable("rlang", "rlang_as_data_mask", (r_fn_ptr_t) &rlang_as_data_mask_compat);
+  r_register_c_callable("rlang", "rlang_new_data_mask", (r_fn_ptr_t) &rlang_new_data_mask_compat);
 
   r_register_r_callables(dll, r_callables, NULL);
 }

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -155,6 +155,24 @@ static bool is_data_mask(sexp* env) {
 
 static sexp* data_pronoun_sym = NULL;
 
+static void warn_env_as_mask_once() {
+  r_warn_deprecated_once("environment passed to rlang::as_data_mask()",
+    "Passing an environment as data mask is deprecated.\n"
+    "Please use `new_data_mask()` to transform your environment to a mask.\n"
+    "\n"
+    "  env <- env(foo = \"bar\")\n"
+    "\n"
+    "  # Bad:\n"
+    "  as_data_mask(env)\n"
+    "  eval_tidy(expr, env)\n"
+    "\n"
+    "  # Good:\n"
+    "  mask <- new_data_mask(env)\n"
+    "  eval_tidy(expr, mask)\n"
+    "\n"
+    "This warning is displayed once per session."
+  );
+}
 sexp* rlang_as_data_mask(sexp* data) {
   if (is_data_mask(data)) {
     return data;
@@ -170,6 +188,7 @@ sexp* rlang_as_data_mask(sexp* data) {
 
   switch (r_typeof(data)) {
   case r_type_environment:
+    warn_env_as_mask_once();
     bottom = KEEP_N(r_env_clone(data, NULL), n_protect);
     break;
 

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -85,7 +85,7 @@ void signal_namespaced_uq_deprecation() {
     "  # Good:\n"
     "  rlang::expr(mean(!!var * 100))\n"
     "\n"
-    "This warning is only displayed once per session."
+    "This warning is displayed once per session."
   );
 }
 void signal_namespaced_uqs_deprecation() {
@@ -102,7 +102,7 @@ void signal_namespaced_uqs_deprecation() {
     "  # Good:\n"
     "  rlang::expr(mean(!!!args))\n"
     "\n"
-    "This warning is only displayed once per session."
+    "This warning is displayed once per session."
   );
 }
 

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -396,7 +396,7 @@ test_that("failed parses are printed if `rlang__verbose_errors` is non-NULL", {
 })
 
 test_that("r_warn_deprecated_once() warns once", {
-  expect_warning(.Call(rlang_test_warn_deprecated_once, "foo", "retired"), "retired")
-  expect_no_warning(.Call(rlang_test_warn_deprecated_once, "foo", "retired"))
-  expect_warning(.Call(rlang_test_warn_deprecated_once, "bar", "retired"), "retired")
+  expect_warning(warn_deprecated_once("foo", "retired"), "retired")
+  expect_no_warning(warn_deprecated_once("foo", "retired"))
+  expect_warning(warn_deprecated_once("bar", "retired"), "retired")
 })

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -209,12 +209,6 @@ test_that("formulas are not evaluated as quosures", {
   expect_identical(eval_tidy(~letters), ~letters)
 })
 
-test_that("can supply environment as data", {
-  `_x` <- "foo"
-  expect_identical(eval_tidy(quo(`_x`), environment()), "foo")
-  expect_error(eval_tidy(quo(`_y`), environment()), "not found")
-})
-
 test_that("tilde calls are evaluated in overscope", {
   quo <- quo({
     foo <- "foo"
@@ -343,3 +337,9 @@ test_that("as_data_mask() and new_data_mask() warn once when passed a parent", {
   expect_no_warning(new_data_mask(NULL, NULL, parent = env()))
 })
 
+test_that("supplying environment as data is deprecated", {
+  `_x` <- "foo"
+  expect_warning(eval_tidy("foo", current_env()), "deprecated")
+  expect_identical(eval_tidy(quo(`_x`), current_env()), "foo")
+  expect_error(eval_tidy(quo(`_y`), current_env()), "not found")
+})

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -175,12 +175,6 @@ test_that("inner formulas are rechained to evaluation env", {
   expect_true(env_inherits(env$eval_env2, get_env(f2)))
 })
 
-test_that("dyn scope is chained to lexical env", {
-  foo <- "bar"
-  overscope <- child_env(NULL)
-  expect_identical(eval_tidy_(quo(foo), overscope), "bar")
-})
-
 test_that("whole scope is purged", {
   outside <- child_env(NULL, important = TRUE)
   top <- child_env(outside, foo = "bar", hunoz = 1)
@@ -324,3 +318,28 @@ test_that("new_data_mask() checks `top` is a parent of `bottom`", {
   expect_no_error(new_data_mask(bottom, top))
   expect_error(new_data_mask(top, bottom), "`top` is not a parent of `bottom`")
 })
+
+test_that("data mask inherits from last environment", {
+  mask <- new_data_mask(NULL, NULL)
+  expect_reference(env_parent(mask), empty_env())
+
+  eval_tidy(NULL, mask)
+  expect_reference(env_parent(mask), current_env())
+
+  env <- env()
+  quo <- new_quosure(NULL, env)
+  eval_tidy(quo, mask)
+  expect_reference(env_parent(mask), env)
+})
+
+
+# Lifecycle ----------------------------------------------------------
+
+test_that("as_data_mask() and new_data_mask() warn once when passed a parent", {
+  expect_warning(as_data_mask(mtcars, env()), "deprecated")
+  expect_no_warning(as_data_mask(mtcars, env()))
+
+  expect_warning(new_data_mask(NULL, NULL, parent = env()), "deprecated")
+  expect_no_warning(new_data_mask(NULL, NULL, parent = env()))
+})
+

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -119,3 +119,7 @@ test_that("is_quosureish() and as_quosureish() still work", {
 test_that("node() still works", {
   expect_identical(node(1, NULL), new_node(1, NULL))
 })
+
+test_that("eval_tidy_() is defunct", {
+  expect_error(eval_tidy_(), "defunct")
+})

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -79,8 +79,6 @@ test_that("overscope functions forward to mask functions", {
   mask <- new_overscope(bottom, top)
   expect_true(env_has(mask, ".__tidyeval_data_mask__."))
 
-  expect_identical(eval_tidy_(quote(foo), bottom, top), "bar")
-
   overscope_clean(mask)
   expect_false(env_has(env_parent(mask), "foo"))
 


### PR DESCRIPTION
* Deprecate bare environments passed to `eval_tidy()` and `as_data_mask()` Passing bare environments is confusing because their parents is silently changed to the current evaluation env. (There is a similar confusion in `base::eval()` except that it goes the other way around, the current evaluation env is silently ignored.)

* Deprecate `parent` arguments of `as_data_mask()` and `new_data_mask()`.

The idea behind these two changes is that the parent of the data mask is undetermined at time of creation. The parent changes during evaluation to the `env` argument of `eval_tidy()`, or to quosure environments when applicable. Given these semantics, allowing parents at data mask creation and supporting bare environments were confusing.

Closes #571 