### PR TITLE
Gracefully handle expr_text(<symbol>).

### DIFF
--- a/R/expr.R
+++ b/R/expr.R
@@ -178,6 +178,9 @@ expr_name <- function(expr) {
 #' @param width Width of each line.
 #' @param nlines Maximum number of lines to extract.
 expr_text <- function(expr, width = 60L, nlines = Inf) {
+  if (is_symbol(expr)) {
+    return(as_string(expr))
+  }
   str <- deparse(expr, width.cutoff = width)
 
   if (length(str) > nlines) {

--- a/tests/testthat/test-quo.R
+++ b/tests/testthat/test-quo.R
@@ -128,16 +128,7 @@ test_that("quosures are spliced", {
   expect_identical(quo_text(q), "foo(bar(baz))")
 })
 
-test_that("quo_text() uses as_string encoding repair (#611)", {
-  old <- Sys.getlocale("LC_CTYPE")
-  on.exit(Sys.setlocale("LC_CTYPE", old))
-  Sys.setlocale("LC_CTYPE", "C")
-
-  s <- sym("\u4e2d")
-  expect_equal(quo_text(s), as_string(s))
-})
-
-test_that("expr_text() interprets unicode notation", {
+test_that("expr_text() interprets unicode tags (#611)", {
   expect_equal(expr_text(quote(`<U+006F>`)), "o")
 })
 

--- a/tests/testthat/test-quo.R
+++ b/tests/testthat/test-quo.R
@@ -137,6 +137,10 @@ test_that("quo_text() uses as_string encoding repair (#611)", {
   expect_equal(quo_text(s), as_string(s))
 })
 
+test_that("expr_text() interprets unicode notation", {
+  expect_equal(expr_text(quote(`<U+006F>`)), "o")
+})
+
 test_that("formulas are not spliced", {
   expect_identical(quo_text(quo(~foo(~bar))), "~foo(~bar)")
 })

--- a/tests/testthat/test-quo.R
+++ b/tests/testthat/test-quo.R
@@ -128,6 +128,15 @@ test_that("quosures are spliced", {
   expect_identical(quo_text(q), "foo(bar(baz))")
 })
 
+test_that("quo_text() uses as_string encoding repair (#611)", {
+  old <- Sys.getlocale("LC_CTYPE")
+  on.exit(Sys.setlocale("LC_CTYPE", old))
+  Sys.setlocale("LC_CTYPE", "C")
+
+  s <- sym("\u4e2d")
+  expect_equal(quo_text(s), as_string(s))
+})
+
 test_that("formulas are not spliced", {
   expect_identical(quo_text(quo(~foo(~bar))), "~foo(~bar)")
 })


### PR DESCRIPTION
When the expression is a bare symbol, rather use as_string and its magic handling of encoding. closes #611

Same fix as https://github.com/tidyverse/dplyr/pull/3830 but potentially benefitting outside of dplyr. 