### PR TITLE
Add `.forward_empty` argument to dots collectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang 0.2.2.9000
 
+* `dots_list()` gains a `.preserve_empty` argument. When `TRUE`, empty
+  arguments are stored as missing arguments (see `?missing_arg`).
+
 * New experimental option `rlang__backtrace_on_error` to display
   backtraces alongside error messages. See `?rlang::abort` for
   supported options.

--- a/R/dots.R
+++ b/R/dots.R
@@ -46,6 +46,10 @@
 #' @param .ignore_empty Whether to ignore empty arguments. Can be one
 #'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
 #'   last argument is ignored if it is empty.
+#' @param .preserve_empty Whether to preserve the empty arguments that
+#'   were not ignored. If `TRUE`, empty arguments are stored with
+#'   [missing_arg()] values. If `FALSE` (the default) an error is
+#'   thrown when an empty argument is detected.
 #' @return A list of arguments. This list is always named: unnamed
 #'   arguments are named with the empty string `""`.
 #'
@@ -85,18 +89,34 @@
 #' # provides a workaround:
 #' fn("wrong!", data = letters)  # exact matching of `data`
 #' fn("wrong!", dat = letters)   # partial matching of `data`
-#' fn(some_data, !!! list(data = letters))  # no matching
+#' fn(some_data, !!!list(data = letters))  # no matching
+#'
+#'
+#' # Empty arguments trigger an error by default:
+#' try(fn(, ))
+#'
+#' # You can choose to preserve empty arguments instead:
+#' list3 <- function(...) dots_list(..., .preserve_empty = TRUE)
+#'
+#' # Note how the last empty argument is still ignored because
+#' # `.ignore_empty` defaults to "trailing":
+#' list3(, )
+#'
+#' # The list with preserved empty arguments is equivalent to:
+#' list(missing_arg())
 dots_list <- function(...,
-                      .ignore_empty = c("trailing", "none", "all")) {
-  dots <- .Call(rlang_dots_list, environment(), FALSE, .ignore_empty, TRUE)
+                      .ignore_empty = c("trailing", "none", "all"),
+                      .preserve_empty = FALSE) {
+  dots <- .Call(rlang_dots_list, environment(), FALSE, .ignore_empty, .preserve_empty, TRUE)
   names(dots) <- names2(dots)
   dots
 }
 
 dots_split <- function(...,
                        .n_unnamed = NULL,
-                       .ignore_empty = c("trailing", "none", "all")) {
-  dots <- .Call(rlang_dots_list, environment(), FALSE, .ignore_empty, TRUE)
+                       .ignore_empty = c("trailing", "none", "all"),
+                       .preserve_empty = FALSE) {
+  dots <- .Call(rlang_dots_list, environment(), FALSE, .ignore_empty, .preserve_empty, TRUE)
 
   if (is_null(names(dots))) {
     if (length(dots)) {
@@ -216,8 +236,9 @@ is_spliced_bare <- function(x) {
 #' @inheritParams tidy-dots
 #' @export
 dots_splice <- function(...,
-                        .ignore_empty = c("trailing", "none", "all")) {
-  dots <- .Call(rlang_dots_flat_list, environment(), FALSE, .ignore_empty, TRUE)
+                        .ignore_empty = c("trailing", "none", "all"),
+                        .preserve_empty = FALSE) {
+  dots <- .Call(rlang_dots_flat_list, environment(), FALSE, .ignore_empty, .preserve_empty, TRUE)
   names(dots) <- names2(dots)
   dots
 }
@@ -242,8 +263,9 @@ dots_splice <- function(...,
 #' # Flatten the objects marked as spliced:
 #' flatten_if(dots, is_spliced)
 dots_values <- function(...,
-                        .ignore_empty = c("trailing", "none", "all")) {
-  .Call(rlang_dots_values, environment(), FALSE, .ignore_empty, TRUE)
+                        .ignore_empty = c("trailing", "none", "all"),
+                        .preserve_empty = FALSE) {
+  .Call(rlang_dots_values, environment(), FALSE, .ignore_empty, .preserve_empty, TRUE)
 }
 
 #' Capture definition objects

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -100,12 +100,12 @@ bytes <- function(...) {
 #' @rdname tidy-dots
 #' @export
 list2 <- function(...) {
-  .Call(rlang_dots_list, environment(), FALSE, "trailing", TRUE)
+  .Call(rlang_dots_list, environment(), FALSE, "trailing", FALSE, TRUE)
 }
 #' @rdname vector-construction
 #' @export
 ll <- function(...) {
-  .Call(rlang_dots_list, environment(), FALSE, "trailing", TRUE)
+  .Call(rlang_dots_list, environment(), FALSE, "trailing", FALSE, TRUE)
 }
 
 

--- a/man/dots_values.Rd
+++ b/man/dots_values.Rd
@@ -4,7 +4,8 @@
 \alias{dots_values}
 \title{Evaluate dots with preliminary splicing}
 \usage{
-dots_values(..., .ignore_empty = c("trailing", "none", "all"))
+dots_values(..., .ignore_empty = c("trailing", "none", "all"),
+  .preserve_empty = FALSE)
 }
 \arguments{
 \item{...}{Arguments to evaluate and process splicing operators.}
@@ -12,6 +13,11 @@ dots_values(..., .ignore_empty = c("trailing", "none", "all"))
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
+
+\item{.preserve_empty}{Whether to preserve the empty arguments that
+were not ignored. If \code{TRUE}, empty arguments are stored with
+\code{\link[=missing_arg]{missing_arg()}} values. If \code{FALSE} (the default) an error is
+thrown when an empty argument is detected.}
 }
 \description{
 This is a tool for advanced users. It captures dots, processes

--- a/man/splice.Rd
+++ b/man/splice.Rd
@@ -13,7 +13,8 @@ is_spliced(x)
 
 is_spliced_bare(x)
 
-dots_splice(..., .ignore_empty = c("trailing", "none", "all"))
+dots_splice(..., .ignore_empty = c("trailing", "none", "all"),
+  .preserve_empty = FALSE)
 }
 \arguments{
 \item{x}{A list to splice.}
@@ -25,6 +26,11 @@ arguments are embedded in the returned list.}
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
+
+\item{.preserve_empty}{Whether to preserve the empty arguments that
+were not ignored. If \code{TRUE}, empty arguments are stored with
+\code{\link[=missing_arg]{missing_arg()}} values. If \code{FALSE} (the default) an error is
+thrown when an empty argument is detected.}
 }
 \description{
 \Sexpr[results=rd, stage=render]{rlang:::lifecycle("questioning")}

--- a/man/tidy-dots.Rd
+++ b/man/tidy-dots.Rd
@@ -6,7 +6,8 @@
 \alias{list2}
 \title{Collect dots tidily}
 \usage{
-dots_list(..., .ignore_empty = c("trailing", "none", "all"))
+dots_list(..., .ignore_empty = c("trailing", "none", "all"),
+  .preserve_empty = FALSE)
 
 list2(...)
 }
@@ -18,6 +19,11 @@ arguments are embedded in the returned list.}
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
 last argument is ignored if it is empty.}
+
+\item{.preserve_empty}{Whether to preserve the empty arguments that
+were not ignored. If \code{TRUE}, empty arguments are stored with
+\code{\link[=missing_arg]{missing_arg()}} values. If \code{FALSE} (the default) an error is
+thrown when an empty argument is detected.}
 }
 \value{
 A list of arguments. This list is always named: unnamed
@@ -91,7 +97,21 @@ fn <- function(data, ...) {
 # provides a workaround:
 fn("wrong!", data = letters)  # exact matching of `data`
 fn("wrong!", dat = letters)   # partial matching of `data`
-fn(some_data, !!! list(data = letters))  # no matching
+fn(some_data, !!!list(data = letters))  # no matching
+
+
+# Empty arguments trigger an error by default:
+try(fn(, ))
+
+# You can choose to preserve empty arguments instead:
+list3 <- function(...) dots_list(..., .preserve_empty = TRUE)
+
+# Note how the last empty argument is still ignored because
+# `.ignore_empty` defaults to "trailing":
+list3(, )
+
+# The list with preserved empty arguments is equivalent to:
+list(missing_arg())
 }
 \seealso{
 \code{\link[=exprs]{exprs()}} for extracting dots without evaluation.

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -59,9 +59,9 @@ extern sexp* rlang_cnd_signal(sexp*);
 extern sexp* rlang_r_string(sexp*);
 extern sexp* rlang_exprs_interp(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_quos_interp(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_dots_values(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_dots_list(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_dots_flat_list(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_dots_values(sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_dots_list(sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_dots_flat_list(sexp*, sexp*, sexp*, sexp*, sexp*);
 extern sexp* r_new_formula(sexp*, sexp*, sexp*);
 extern sexp* rlang_new_quosure(sexp*, sexp*);
 extern sexp* rlang_enexpr(sexp*, sexp*);
@@ -199,9 +199,9 @@ static const r_callable r_callables[] = {
   {"rlang_r_string",            (r_fn_ptr_t) &rlang_r_string, 1},
   {"rlang_exprs_interp",        (r_fn_ptr_t) &rlang_exprs_interp, 4},
   {"rlang_quos_interp",         (r_fn_ptr_t) &rlang_quos_interp, 4},
-  {"rlang_dots_values",         (r_fn_ptr_t) &rlang_dots_values, 4},
-  {"rlang_dots_list",           (r_fn_ptr_t) &rlang_dots_list, 4},
-  {"rlang_dots_flat_list",      (r_fn_ptr_t) &rlang_dots_flat_list, 4},
+  {"rlang_dots_values",         (r_fn_ptr_t) &rlang_dots_values, 5},
+  {"rlang_dots_list",           (r_fn_ptr_t) &rlang_dots_list, 5},
+  {"rlang_dots_flat_list",      (r_fn_ptr_t) &rlang_dots_flat_list, 5},
   {"rlang_new_formula",         (r_fn_ptr_t) &r_new_formula, 3},
   {"rlang_new_quosure",         (r_fn_ptr_t) &rlang_new_quosure, 2},
   {"rlang_enexpr",              (r_fn_ptr_t) &rlang_enexpr, 2},

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -149,3 +149,10 @@ test_that("can unquote quosures in LHS", {
   expect_identical(list2(!!quo := NULL), list(foo = NULL))
   expect_identical(exprs(!!quo := bar), exprs(foo = bar))
 })
+
+test_that("can preserve empty arguments", {
+  list3 <- function(...) unname(dots_list(..., .preserve_empty = TRUE))
+  expect_identical(list3(, ), list(missing_arg()))
+  expect_identical(list3(, , .ignore_empty = "none"), list(missing_arg(), missing_arg()))
+  expect_identical(list3(, , .ignore_empty = "all"), list())
+})


### PR DESCRIPTION
Allow dots collectors to preserve empty arguments.