### PR TITLE
Return old values from `env_bind()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 
 # rlang 0.2.2.9000
 
-* `env_bind()` now returns the list of old binding values (or missing
-  arguments when there is no old value). This makes it easy to restore
-  the original environment state:
+* `env_bind()`, `env_bind_exprs()`, and `env_bind_fns()` now return
+  the list of old binding values (or missing arguments when there is
+  no old value). This makes it easy to restore the original
+  environment state:
 
   ```
   old <- env_bind(env, foo = "foo", bar = "bar")

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,18 @@
 
 # rlang 0.2.2.9000
 
+* `env_bind()` now returns the list of old binding values (or missing
+  arguments when there is no old value). This makes it easy to restore
+  the original environment state:
+
+  ```
+  old <- env_bind(env, foo = "foo", bar = "bar")
+  env_bind(env, !!!old)
+  ```
+
+* `env_bind()` now supports removing bindings with empty arguments.
+  `env_bind(env, foo = )` removes the `foo` binding.
+
 * `dots_list()` gains a `.preserve_empty` argument. When `TRUE`, empty
   arguments are stored as missing arguments (see `?missing_arg`).
 

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -42,8 +42,8 @@
 #' produces effects in all other references to that environment. In
 #' other words, `env_bind()` and its variants have side effects.
 #'
-#' As they are called primarily for their side effects, these
-#' functions follow the convention of returning their input invisibly.
+#' Like other side-effecty functions like `par()` and `options()`,
+#' `env_bind()` and variants return the old values invisibly.
 #'
 #'
 #' @section Life cycle:
@@ -71,6 +71,10 @@
 #' env_bind(current_env(), bar = "BAR")
 #' bar
 #'
+#' # You can remove bindings by supplying empty arguments:
+#' env_bind(current_env(), foo = , bar = )
+#' try(foo)
+#'
 #' # It is most useful to change other environments:
 #' my_env <- env()
 #' env_bind(my_env, foo = "foo")
@@ -78,7 +82,7 @@
 #'
 #' # A useful feature is to splice lists of named values:
 #' vals <- list(a = 10, b = 20)
-#' env_bind(my_env, !!! vals, c = 30)
+#' env_bind(my_env, !!!vals, c = 30)
 #' my_env$b
 #' my_env$c
 #'
@@ -87,10 +91,19 @@
 #' var <- "baz"
 #' env_bind(my_env, !!var := "BAZ")
 #' my_env$baz
+#'
+#'
+#' # The old values of the bindings are returned invisibly:
+#' old <- env_bind(my_env, a = 1, b = 2, baz = "baz")
+#' old
+#'
+#' # You can restore the original environment state by supplying the
+#' # old values back:
+#' env_bind(my_env, !!!old)
 env_bind <- function(.env, ...) {
-  invisible(env_bind_impl(.env, list2(...), "env_bind()"))
+  env_bind_impl(.env, list3(...), "env_bind()", bind = TRUE)
 }
-env_bind_impl <- function(env, data, fn) {
+env_bind_impl <- function(env, data, fn, bind = FALSE) {
   if (!is_vector(data)) {
     type <- as_friendly_type(type_of(data))
     abort(sprintf("`data` must be a vector not a %s", type))
@@ -105,15 +118,30 @@ env_bind_impl <- function(env, data, fn) {
     }
   }
 
-  nms <- names(data)
   env_ <- get_env_retired(env, fn, caller_env(2))
+  nms <- names2(data)
+
+  if (bind) {
+    old <- new_list_along(nms, nms)
+    overwritten <- env_has(env_, nms)
+    old[overwritten] <- env_get_list(env_, nms[overwritten])
+    old[!overwritten] <- list(missing_arg())
+  }
 
   for (i in seq_along(data)) {
     nm <- nms[[i]]
-    base::assign(nm, data[[nm]], envir = env_)
+    if (bind && overwritten[[i]] && is_missing(data[[i]])) {
+      base::rm(list = nm, envir = env_)
+    } else {
+      base::assign(nm, data[[nm]], envir = env_)
+    }
   }
 
-  env
+  if (bind) {
+    invisible(old)
+  } else {
+    invisible(env_)
+  }
 }
 
 # FIXME: Should these be env_bind_promises() and env_bind_actives()?
@@ -240,20 +268,9 @@ scoped_bindings <- function(..., .env = .frame, .frame = caller_env()) {
     return(list())
   }
 
-  stopifnot(is_named(bindings))
+  old <- env_bind_impl(env, bindings, "scoped_bindings()", bind = TRUE)
+  scoped_exit(frame = .frame, !!call2(env_bind_impl, env, old, bind = TRUE))
 
-  nms <- names(bindings)
-  is_old <- env_has(env, nms)
-  old <- env_get_list(env, nms[is_old])
-
-  unbind_lang <- call2(env_unbind, env, nms[!is_old])
-  rebind_lang <- call2(env_bind_impl, env, old)
-  scoped_exit(frame = .frame, {
-    !! unbind_lang
-    !! rebind_lang
-  })
-
-  env_bind_impl(env, bindings, "scoped_bindings()")
   invisible(old)
 }
 #' @rdname scoped_bindings

--- a/R/env.R
+++ b/R/env.R
@@ -151,18 +151,21 @@ env <- function(...) {
 
   env <- new.env(parent = parent)
   env_bind_impl(env, dots$named)
+  env
 }
 #' @rdname env
 #' @export
 child_env <- function(.parent, ...) {
   env <- new.env(parent = as_environment(.parent))
   env_bind_impl(env, list2(...))
+  env
 }
 #' @rdname env
 #' @export
 new_environment <- function(data = list(), parent = empty_env()) {
   env <- new.env(parent = parent)
   env_bind_impl(env, data)
+  env
 }
 
 #' Coerce to an environment

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -108,6 +108,11 @@ ll <- function(...) {
   .Call(rlang_dots_list, environment(), FALSE, "trailing", FALSE, TRUE)
 }
 
+# Preserves empty arguments
+list3 <- function(...) {
+  .Call(rlang_dots_list, environment(), FALSE, "trailing", TRUE, TRUE)
+}
+
 
 #' Create vectors matching a given length
 #'

--- a/man/env_bind.Rd
+++ b/man/env_bind.Rd
@@ -56,8 +56,8 @@ in \code{\link[=env]{env()}} documentation), modifying the bindings of an enviro
 produces effects in all other references to that environment. In
 other words, \code{env_bind()} and its variants have side effects.
 
-As they are called primarily for their side effects, these
-functions follow the convention of returning their input invisibly.
+Like other side-effecty functions like \code{par()} and \code{options()},
+\code{env_bind()} and variants return the old values invisibly.
 }
 
 \section{Life cycle}{
@@ -81,6 +81,10 @@ bar <- "bar"
 env_bind(current_env(), bar = "BAR")
 bar
 
+# You can remove bindings by supplying empty arguments:
+env_bind(current_env(), foo = , bar = )
+try(foo)
+
 # It is most useful to change other environments:
 my_env <- env()
 env_bind(my_env, foo = "foo")
@@ -88,7 +92,7 @@ my_env$foo
 
 # A useful feature is to splice lists of named values:
 vals <- list(a = 10, b = 20)
-env_bind(my_env, !!! vals, c = 30)
+env_bind(my_env, !!!vals, c = 30)
 my_env$b
 my_env$c
 
@@ -97,4 +101,13 @@ my_env$c
 var <- "baz"
 env_bind(my_env, !!var := "BAZ")
 my_env$baz
+
+
+# The old values of the bindings are returned invisibly:
+old <- env_bind(my_env, a = 1, b = 2, baz = "baz")
+old
+
+# You can restore the original environment state by supplying the
+# old values back:
+env_bind(my_env, !!!old)
 }

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -80,7 +80,7 @@ test_that("scoped_bindings binds temporarily", {
       bar = "BAR",
       baz = "BAZ"
     )
-    expect_identical(old, list(foo = "foo", bar = "bar"))
+    expect_identical(old, list3(foo = "foo", bar = "bar", baz = ))
     temp_bindings <- env_get_list(env, c("foo", "bar", "baz"))
     expect_identical(temp_bindings, list(foo = "FOO", bar = "BAR", baz = "BAZ"))
   })
@@ -234,4 +234,13 @@ test_that("can pluck missing arg from environment", {
 test_that("can call scoped_bindings() and with_bindings() without arguments", {
   expect_no_error(scoped_bindings())
   expect_no_error(with_bindings("foo"))
+})
+
+test_that("can remove bindings by supplying empty arguments", {
+  empty <- env()
+  expect_no_error(env_bind(empty, foo = ))
+
+  env <- env(foo = "foo", bar = "bar")
+  env_bind(env, foo = , bar = )
+  expect_identical(env_names(env), chr())
 })

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -14,7 +14,8 @@ test_that("promises are created", {
 })
 
 test_that("env_bind_fns() creates active bindings", {
-  env <- env_bind_fns(env(), a = function() "foo")
+  env <- env()
+  env_bind_fns(env, a = function() "foo")
   expect_identical(env$a, "foo")
   expect_identical(env$a, "foo")
 })
@@ -186,7 +187,8 @@ test_that("applies predicates to all bindings by default", {
 })
 
 test_that("env_binding_are_active() doesn't force promises", {
-  env <- env_bind_exprs(env(), foo = stop("kaboom"))
+  env <- env()
+  env_bind_exprs(env, foo = stop("kaboom"))
   expect_no_error(env_binding_are_active(env))
   expect_identical(env_binding_are_promise(env), lgl(foo = TRUE))
   expect_identical(env_binding_are_promise(env), lgl(foo = TRUE))


### PR DESCRIPTION
Includes #619 for empty argument support.

- Allow removing bindings by supplying empty arguments:

    ```
    env_bind(env, foo = )
    ```

- Return old binding values from `env_bind()`. When there is no old value, missing arguments are returned.

The combination of these features ensures the following roundtrip always restores the environment state:

```
old <- env_bind(env, ...)
env_bind(env, !!!old)
```