### PR TITLE
Improve empty punning idioms for trace subsetting

### DIFF
--- a/R/cnd.R
+++ b/R/cnd.R
@@ -398,11 +398,7 @@ trace_trim_context <- function(trace, frame = caller_env()) {
   }
 
   to_trim <- seq2(idx, trace_length(trace))
-  if (length(to_trim)) {
-    trace <- trace_subset(trace, -to_trim)
-  }
-
-  trace
+  trace_subset(trace, -to_trim %0% expr())
 }
 # FIXME: Find more robust strategy of stripping catching context
 find_capture_context <- function(n = 3L) {
@@ -618,9 +614,7 @@ print.rlang_error <- function(x,
       if (length(calls) && is_call(calls[[1]], c("tryCatch", "with_handlers"))) {
         parent <- trace$parents[[1]]
         next_sibling_idx <- seq2(1L, match2(trace$parents[-1], parent))
-        if (length(next_sibling_idx)) {
-          trace <- trace_subset(trace, -next_sibling_idx)
-        }
+        trace <- trace_subset(trace, -next_sibling_idx %0% expr())
       }
     }
 

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -617,9 +617,9 @@ print.rlang_error <- function(x,
       calls <- trace$calls
       if (length(calls) && is_call(calls[[1]], c("tryCatch", "with_handlers"))) {
         parent <- trace$parents[[1]]
-        next_sibling <- which(trace$parents[-1] == parent)
-        if (length(next_sibling)) {
-          trace <- trace_subset(trace, -seq2(1L, next_sibling))
+        next_sibling_idx <- seq2(1L, match2(trace$parents[-1], parent))
+        if (length(next_sibling_idx)) {
+          trace <- trace_subset(trace, -next_sibling_idx)
         }
       }
     }

--- a/R/operators.R
+++ b/R/operators.R
@@ -32,6 +32,14 @@
   .Call(rlang_replace_na, x, y)
 }
 
+`%0%` <- function(x, y) {
+  if (length(x)) {
+    x
+  } else {
+    y
+  }
+}
+
 #' Infix attribute accessor
 #'
 #' @param x Object

--- a/R/trace.R
+++ b/R/trace.R
@@ -318,7 +318,7 @@ trace_trim_env <- function(x, to = NULL) {
   start <- last(which(is_top)) + 1
   end <- length(x$envs)
 
-  trace_subset(x, start:end)
+  trace_subset(x, seq2(start, end) %0% expr())
 }
 
 set_trace_skipped <- function(trace, id, n) {

--- a/R/vec-utils.R
+++ b/R/vec-utils.R
@@ -128,6 +128,16 @@ seq2_along <- function(from, x) {
   seq2(from, length(x))
 }
 
+# Better argument ordering and empty punning when no match
+match2 <- function(vec, elt) {
+  idx <- match(elt, vec)
+  if (identical(idx, na_int)) {
+    int()
+  } else {
+    idx
+  }
+}
+
 first <- function(x) {
   .subset2(x, 1L)
 }

--- a/R/vec-utils.R
+++ b/R/vec-utils.R
@@ -106,6 +106,16 @@ modify <- function(.x, ...) {
 #'
 #' seq2_along(10, letters)
 seq2 <- function(from, to) {
+  n_from <- length(from)
+  n_to <- length(to)
+
+  if (n_from == 0 || n_to == 0) {
+    return(int())
+  }
+  if (n_from > 1 || n_to > 1) {
+    abort("`from` and `to` must be length zero or one")
+  }
+
   if (from > to) {
     int()
   } else {

--- a/tests/testthat/test-vec.R
+++ b/tests/testthat/test-vec.R
@@ -75,3 +75,13 @@ test_that("vector pokers fail if parameters are not integerish", {
 test_that("is_string() returns FALSE for `NA`", {
   expect_false(is_string(na_chr))
 })
+
+test_that("seq2() does empty punning on its arguments", {
+  expect_identical(seq2(int(), 1), int())
+  expect_identical(seq2(0, int()), int())
+})
+
+test_that("seq2() fails when arguments are length > 1", {
+  expect_error(seq2(1, 1:2), "must be length")
+  expect_error(seq2(1:2, 1), "must be length")
+})

--- a/tests/testthat/test-vec.R
+++ b/tests/testthat/test-vec.R
@@ -85,3 +85,8 @@ test_that("seq2() fails when arguments are length > 1", {
   expect_error(seq2(1, 1:2), "must be length")
   expect_error(seq2(1:2, 1), "must be length")
 })
+
+test_that("match2() returns empty vector on failed match", {
+  expect_identical(match2(1:3, 2), 2L)
+  expect_identical(match2(1:3, 10), int())
+})


### PR DESCRIPTION
* `seq2()` recycles to length zero over its arguments.
* Use `x[vec %0% expr()]` idiom to escape from empty punning while subsetting.
* Draft `match2()`, an empty punning version of `match()` with better argument ordering.