### PR TITLE
Fix !!! input types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,12 @@
   and in quoting functions. `!!!` accepts these types:
 
   - Lists, pairlists, and atomic vectors. If they have a class, they
-    are converted with `base::as.list()` to allow S3 and S4 dispatch.
+    are converted with `base::as.list()` to allow S3 dispatch.
     Following this change, objects like factors can now be spliced
     without data loss.
+
+  - S4 objects. These are converted with `as(obj, "list")` before
+    splicing.
 
   - Quoted blocks of expressions, i.e. `{ }` calls
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,29 @@
 
 # rlang 0.2.2.9000
 
+* The input types of `!!!` have been standardised. `!!!` is generally
+  defined on vectors: it takes a vector (typically, a list) and
+  unquotes each element as a separate argument. The standardisation
+  makes `!!!` behave the same in functions taking dots with `list2()`
+  and in quoting functions. `!!!` accepts these types:
+
+  - Lists, pairlists, and atomic vectors. If they have a class, they
+    are converted with `base::as.list()` to allow S3 and S4 dispatch.
+    Following this change, objects like factors can now be spliced
+    without data loss.
+
+  - Quoted blocks of expressions, i.e. `{ }` calls
+
+  `!!!` disallows:
+
+  - Any other objects like functions or environments, but also
+    language objects like formula, symbols, or quosures.
+
+  Quoting functions used to automatically wrap language objects in
+  lists to make them spliceable. This behaviour is now soft-deprecated
+  and it is no longer valid to write `!!!enquo(x)`. Please unquote
+  scalar objects with `!!` instead.
+
 * `dots_list()`, `enexprs()` and `enquos()` gain a `.check_assign`
   argument. When `TRUE`, a warning is issued when a `<-` call is
   detected in `...`. No warning is issued if the assignment is wrapped

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,10 @@
   and it is no longer valid to write `!!!enquo(x)`. Please unquote
   scalar objects with `!!` instead.
 
+* `fn_body()` always returns a `{` block, even if the function has a
+  single expression. For instance `fn_body(function(x) do()) ` returns
+  `quote({ do() })`.
+
 * `dots_list()`, `enexprs()` and `enquos()` gain a `.check_assign`
   argument. When `TRUE`, a warning is issued when a `<-` call is
   detected in `...`. No warning is issued if the assignment is wrapped

--- a/R/dots.R
+++ b/R/dots.R
@@ -40,9 +40,7 @@
 #' default. `list2()` does not have this issue.
 #'
 #'
-#' @param ... Arguments with explicit (`dots_list()`) or list
-#'   (`dots_splice()`) splicing semantics. The contents of spliced
-#'   arguments are embedded in the returned list.
+#' @param ... Arguments to collect with `!!!` support.
 #' @param .ignore_empty Whether to ignore empty arguments. Can be one
 #'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
 #'   last argument is ignored if it is empty.

--- a/R/fn.R
+++ b/R/fn.R
@@ -162,17 +162,34 @@ fn_fmls_syms <- function(fn = caller_fn()) {
 
 #' Get or set function body
 #'
-#' `fn_body()` is a simple wrapper around `base::body()`. The setter
+#' `fn_body()` is a simple wrapper around [base::body()]. It always
+#' returns a `\{` expression and throws an error when the input is a
+#' primitive function (whereas `body()` returns `NULL`). The setter
 #' version preserves attributes, unlike `body<-`.
 #'
 #' @inheritParams fn_fmls
 #'
 #' @export
+#' @examples
+#' # fn_body() is like body() but always returns a block:
+#' fn <- function() do()
+#' body(fn)
+#' fn_body(fn)
+#'
+#' # It also throws an error when used on a primitive function:
+#' try(fn_body(base::list))
 fn_body <- function(fn = caller_fn()) {
   if(!is_closure(fn)) {
     abort("`fn` is not a closure")
   }
-  body(fn)
+
+  body <- body(fn)
+
+  if (is_call(body, "{")) {
+    body
+  } else {
+    call("{", body)
+  }
 }
 #' @rdname fn_body
 #' @export

--- a/R/quasiquotation.R
+++ b/R/quasiquotation.R
@@ -23,7 +23,8 @@
 #'
 #'   If the vector is a classed object (like a factor), it is
 #'   converted to a list with [base::as.list()] to ensure proper
-#'   dispatch.
+#'   dispatch. If it is an S4 objects, it is converted to a list with
+#'   [methods::as()].
 #'
 #' Use `qq_show()` to experiment with quasiquotation or debug the
 #' effect of unquoting operators. `qq_show()` quotes its input,

--- a/R/quasiquotation.R
+++ b/R/quasiquotation.R
@@ -21,6 +21,10 @@
 #'   inserted as an argument. If the vector is named, the names are
 #'   used as argument names.
 #'
+#'   If the vector is a classed object (like a factor), it is
+#'   converted to a list with [base::as.list()] to ensure proper
+#'   dispatch.
+#'
 #' Use `qq_show()` to experiment with quasiquotation or debug the
 #' effect of unquoting operators. `qq_show()` quotes its input,
 #' processes unquoted parts, and prints the result with

--- a/man/fn_body.Rd
+++ b/man/fn_body.Rd
@@ -16,6 +16,17 @@ supplied.}
 \item{value}{New formals or formals names for \code{fn}.}
 }
 \description{
-\code{fn_body()} is a simple wrapper around \code{base::body()}. The setter
+\code{fn_body()} is a simple wrapper around \code{\link[base:body]{base::body()}}. It always
+returns a \code{\{} expression and throws an error when the input is a
+primitive function (whereas \code{body()} returns \code{NULL}). The setter
 version preserves attributes, unlike \code{body<-}.
+}
+\examples{
+# fn_body() is like body() but always returns a block:
+fn <- function() do()
+body(fn)
+fn_body(fn)
+
+# It also throws an error when used on a primitive function:
+try(fn_body(base::list))
 }

--- a/man/quasiquotation.Rd
+++ b/man/quasiquotation.Rd
@@ -44,6 +44,10 @@ argument should represent a list or a vector. Each element will
 be embedded in the surrounding call, i.e. each element is
 inserted as an argument. If the vector is named, the names are
 used as argument names.
+
+If the vector is a classed object (like a factor), it is
+converted to a list with \code{\link[base:as.list]{base::as.list()}} to ensure proper
+dispatch.
 }
 
 Use \code{qq_show()} to experiment with quasiquotation or debug the

--- a/man/quasiquotation.Rd
+++ b/man/quasiquotation.Rd
@@ -47,7 +47,8 @@ used as argument names.
 
 If the vector is a classed object (like a factor), it is
 converted to a list with \code{\link[base:as.list]{base::as.list()}} to ensure proper
-dispatch.
+dispatch. If it is an S4 objects, it is converted to a list with
+\code{\link[methods:as]{methods::as()}}.
 }
 
 Use \code{qq_show()} to experiment with quasiquotation or debug the

--- a/man/splice.Rd
+++ b/man/splice.Rd
@@ -19,9 +19,7 @@ dots_splice(..., .ignore_empty = c("trailing", "none", "all"),
 \arguments{
 \item{x}{A list to splice.}
 
-\item{...}{Arguments with explicit (\code{dots_list()}) or list
-(\code{dots_splice()}) splicing semantics. The contents of spliced
-arguments are embedded in the returned list.}
+\item{...}{Arguments to collect with \code{!!!} support.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/man/tidy-dots.Rd
+++ b/man/tidy-dots.Rd
@@ -12,9 +12,7 @@ dots_list(..., .ignore_empty = c("trailing", "none", "all"),
 list2(...)
 }
 \arguments{
-\item{...}{Arguments with explicit (\code{dots_list()}) or list
-(\code{dots_splice()}) splicing semantics. The contents of spliced
-arguments are embedded in the returned list.}
+\item{...}{Arguments to collect with \code{!!!} support.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -128,8 +128,8 @@ static sexp* dots_value_big_bang_coerce(sexp* x) {
   }
 }
 
-static sexp* dots_big_bang_coerce(sexp* expr) {
-  switch (r_typeof(expr)) {
+static sexp* dots_big_bang_coerce(sexp* x) {
+  switch (r_typeof(x)) {
   case r_type_null:
   case r_type_pairlist:
   case r_type_logical:
@@ -138,16 +138,30 @@ static sexp* dots_big_bang_coerce(sexp* expr) {
   case r_type_complex:
   case r_type_character:
   case r_type_raw:
-    return r_vec_coerce(expr, r_type_list);
-  case r_type_list:
-    return r_duplicate(expr, true);
-  case r_type_call:
-    if (r_is_symbol(r_node_car(expr), "{")) {
-      return r_vec_coerce(r_node_cdr(expr), r_type_list);
+    if (r_is_object(x)) {
+      return eval_with_x(as_list_call, x);
+    } else {
+      return r_vec_coerce(x, r_type_list);
     }
-    // else fallthrough
+  case r_type_list:
+    if (r_is_object(x)) {
+      return eval_with_x(as_list_call, x);
+    } else {
+      return r_duplicate(x, true);
+    }
+  case r_type_call:
+    if (r_is_symbol(r_node_car(x), "{")) {
+      return r_vec_coerce(r_node_cdr(x), r_type_list);
+    } else {
+      return r_new_list(x, NULL);
+    }
+  case r_type_symbol:
+    return r_new_list(x, NULL);
   default:
-    return r_new_list(expr, NULL);
+    r_abort(
+      "Can't splice an object of type `%s` because it is not a vector",
+      r_type_as_c_string(r_typeof(x))
+    );
   }
 }
 

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -271,18 +271,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
       break;
     case OP_EXPR_UQS:
       capture_info->needs_expansion = true;
-      expr = KEEP(dots_big_bang(capture_info, info.operand, env, false));
-
-      // Work around bug in dplyr 0.7.4
-      int n = r_length(expr);
-      for (int i = 0; i < n; ++i) {
-        sexp* elt = r_list_get(expr, i);
-        if (rlang_is_quosure(elt)) {
-          r_list_poke(expr, i, rlang_quo_get_expr(elt));
-        }
-      }
-
-      FREE(1);
+      expr = dots_big_bang(capture_info, info.operand, env, false);
       break;
     case OP_QUO_NONE:
     case OP_QUO_UQ:

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -152,11 +152,22 @@ static sexp* dots_big_bang_coerce(sexp* x) {
   case r_type_call:
     if (r_is_symbol(r_node_car(x), "{")) {
       return r_vec_coerce(r_node_cdr(x), r_type_list);
-    } else {
-      return r_new_list(x, NULL);
     }
-  case r_type_symbol:
+    // else fallthrough
+  case r_type_symbol: {
+    const char* msg =
+      "Unquoting language objects with `!!!` is soft-deprecated as of rlang 0.3.0.\n"
+      "Please use `!!` instead.\n"
+      "\n"
+      "  # Bad:\n"
+      "  dplyr::select(data, !!!enquo(x))\n"
+      "\n"
+      "  # Good:\n"
+      "  dplyr::select(data, !!enquo(x))    # Unquote single quosure\n"
+      "  dplyr::select(data, !!!enquos(x))  # Splice list of quosures\n";
+      r_signal_soft_deprecated(msg, msg, "rlang", r_empty_env);
     return r_new_list(x, NULL);
+  }
   default:
     r_abort(
       "Can't splice an object of type `%s` because it is not a vector",

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -3,8 +3,6 @@
 #include "expr-interp.h"
 #include "utils.h"
 
-sexp* eval_with_x(sexp* call, sexp* x);
-sexp* eval_with_xy(sexp* call, sexp* x, sexp* y);
 sexp* rlang_ns_get(const char* name);
 
 
@@ -110,13 +108,13 @@ static sexp* dots_value_big_bang_coerce(sexp* x) {
   case r_type_character:
   case r_type_raw:
     if (r_is_object(x)) {
-      return eval_with_x(as_list_call, x);
+      return r_eval_with_x(as_list_call, r_base_env, x);
     } else {
       return r_vec_coerce(x, r_type_list);
     }
   case r_type_list:
     if (r_is_object(x)) {
-      return eval_with_x(as_list_call, x);
+      return r_eval_with_x(as_list_call, r_base_env, x);
     } else {
       return x;
     }
@@ -139,13 +137,13 @@ static sexp* dots_big_bang_coerce(sexp* x) {
   case r_type_character:
   case r_type_raw:
     if (r_is_object(x)) {
-      return eval_with_x(as_list_call, x);
+      return r_eval_with_x(as_list_call, r_base_env, x);
     } else {
       return r_vec_coerce(x, r_type_list);
     }
   case r_type_list:
     if (r_is_object(x)) {
-      return eval_with_x(as_list_call, x);
+      return r_eval_with_x(as_list_call, r_base_env, x);
     } else {
       return r_duplicate(x, true);
     }
@@ -418,7 +416,7 @@ static sexp* maybe_auto_name(sexp* x, sexp* named) {
 
   if (names_width && (!names || r_chr_has(names, ""))) {
     sexp* width = KEEP(r_int(names_width));
-    x = eval_with_xy(auto_name_call, x, width);
+    x = r_eval_with_xy(auto_name_call, r_base_env, x, width);
     FREE(1);
   }
 
@@ -678,7 +676,6 @@ void rlang_init_dots() {
   as_list_call = r_parse("as.list(x)");
   r_mark_precious(as_list_call);
 
-  auto_name_call = r_parse_eval("as.call(list(rlang:::quos_auto_name, quote(x), quote(y)))",
-                                r_base_env);
+  auto_name_call = r_parse("rlang:::quos_auto_name(x, y)");
   r_mark_precious(auto_name_call);
 }

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -131,6 +131,8 @@ static sexp* dots_big_bang_coerce(sexp* x) {
     } else {
       return r_duplicate(x, true);
     }
+  case r_type_s4:
+    return r_eval_with_x(as_list_s4_call, r_methods_ns_env, x);
   case r_type_call:
     if (r_is_symbol(r_node_car(x), "{")) {
       return r_vec_coerce(r_node_cdr(x), r_type_list);

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -271,7 +271,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
       break;
     case OP_EXPR_UQS:
       capture_info->needs_expansion = true;
-      expr = dots_big_bang(capture_info, info.operand, env, false);
+      expr = KEEP(dots_big_bang(capture_info, info.operand, env, false));
 
       // Work around bug in dplyr 0.7.4
       int n = r_length(expr);
@@ -282,6 +282,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
         }
       }
 
+      FREE(1);
       break;
     case OP_QUO_NONE:
     case OP_QUO_UQ:

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -281,6 +281,12 @@ static sexp* deep_big_bang_coerce(sexp* x) {
     FREE(n_protect);
     return x;
   }
+  case r_type_s4: {
+    x = KEEP(r_eval_with_x(as_list_s4_call, r_methods_ns_env, x));
+    x = r_vec_coerce(x, r_type_pairlist);
+    FREE(1);
+    return x;
+  }
   case r_type_call:
     if (r_is_symbol(r_node_car(x), "{")) {
       return r_node_cdr(x);

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -260,7 +260,7 @@ static sexp* bang_bang_expression(struct expansion_info info, sexp* env) {
 void signal_retired_splice();
 
 // Maintain parity with dots_big_bang_coerce() in dots.c
-sexp* deep_big_bang_coerce(sexp* x) {
+static sexp* deep_big_bang_coerce(sexp* x) {
   switch (r_typeof(x)) {
   case r_type_null:
     return x;

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -3,6 +3,7 @@
 
 
 sexp* as_list_call = NULL;
+sexp* as_list_s4_call = NULL;
 
 void rlang_init_dots();
 void rlang_init_eval_tidy();
@@ -13,6 +14,9 @@ void rlang_init_internal() {
 
   as_list_call = r_parse("as.list(x)");
   r_mark_precious(as_list_call);
+
+  as_list_s4_call = r_parse("as(x, 'list')");
+  r_mark_precious(as_list_s4_call);
 
   /* dots.c - enum dots_expansion_op */
   RLANG_ASSERT(OP_DOTS_MAX == DOTS_CAPTURE_TYPE_MAX * EXPANSION_OP_MAX);

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -9,9 +9,11 @@ sexp* rlang_constants_get(const char* name) {
 }
 
 
+void rlang_init_dots();
 void rlang_init_eval_tidy();
 
 void rlang_init_internal() {
+  rlang_init_dots();
   rlang_init_eval_tidy();
 
   /* dots.c - enum dots_expansion_op */

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -2,13 +2,6 @@
 #include "internal.h"
 
 
-sexp* rlang_constants_env;
-
-sexp* rlang_constants_get(const char* name) {
-  return r_env_get(rlang_constants_env, r_sym(name));
-}
-
-
 void rlang_init_dots();
 void rlang_init_eval_tidy();
 

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -2,12 +2,17 @@
 #include "internal.h"
 
 
+sexp* as_list_call = NULL;
+
 void rlang_init_dots();
 void rlang_init_eval_tidy();
 
 void rlang_init_internal() {
   rlang_init_dots();
   rlang_init_eval_tidy();
+
+  as_list_call = r_parse("as.list(x)");
+  r_mark_precious(as_list_call);
 
   /* dots.c - enum dots_expansion_op */
   RLANG_ASSERT(OP_DOTS_MAX == DOTS_CAPTURE_TYPE_MAX * EXPANSION_OP_MAX);

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -4,10 +4,8 @@
 #include "quo.h"
 
 
-sexp* rlang_constants_env;
 void rlang_init_internal();
 sexp* rlang_ns_get(const char* name);
-sexp* rlang_constants_get(const char* name);
 
 
 #endif

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -4,6 +4,8 @@
 #include "quo.h"
 
 
+extern sexp* as_list_call;
+
 void rlang_init_internal();
 sexp* rlang_ns_get(const char* name);
 

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -5,6 +5,7 @@
 
 
 extern sexp* as_list_call;
+extern sexp* as_list_s4_call;
 
 void rlang_init_internal();
 sexp* rlang_ns_get(const char* name);

--- a/src/lib/env.c
+++ b/src/lib/env.c
@@ -148,6 +148,8 @@ void r_init_rlang_ns_env() {
   rlang_ns_env = r_ns_env("rlang");
 }
 
+sexp* r_methods_ns_env = NULL;
+
 void r_init_library_env() {
   new_env_call = r_parse_eval("as.call(list(new.env, TRUE, NULL, NULL))", r_base_env);
   r_mark_precious(new_env_call);
@@ -163,4 +165,6 @@ void r_init_library_env() {
 
   remove_call = r_parse("remove(list = y, envir = x, inherits = z)");
   r_mark_precious(remove_call);
+
+  r_methods_ns_env = r_parse_eval("asNamespace('methods')", r_base_env);
 }

--- a/src/lib/env.h
+++ b/src/lib/env.h
@@ -9,6 +9,9 @@
 #define r_base_env R_BaseEnv
 #define r_empty_env R_EmptyEnv
 
+extern sexp* r_methods_ns_env;
+
+
 #if (!defined(R_VERSION) || R_VERSION < R_Version(3, 2, 0))
 static inline sexp* r_env_names(sexp* env) {
   return R_lsInternal(env, true);

--- a/tests/testthat/helper-cnd.R
+++ b/tests/testthat/helper-cnd.R
@@ -108,3 +108,7 @@ skip_silently <- function(reason, env = caller_env()) {
   expect_true(TRUE)
   return_from(env)
 }
+
+scoped_silent_retirement <- function(env = caller_env()) {
+  scoped_options(lifecycle_disable_verbose_retirement = TRUE, .frame = env)
+}

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -197,3 +197,30 @@ test_that("dots collectors never warn for <- when option is set", {
   expect_no_warning(myquos(a <- 1))
 })
 
+test_that("list2() !!! fails with non-vectors", {
+  expect_error_(list2(!!!env()), "not a vector")
+  expect_error_(list2(!!!function() NULL), "not a vector")
+  expect_error_(list2(!!!base::c), "not a vector")
+  expect_error_(list2(!!!base::`{`), "not a vector")
+  expect_error_(list2(!!!~foo), "not a vector")
+  expect_error_(list2(!!!quote(foo(bar))), "not a vector")
+  expect_error_(list2(!!!expression()), "not a vector")
+})
+
+test_that("list2() succeeds with vectors and pairlists", {
+  expect_identical_(list2(!!!NULL), list())
+  expect_identical_(list2(!!!pairlist(1)), list(1))
+  expect_identical_(list2(!!!list(1)), list(1))
+  expect_identical_(list2(!!!TRUE), list(TRUE))
+  expect_identical_(list2(!!!1L), list(1L))
+  expect_identical_(list2(!!!1), list(1))
+  expect_identical_(list2(!!!1i), list(1i))
+  expect_identical_(list2(!!!"foo"), list("foo"))
+  expect_identical_(list2(!!!bytes(0)), list(bytes(0)))
+})
+
+test_that("list2() calls as.list()", {
+  expect_identical_(list2(!!!mtcars), as.list(mtcars))
+  fct <- factor(c("a", "b"))
+  expect_identical_(list2(!!!fct), as.list(fct))
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -196,31 +196,3 @@ test_that("dots collectors never warn for <- when option is set", {
   expect_no_warning(myexprs(a <- 1))
   expect_no_warning(myquos(a <- 1))
 })
-
-test_that("list2() !!! fails with non-vectors", {
-  expect_error_(list2(!!!env()), "not a vector")
-  expect_error_(list2(!!!function() NULL), "not a vector")
-  expect_error_(list2(!!!base::c), "not a vector")
-  expect_error_(list2(!!!base::`{`), "not a vector")
-  expect_error_(list2(!!!~foo), "not a vector")
-  expect_error_(list2(!!!quote(foo(bar))), "not a vector")
-  expect_error_(list2(!!!expression()), "not a vector")
-})
-
-test_that("list2() succeeds with vectors and pairlists", {
-  expect_identical_(list2(!!!NULL), list())
-  expect_identical_(list2(!!!pairlist(1)), list(1))
-  expect_identical_(list2(!!!list(1)), list(1))
-  expect_identical_(list2(!!!TRUE), list(TRUE))
-  expect_identical_(list2(!!!1L), list(1L))
-  expect_identical_(list2(!!!1), list(1))
-  expect_identical_(list2(!!!1i), list(1i))
-  expect_identical_(list2(!!!"foo"), list("foo"))
-  expect_identical_(list2(!!!bytes(0)), list(bytes(0)))
-})
-
-test_that("list2() calls as.list()", {
-  expect_identical_(list2(!!!mtcars), as.list(mtcars))
-  fct <- factor(c("a", "b"))
-  expect_identical_(list2(!!!fct), as.list(fct))
-})

--- a/tests/testthat/test-fn.R
+++ b/tests/testthat/test-fn.R
@@ -152,7 +152,8 @@ test_that("print method for `fn` discards attributes", {
 
 test_that("fn_body() requires a closure to extract body", {
   expect_error(fn_body(c), "`fn` is not a closure")
-  expect_null(fn_body(function() NULL))
+  expect_equal(fn_body(function() { NULL }), quote({ NULL }))
+  expect_equal(fn_body(function() NULL), quote({ NULL }))
 })
 
 test_that("fn_env() requires a function to extract env", {
@@ -187,4 +188,8 @@ test_that("as_function() supports nested quosures", {
 
   fn <- as_function(quo)
   expect_identical(fn(), "quux hunoz")
+})
+
+test_that("fn_body() always returns a `{` block", {
+  expect_equal(fn_body(function() "foo"), quote({ "foo" }))
 })

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -267,6 +267,12 @@ test_that("`!!!` doesn't modify spliced inputs by reference", {
   expect_equal(x, quote({ 1L; 2L; 3L }))  # equal because of srcrefs
 })
 
+test_that("exprs() preserves spliced quosures", {
+  out <- exprs(!!!quos(a, b))
+  expect_identical(out, exprs(!!quo(a), !!quo(b)))
+  expect_identical(out, named_list(quo(a), quo(b)))
+})
+
 
 # bang ---------------------------------------------------------------
 

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -268,7 +268,7 @@ test_that("exprs() preserves spliced quosures", {
   expect_identical(out, named_list(quo(a), quo(b)))
 })
 
-test_that("quoting-!!! fails with non-vectors", {
+test_that("!!! fails with non-vectors", {
   expect_error_(exprs(!!!env()), "not a vector")
   expect_error_(exprs(!!!function() NULL), "not a vector")
   expect_error_(exprs(!!!base::c), "not a vector")
@@ -286,9 +286,15 @@ test_that("quoting-!!! fails with non-vectors", {
   expect_error_(expr(list(!!!base::c)), "not a vector")
   expect_error_(expr(list(!!!base::`{`)), "not a vector")
   expect_error_(expr(list(!!!expression())), "not a vector")
+
+  expect_error_(list2(!!!env()), "not a vector")
+  expect_error_(list2(!!!function() NULL), "not a vector")
+  expect_error_(list2(!!!base::c), "not a vector")
+  expect_error_(list2(!!!base::`{`), "not a vector")
+  expect_error_(list2(!!!expression()), "not a vector")
 })
 
-test_that("quoting-!!! succeed with vectors, pairlists and language objects", {
+test_that("!!! succeeds with vectors, pairlists and language objects", {
   expect_identical_(exprs(!!!NULL), named_list())
   expect_identical_(exprs(!!!pairlist(1)), named_list(1))
   expect_identical_(exprs(!!!list(1)), named_list(1))
@@ -318,9 +324,19 @@ test_that("quoting-!!! succeed with vectors, pairlists and language objects", {
   expect_identical_(expr(foo(!!!1i)), quote(foo(1i)))
   expect_identical_(expr(foo(!!!"foo")), quote(foo("foo")))
   expect_identical_(expr(foo(!!!bytes(0))), expr(foo(!!bytes(0))))
+
+  expect_identical_(list2(!!!NULL), list())
+  expect_identical_(list2(!!!pairlist(1)), list(1))
+  expect_identical_(list2(!!!list(1)), list(1))
+  expect_identical_(list2(!!!TRUE), list(TRUE))
+  expect_identical_(list2(!!!1L), list(1L))
+  expect_identical_(list2(!!!1), list(1))
+  expect_identical_(list2(!!!1i), list(1i))
+  expect_identical_(list2(!!!"foo"), list("foo"))
+  expect_identical_(list2(!!!bytes(0)), list(bytes(0)))
 })
 
-test_that("quoting-!!! call as.list()", {
+test_that("!!! calls as.list()", {
   as_quos_list <- function(x, env = empty_env()) {
     new_quosures(map(x, new_quosure, env = env))
   }
@@ -328,12 +344,14 @@ test_that("quoting-!!! call as.list()", {
   expect_identical_(exprs(!!!mtcars), exp)
   expect_identical_(quos(!!!mtcars), as_quos_list(exp))
   expect_identical_(expr(foo(!!!mtcars)), do.call(call, c(list("foo"), exp)))
+  expect_identical_(list2(!!!mtcars), as.list(mtcars))
 
   fct <- factor(c("a", "b"))
   exp <- set_names(as.list(fct), c("", ""))
   expect_identical_(exprs(!!!fct), exp)
   expect_identical_(quos(!!!fct), as_quos_list(exp))
   expect_identical_(expr(foo(!!!fct)), do.call(call, c(list("foo"), exp)))
+  expect_identical_(list2(!!!fct), as.list(fct))
 })
 
 
@@ -477,4 +495,10 @@ test_that("splicing language objects still works", {
 
   expect_identical_(quos(!!!~foo), quos_list(quo(!!~foo)))
   expect_identical_(quos(!!!quote(foo(bar))), quos_list(quo(foo(bar))))
+
+  expect_identical_(expr(foo(!!!~foo)), expr(foo(!!~foo)))
+  expect_identical_(expr(foo(!!!quote(foo(bar)))), expr(foo(foo(bar))))
+
+  expect_identical_(list2(!!!~foo), list(~foo))
+  expect_identical_(list2(!!!quote(foo(bar))), list(quote(foo(bar))))
 })

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -354,6 +354,22 @@ test_that("!!! calls as.list()", {
   expect_identical_(list2(!!!fct), as.list(fct))
 })
 
+test_that("!!! calls methods::as()", {
+  as_quos_list <- function(x, env = empty_env()) {
+    new_quosures(map(x, new_quosure, env = env))
+  }
+
+  .Person <- setClass("Person", slots = c(name = "character", species = "character"))
+  fievel <- .Person(name = "Fievel", species = "mouse")
+  methods::setAs("Person", "list", function(from, to) list(name = from@name, species = from@species))
+
+  exp <- list(name = "Fievel", species = "mouse")
+  expect_identical_(exprs(!!!fievel), exp)
+  expect_identical_(quos(!!!fievel), as_quos_list(exp))
+  expect_identical_(expr(foo(!!!fievel)), quote(foo(name = "Fievel", species = "mouse")))
+  expect_identical_(list2(!!!fievel), exp)
+})
+
 
 # bang ---------------------------------------------------------------
 

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -273,6 +273,60 @@ test_that("exprs() preserves spliced quosures", {
   expect_identical(out, named_list(quo(a), quo(b)))
 })
 
+test_that("exprs() and quos() !!! fails with non-vectors", {
+  expect_error_(exprs(!!!env()), "not a vector")
+  expect_error_(exprs(!!!function() NULL), "not a vector")
+  expect_error_(exprs(!!!base::c), "not a vector")
+  expect_error_(exprs(!!!base::`{`), "not a vector")
+  expect_error_(exprs(!!!expression()), "not a vector")
+
+  expect_error_(quos(!!!env()), "not a vector")
+  expect_error_(quos(!!!function() NULL), "not a vector")
+  expect_error_(quos(!!!base::c), "not a vector")
+  expect_error_(quos(!!!base::`{`), "not a vector")
+  expect_error_(quos(!!!expression()), "not a vector")
+})
+
+test_that("exprs() and quos() succeed with vectors, pairlists and language objects", {
+  expect_identical_(exprs(!!!NULL), named_list())
+  expect_identical_(exprs(!!!pairlist(1)), named_list(1))
+  expect_identical_(exprs(!!!list(1)), named_list(1))
+  expect_identical_(exprs(!!!TRUE), named_list(TRUE))
+  expect_identical_(exprs(!!!1L), named_list(1L))
+  expect_identical_(exprs(!!!1), named_list(1))
+  expect_identical_(exprs(!!!1i), named_list(1i))
+  expect_identical_(exprs(!!!"foo"), named_list("foo"))
+  expect_identical_(exprs(!!!bytes(0)), named_list(bytes(0)))
+  expect_identical_(exprs(!!!~foo), named_list(~foo))
+  expect_identical_(exprs(!!!quote(foo(bar))), named_list(quote(foo(bar))))
+
+  expect_identical_(quos(!!!NULL), quos_list())
+  expect_identical_(quos(!!!pairlist(1)), quos_list(quo(1)))
+  expect_identical_(quos(!!!list(1)), quos_list(quo(1)))
+  expect_identical_(quos(!!!TRUE), quos_list(quo(TRUE)))
+  expect_identical_(quos(!!!1L), quos_list(quo(1L)))
+  expect_identical_(quos(!!!1), quos_list(quo(1)))
+  expect_identical_(quos(!!!1i), quos_list(quo(1i)))
+  expect_identical_(quos(!!!"foo"), quos_list(quo("foo")))
+  expect_identical_(quos(!!!bytes(0)), quos_list(quo(!!bytes(0))))
+  expect_identical_(quos(!!!~foo), quos_list(quo(!!~foo)))
+  expect_identical_(quos(!!!quote(foo(bar))), quos_list(quo(foo(bar))))
+})
+
+test_that("exprs() and quos() call as.list()", {
+  as_quos_list <- function(x, env = empty_env()) {
+    new_quosures(map(x, new_quosure, env = env))
+  }
+  exp <- as.list(mtcars)
+  expect_identical_(exprs(!!!mtcars), exp)
+  expect_identical_(quos(!!!mtcars), as_quos_list(exp))
+
+  fct <- factor(c("a", "b"))
+  exp <- set_names(as.list(fct), c("", ""))
+  expect_identical_(exprs(!!!fct), exp)
+  expect_identical_(quos(!!!fct), as_quos_list(exp))
+})
+
 
 # bang ---------------------------------------------------------------
 

--- a/tests/testthat/test-quasiquotation.R
+++ b/tests/testthat/test-quasiquotation.R
@@ -297,8 +297,6 @@ test_that("exprs() and quos() succeed with vectors, pairlists and language objec
   expect_identical_(exprs(!!!1i), named_list(1i))
   expect_identical_(exprs(!!!"foo"), named_list("foo"))
   expect_identical_(exprs(!!!bytes(0)), named_list(bytes(0)))
-  expect_identical_(exprs(!!!~foo), named_list(~foo))
-  expect_identical_(exprs(!!!quote(foo(bar))), named_list(quote(foo(bar))))
 
   expect_identical_(quos(!!!NULL), quos_list())
   expect_identical_(quos(!!!pairlist(1)), quos_list(quo(1)))
@@ -309,8 +307,6 @@ test_that("exprs() and quos() succeed with vectors, pairlists and language objec
   expect_identical_(quos(!!!1i), quos_list(quo(1i)))
   expect_identical_(quos(!!!"foo"), quos_list(quo("foo")))
   expect_identical_(quos(!!!bytes(0)), quos_list(quo(!!bytes(0))))
-  expect_identical_(quos(!!!~foo), quos_list(quo(!!~foo)))
-  expect_identical_(quos(!!!quote(foo(bar))), quos_list(quo(foo(bar))))
 })
 
 test_that("exprs() and quos() call as.list()", {
@@ -458,4 +454,14 @@ test_that("unquoting with rlang namespace is deprecated", {
 test_that("UQE() is defunct", {
   expect_error_(expr(foo$UQE(NULL)), "defunct")
   expect_error_(UQE(), "defunct")
+})
+
+test_that("splicing language objects still works", {
+  scoped_silent_retirement()
+
+  expect_identical_(exprs(!!!~foo), named_list(~foo))
+  expect_identical_(exprs(!!!quote(foo(bar))), named_list(quote(foo(bar))))
+
+  expect_identical_(quos(!!!~foo), quos_list(quo(!!~foo)))
+  expect_identical_(quos(!!!quote(foo(bar))), quos_list(quo(foo(bar))))
 })


### PR DESCRIPTION
Closes #572

Changes for `list2()`:

* Accept pairlists
* Fail with language objects
* Call `base::as.list()` for classed vector objects

Changes for `exprs()` and `quos()`:

* Non-vector non-language objects like environments and functions now fail. Before they were automatically wrapped in a list to allow splicing.

* Call `base::as.list()` for classed vector objects.

* Soft-deprecate splicing of language objects, including scalar quosures. This makes this kind of code throw an error: https://github.com/tidyverse/tidyr/commit/82ef03af587b5ad57e6edf185a0ca5af8c969d4b#diff-65e6a5a29a28bb3768b7a3c192f952f1R147.

    ```r
    #> Warning message:
    #> Unquoting language objects with `!!!` is soft-deprecated as of rlang 0.3.0.
    #> Please use `!!` instead.
    #>
    #>   # Bad:
    #>   dplyr::select(data, !!!enquo(x))
    #>
    #>   # Good:
    #>   dplyr::select(data, !!enquo(x))    # Unquote single quosure
    #>   dplyr::select(data, !!!enquos(x))  # Splice list of quosures
    #>
    #> This warning is displayed once per session.
    ```

    The soft-deprecation won't be very verbose because there's no reliable way of detecting the caller env, so the warning only occurs when rlang is attached. However we can't deprecate right away because of the tidyr bug (dplyr and tidyselect are fine).

With these changes, and once splicing scalar language objects is defunct, the semantics of `!!!` for `list2()` and `exprs()`/`quos()` will be very similar. I think it'd be a good idea to make them identical. This involves supporting quoted `{` calls in `list2()`:

```r
list2(!!!quote({ foo; bar; }))
#> [[1]]
#> foo
#>
#> [[2]]
#> bar
```

Should we make this change?