### PR TITLE
Use quo_name() to create default names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # rlang 0.2.2.9000
 
+* Automatic naming of expressions now uses `quo_name()` instead of
+  `quo_text()`. This makes it compatible with all object types,
+  prevents multi-line names, and ensures `name` and `.data[["name"]]`
+  are given the same default name.
+
 * `quo_name()` now uses `pillar::type_sum()` to create default names
   for constant objects.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang 0.2.2.9000
 
+* `quo_name()` now uses `pillar::type_sum()` to create default names
+  for constant objects.
+
 * `.data[[foo]]` is now an unquote operator. This guarantees that
   `foo` is evaluated in the context rather than the data mask and
   makes it easier to treat `.data[["bar"]]` the same way as a

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -425,3 +425,27 @@ unclass_data_pronoun <- function(x) {
   class(x) <- class(x)[-i]
   x
 }
+
+is_data_pronoun <- function(x) {
+  is_call(x, c("[[", "$")) && identical(node_cadr(x), dot_data_sym)
+}
+
+data_pronoun_name <- function(x) {
+  if (is_call(x, "$")) {
+    arg <- node_cadr(node_cdr(x))
+    if (is_symbol(arg)) {
+      return(as_string(arg))
+    } else {
+      return(NULL)
+    }
+  }
+
+  if (is_call(x, "[[")) {
+    arg <- node_cadr(node_cdr(x))
+    if (is_string(arg)) {
+      return(arg)
+    } else {
+      return(NULL)
+    }
+  }
+}

--- a/R/expr.R
+++ b/R/expr.R
@@ -158,9 +158,13 @@ expr_name <- function(expr) {
     NULL = "NULL",
     symbol = as_string(expr),
     language = {
-      name <- deparse_one(expr)
-      name <- gsub("\n.*$", "...", name)
-      name
+      if (is_data_pronoun(expr)) {
+        data_pronoun_name(expr) %||% "<unknown>"
+      } else {
+        name <- deparse_one(expr)
+        name <- gsub("\n.*$", "...", name)
+        name
+      }
     },
     if (is_scalar_atomic(expr)) {
       # So 1L is translated to "1" and not "1L"

--- a/R/expr.R
+++ b/R/expr.R
@@ -174,7 +174,7 @@ expr_name <- function(expr) {
       name <- gsub("\n.*$", "...", name)
       name
     } else {
-      abort("`expr` must quote a symbol, scalar, or call")
+      paste0("<", rlang_type_sum(expr), ">")
     }
   )
 }

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -171,6 +171,12 @@ upcase1 <- function(x) {
 #' * `scoped_env()` => [search_env()]
 #' * `scoped_envs()` => [search_envs()]
 #'
+#' * The `width` argument of [exprs_auto_name()] and
+#'   [quos_auto_name()] no longer has any effect because [quo_name()]
+#'   is used for deparsing instead of [quo_text()]. For the same
+#'   reason, passing a width as `.named` argument of dots collectors
+#'   like `quos()` is soft-deprecated.
+#'
 #'
 #' **Soft-deprecated as of rlang 0.2.0:**
 #'

--- a/R/quotation.R
+++ b/R/quotation.R
@@ -116,10 +116,8 @@
 #'   `exprs()` and `quos()`, the expressions to capture unevaluated
 #'   (including expressions contained in `...`).
 #' @param .named Whether to ensure all dots are named. Unnamed
-#'   elements are processed with [expr_text()] to figure out a default
-#'   name. If an integer, it is passed to the `width` argument of
-#'   `expr_text()`, if `TRUE`, the default width is used. See
-#'   [exprs_auto_name()].
+#'   elements are processed with [quo_name()] to build a default
+#'   name. See also [quos_auto_name()].
 #' @param .unquote_names Whether to treat `:=` as `=`. Unlike `=`, the
 #'   `:=` syntax supports `!!` unquoting on the LHS.
 #' @name quotation
@@ -372,20 +370,25 @@ endots <- function(call,
 #' This gives default names to unnamed elements of a list of
 #' expressions (or expression wrappers such as formulas or
 #' quosures). `exprs_auto_name()` deparses the expressions with
-#' [expr_text()] by default. `quos_auto_name()` deparses with
-#' [quo_text()].
+#' [expr_name()] by default. `quos_auto_name()` deparses with
+#' [quo_name()].
 #'
 #' @param exprs A list of expressions.
-#' @param width Maximum width of names.
+#' @param width Soft-deprecated. Maximum width of names.
 #' @param printer A function that takes an expression and converts it
 #'   to a string. This function must take an expression as the first
 #'   argument and `width` as the second argument.
 #' @export
-exprs_auto_name <- function(exprs, width = 60L, printer = expr_text) {
+exprs_auto_name <- function(exprs, width = NULL, printer = expr_name) {
+  if (!is_null(width)) {
+    signal_soft_deprecated(env = empty_env(), paste_line(
+      "The `width` argument is soft-deprecated as of rlang 0.3.0."
+    ))
+  }
   have_name <- have_name(exprs)
 
   if (any(!have_name)) {
-    nms <- map_chr(exprs[!have_name], printer, width = width)
+    nms <- map_chr(exprs[!have_name], printer)
     names(exprs)[!have_name] <- nms
   }
 
@@ -394,6 +397,6 @@ exprs_auto_name <- function(exprs, width = 60L, printer = expr_text) {
 #' @rdname exprs_auto_name
 #' @param quos A list of quosures.
 #' @export
-quos_auto_name <- function(quos, width = 60L) {
-  exprs_auto_name(quos, width = width, printer = quo_text)
+quos_auto_name <- function(quos, width = NULL) {
+  exprs_auto_name(quos, width = width, printer = quo_name)
 }

--- a/R/sym.R
+++ b/R/sym.R
@@ -52,6 +52,7 @@ is_symbol <- function(x, name = NULL) {
 namespace_sym <- quote(`::`)
 namespace2_sym <- quote(`:::`)
 dollar_sym <- quote(`$`)
+dot_data_sym <- quote(.data)
 at_sym <- quote(`@`)
 tilde_sym <- quote(`~`)
 colon_equals_sym <- quote(`:=`)

--- a/man/dots_definitions.Rd
+++ b/man/dots_definitions.Rd
@@ -14,10 +14,8 @@ arguments to capture without evaluation (including \code{...}). For
 (including expressions contained in \code{...}).}
 
 \item{.named}{Whether to ensure all dots are named. Unnamed
-elements are processed with \code{\link[=expr_text]{expr_text()}} to figure out a default
-name. If an integer, it is passed to the \code{width} argument of
-\code{expr_text()}, if \code{TRUE}, the default width is used. See
-\code{\link[=exprs_auto_name]{exprs_auto_name()}}.}
+elements are processed with \code{\link[=quo_name]{quo_name()}} to build a default
+name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/man/exprs_auto_name.Rd
+++ b/man/exprs_auto_name.Rd
@@ -5,14 +5,14 @@
 \alias{quos_auto_name}
 \title{Ensure that all elements of a list of expressions are named}
 \usage{
-exprs_auto_name(exprs, width = 60L, printer = expr_text)
+exprs_auto_name(exprs, width = NULL, printer = expr_name)
 
-quos_auto_name(quos, width = 60L)
+quos_auto_name(quos, width = NULL)
 }
 \arguments{
 \item{exprs}{A list of expressions.}
 
-\item{width}{Maximum width of names.}
+\item{width}{Soft-deprecated. Maximum width of names.}
 
 \item{printer}{A function that takes an expression and converts it
 to a string. This function must take an expression as the first
@@ -24,6 +24,6 @@ argument and \code{width} as the second argument.}
 This gives default names to unnamed elements of a list of
 expressions (or expression wrappers such as formulas or
 quosures). \code{exprs_auto_name()} deparses the expressions with
-\code{\link[=expr_text]{expr_text()}} by default. \code{quos_auto_name()} deparses with
-\code{\link[=quo_text]{quo_text()}}.
+\code{\link[=expr_name]{expr_name()}} by default. \code{quos_auto_name()} deparses with
+\code{\link[=quo_name]{quo_name()}}.
 }

--- a/man/lifecycle.Rd
+++ b/man/lifecycle.Rd
@@ -115,6 +115,11 @@ separately before calling these functions.
 \item \code{is_scoped()} => \code{\link[=is_attached]{is_attached()}}
 \item \code{scoped_env()} => \code{\link[=search_env]{search_env()}}
 \item \code{scoped_envs()} => \code{\link[=search_envs]{search_envs()}}
+\item The \code{width} argument of \code{\link[=exprs_auto_name]{exprs_auto_name()}} and
+\code{\link[=quos_auto_name]{quos_auto_name()}} no longer has any effect because \code{\link[=quo_name]{quo_name()}}
+is used for deparsing instead of \code{\link[=quo_text]{quo_text()}}. For the same
+reason, passing a width as \code{.named} argument of dots collectors
+like \code{quos()} is soft-deprecated.
 }
 
 \strong{Soft-deprecated as of rlang 0.2.0:}

--- a/man/quotation.Rd
+++ b/man/quotation.Rd
@@ -52,10 +52,8 @@ arguments to capture without evaluation (including \code{...}). For
 (including expressions contained in \code{...}).}
 
 \item{.named}{Whether to ensure all dots are named. Unnamed
-elements are processed with \code{\link[=expr_text]{expr_text()}} to figure out a default
-name. If an integer, it is passed to the \code{width} argument of
-\code{expr_text()}, if \code{TRUE}, the default width is used. See
-\code{\link[=exprs_auto_name]{exprs_auto_name()}}.}
+elements are processed with \code{\link[=quo_name]{quo_name()}} to build a default
+name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -353,3 +353,8 @@ test_that("expr_deparse() handles ANSI escapes in strings", {
   expect_identical(expr_deparse("\\v"), deparse("\\v"))
   expect_identical(expr_deparse("\\0"), deparse("\\0"))
 })
+
+test_that("expr_name() handles .data pronoun", {
+  expect_identical(expr_name(quote(.data[["bar"]])), "bar")
+  expect_identical(quo_name(quo(.data[["bar"]])), "bar")
+})

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -305,6 +305,27 @@ test_that("data mask inherits from last environment", {
   expect_reference(env_parent(mask), env)
 })
 
+test_that("is_data_pronoun() detects pronouns", {
+  expect_true(!!is_data_pronoun(quote(.data$foo)))
+  expect_true(!!is_data_pronoun(quote(.data[[foo]])))
+  expect_false(!!is_data_pronoun(quote(.data[foo])))
+  expect_false(!!is_data_pronoun(quote(data[[foo]])))
+})
+
+test_that("data_pronoun_name() extracts name", {
+  expr <- quote(.data[[foo]])
+  expect_null(data_pronoun_name(expr))
+
+  expr <- quote(.data[[toupper("foo")]])
+  expect_null(data_pronoun_name(expr))
+
+  expr <- quote(`$`(.data, toupper("foo")))
+  expect_null(data_pronoun_name(expr))
+
+  expect_identical(data_pronoun_name(quote(.data[["foo"]])), "foo")
+  expect_identical(data_pronoun_name(quote(.data$foo)), "foo")
+})
+
 
 # Lifecycle ----------------------------------------------------------
 

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -47,14 +47,15 @@ test_that("expr_label() truncates long calls", {
 
 # expr_name() --------------------------------------------------------
 
-test_that("name symbols, calls, and scalars", {
+test_that("name symbols, calls, and literals", {
   expect_identical(expr_name(quote(foo)), "foo")
   expect_identical(expr_name(quote(foo(bar))), "foo(bar)")
   expect_identical(expr_name(1L), "1")
   expect_identical(expr_name("foo"), "foo")
   expect_identical(expr_name(function() NULL), "function () ...")
-  expect_error(expr_name(1:2), "must quote a symbol, scalar, or call")
   expect_identical(expr_name(expr(function() { a; b })), "function() ...")
+  expect_identical(expr_name(1:2), "<int>")
+  expect_identical(expr_name(env()), "<env>")
 })
 
 test_that("supports special objects", {

--- a/tests/testthat/test-quotation.R
+++ b/tests/testthat/test-quotation.R
@@ -452,5 +452,17 @@ test_that("missing names are forwarded", {
 })
 
 test_that("`.named` must be integerish", {
-  expect_error(exprs(foo, .named = 100.5), "scalar logical or number")
+  expect_error(exprs(foo, .named = 100.5), "must be a scalar logical")
+})
+
+test_that("auto-naming uses type_sum() (#573)", {
+  expect_named(quos(foo, !!(1:3), .named = TRUE), c("foo", "<int>"))
+
+  x <- list(env(), 1:3, letters)
+  expect_named(exprs_auto_name(x), c("<env>", "<int>", "<chr>"))
+})
+
+test_that("auto-naming supports the .data pronoun", {
+  exprs <- exprs(.data[[toupper("foo")]], .data$bar, .named = TRUE)
+  expect_named(exprs, c("FOO", "bar"))
 })


### PR DESCRIPTION
Includes #637.

- Use `quo_name()` instead of `quo_text()` to auto name quoted expressions as multi-line text does not make sense for names.

- Use `pillar::type_sum()` in `quo_name()`. Motivation for this change is given in #573.

- Handle `.data` pronouns in `quo_name()`. This way `group_by(df, name)` and `group_by(df, .data$name)` receive the same default name.

Closes #573.
Closes #468.