### PR TITLE
Add .homonyms argument to dots collectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # rlang 0.2.2.9000
 
+* `dots_list()`, `enexprs()` and `enquos()` gain a `.homonyms`
+  argument to control how to treat arguments with the same name.
+  The default is to keep them. Set it to `"first"` or `"last"` to keep
+  only the first or last occurrences. Set it to `"error"` to raise an
+  informative error about the arguments with duplicated names.
+
 * Automatic naming of expressions now uses `quo_name()` instead of
   `quo_text()`. This makes it compatible with all object types,
   prevents multi-line names, and ensures `name` and `.data[["name"]]`

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -50,7 +50,7 @@ pluck_cpl <- function(.x, .f) {
 }
 
 map2 <- function(.x, .y, .f, ...) {
-  mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
+  set_names(mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE), names(.x))
 }
 map2_lgl <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "logical")

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -50,7 +50,12 @@ pluck_cpl <- function(.x, .f) {
 }
 
 map2 <- function(.x, .y, .f, ...) {
-  set_names(mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE), names(.x))
+  out <- mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
+  if (length(out) == length(.x)) {
+    set_names(out, names(.x))
+  } else {
+    set_names(out, NULL)
+  }
 }
 map2_lgl <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "logical")

--- a/R/dots.R
+++ b/R/dots.R
@@ -48,6 +48,12 @@
 #'   were not ignored. If `TRUE`, empty arguments are stored with
 #'   [missing_arg()] values. If `FALSE` (the default) an error is
 #'   thrown when an empty argument is detected.
+#' @param .homonyms How to treat arguments with the same name. The
+#'   default, `"keep"`, preserves these arguments. Set `.homonyms` to
+#'   `"first"` to only keep the first occurrences, to `"last"` to keep
+#'   the last occurrences, and to `"error"` to raise an informative
+#'   error and indicate to the user what arguments have duplicated
+#'   names.
 #' @param .check_assign Whether to check for `<-` calls passed in
 #'   dots. When `TRUE` and a `<-` call is detected, a warning is
 #'   issued to advise users to use `=` if they meant to match a
@@ -107,6 +113,19 @@
 #'
 #' # The list with preserved empty arguments is equivalent to:
 #' list(missing_arg())
+#'
+#'
+#' # Arguments with duplicated names are kept by default:
+#' list2(a = 1, a = 2, b = 3, b = 4, 5, 6)
+#'
+#' # Use the `.homonyms` argument to keep only the first of these:
+#' dots_list(a = 1, a = 2, b = 3, b = 4, 5, 6, .homonyms = "first")
+#'
+#' # Or the last:
+#' dots_list(a = 1, a = 2, b = 3, b = 4, 5, 6, .homonyms = "last")
+#'
+#' # Or raise an informative error:
+#' try(dots_list(a = 1, a = 2, b = 3, b = 4, 5, 6, .homonyms = "error"))
 #'
 #'
 #' # dots_list() can be configured to warn when a `<-` call is

--- a/R/dots.R
+++ b/R/dots.R
@@ -120,6 +120,7 @@
 dots_list <- function(...,
                       .ignore_empty = c("trailing", "none", "all"),
                       .preserve_empty = FALSE,
+                      .homonyms = c("keep", "first", "last", "error"),
                       .check_assign = FALSE) {
   dots <- .Call(rlang_dots_list,
     frame_env = environment(),
@@ -127,6 +128,7 @@ dots_list <- function(...,
     ignore_empty = .ignore_empty,
     preserve_empty = .preserve_empty,
     unquote_names = TRUE,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
   names(dots) <- names2(dots)
@@ -137,6 +139,7 @@ dots_split <- function(...,
                        .n_unnamed = NULL,
                        .ignore_empty = c("trailing", "none", "all"),
                        .preserve_empty = FALSE,
+                       .homonyms = c("keep", "first", "last", "error"),
                        .check_assign = FALSE) {
   dots <- .Call(rlang_dots_list,
     frame_env = environment(),
@@ -144,6 +147,7 @@ dots_split <- function(...,
     ignore_empty = .ignore_empty,
     preserve_empty = .preserve_empty,
     unquote_names = TRUE,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
 
@@ -267,6 +271,7 @@ is_spliced_bare <- function(x) {
 dots_splice <- function(...,
                         .ignore_empty = c("trailing", "none", "all"),
                         .preserve_empty = FALSE,
+                        .homonyms = c("keep", "first", "last", "error"),
                         .check_assign = FALSE) {
   dots <- .Call(rlang_dots_flat_list,
     frame_env = environment(),
@@ -274,6 +279,7 @@ dots_splice <- function(...,
     ignore_empty = .ignore_empty,
     preserve_empty = .preserve_empty,
     unquote_names = TRUE,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
   names(dots) <- names2(dots)
@@ -302,6 +308,7 @@ dots_splice <- function(...,
 dots_values <- function(...,
                         .ignore_empty = c("trailing", "none", "all"),
                         .preserve_empty = FALSE,
+                        .homonyms = c("keep", "first", "last", "error"),
                         .check_assign = FALSE) {
   .Call(rlang_dots_values,
     frame_env = environment(),
@@ -309,6 +316,7 @@ dots_values <- function(...,
     ignore_empty = .ignore_empty,
     preserve_empty = .preserve_empty,
     unquote_names = TRUE,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
 }
@@ -331,6 +339,7 @@ dots_definitions <- function(...,
     named = .named,
     ignore_empty = .ignore_empty,
     unquote_names = FALSE,
+    homonyms = "keep",
     check_assign = FALSE
   )
 

--- a/R/quotation.R
+++ b/R/quotation.R
@@ -218,6 +218,7 @@ exprs <- function(...,
     named = .named,
     ignore_empty = .ignore_empty,
     unquote_names = .unquote_names,
+    homonyms = "keep",
     check_assign = FALSE
   )
 }
@@ -227,6 +228,7 @@ enexprs <- function(...,
                    .named = FALSE,
                    .ignore_empty = c("trailing", "none", "all"),
                    .unquote_names = TRUE,
+                   .homonyms = c("keep", "first", "last", "error"),
                    .check_assign = FALSE) {
   endots(
     call = sys.call(),
@@ -236,6 +238,7 @@ enexprs <- function(...,
     named = .named,
     ignore_empty = .ignore_empty,
     unquote_names = .unquote_names,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
 }
@@ -251,6 +254,7 @@ ensyms <- function(...,
                    .named = FALSE,
                    .ignore_empty = c("trailing", "none", "all"),
                    .unquote_names = TRUE,
+                   .homonyms = c("keep", "first", "last", "error"),
                    .check_assign = FALSE) {
   exprs <- endots(
     call = sys.call(),
@@ -260,6 +264,7 @@ ensyms <- function(...,
     named = .named,
     ignore_empty = .ignore_empty,
     unquote_names = .unquote_names,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
   if (!every(exprs, function(x) is_symbol(x) || is_string(x))) {
@@ -291,6 +296,7 @@ quos <- function(...,
     named = .named,
     ignore_empty = .ignore_empty,
     unquote_names = .unquote_names,
+    homonyms = "keep",
     check_assign = FALSE
   )
 }
@@ -300,6 +306,7 @@ enquos <- function(...,
                    .named = FALSE,
                    .ignore_empty = c("trailing", "none", "all"),
                    .unquote_names = TRUE,
+                   .homonyms = c("keep", "first", "last", "error"),
                    .check_assign = FALSE) {
   quos <- endots(
     call = sys.call(),
@@ -309,6 +316,7 @@ enquos <- function(...,
     named = .named,
     ignore_empty = .ignore_empty,
     unquote_names = .unquote_names,
+    homonyms = .homonyms,
     check_assign = .check_assign
   )
   structure(quos, class = "quosures")
@@ -324,6 +332,7 @@ endots <- function(call,
                    named,
                    ignore_empty,
                    unquote_names,
+                   homonyms,
                    check_assign) {
   syms <- as.list(node_cdr(call))
 
@@ -347,6 +356,7 @@ endots <- function(call,
         named = named,
         ignore_empty = ignore_empty,
         unquote_names = unquote_names,
+        homonyms = homonyms,
         check_assign = check_assign
       ))
     } else {

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -106,6 +106,7 @@ list2 <- function(...) {
     ignore_empty = "trailing",
     preserve_empty = FALSE,
     unquote_names = TRUE,
+    homonyms = "keep",
     check_assign = FALSE
   )
 }
@@ -122,6 +123,7 @@ list3 <- function(...) {
     ignore_empty = "trailing",
     preserve_empty = TRUE,
     unquote_names = TRUE,
+    homonyms = "keep",
     check_assign = FALSE
   )
 }

--- a/man/dots_values.Rd
+++ b/man/dots_values.Rd
@@ -5,7 +5,8 @@
 \title{Evaluate dots with preliminary splicing}
 \usage{
 dots_values(..., .ignore_empty = c("trailing", "none", "all"),
-  .preserve_empty = FALSE, .check_assign = FALSE)
+  .preserve_empty = FALSE, .homonyms = c("keep", "first", "last",
+  "error"), .check_assign = FALSE)
 }
 \arguments{
 \item{...}{Arguments to evaluate and process splicing operators.}
@@ -18,6 +19,13 @@ last argument is ignored if it is empty.}
 were not ignored. If \code{TRUE}, empty arguments are stored with
 \code{\link[=missing_arg]{missing_arg()}} values. If \code{FALSE} (the default) an error is
 thrown when an empty argument is detected.}
+
+\item{.homonyms}{How to treat arguments with the same name. The
+default, \code{"keep"}, preserves these arguments. Set \code{.homonyms} to
+\code{"first"} to only keep the first occurrences, to \code{"last"} to keep
+the last occurrences, and to \code{"error"} to raise an informative
+error and indicate to the user what arguments have duplicated
+names.}
 
 \item{.check_assign}{Whether to check for \code{<-} calls passed in
 dots. When \code{TRUE} and a \code{<-} call is detected, a warning is

--- a/man/quotation.Rd
+++ b/man/quotation.Rd
@@ -22,12 +22,14 @@ exprs(..., .named = FALSE, .ignore_empty = c("trailing", "none",
   "all"), .unquote_names = TRUE)
 
 enexprs(..., .named = FALSE, .ignore_empty = c("trailing", "none",
-  "all"), .unquote_names = TRUE, .check_assign = FALSE)
+  "all"), .unquote_names = TRUE, .homonyms = c("keep", "first", "last",
+  "error"), .check_assign = FALSE)
 
 ensym(arg)
 
 ensyms(..., .named = FALSE, .ignore_empty = c("trailing", "none",
-  "all"), .unquote_names = TRUE, .check_assign = FALSE)
+  "all"), .unquote_names = TRUE, .homonyms = c("keep", "first", "last",
+  "error"), .check_assign = FALSE)
 
 quo(expr)
 
@@ -37,7 +39,8 @@ quos(..., .named = FALSE, .ignore_empty = c("trailing", "none", "all"),
   .unquote_names = TRUE)
 
 enquos(..., .named = FALSE, .ignore_empty = c("trailing", "none",
-  "all"), .unquote_names = TRUE, .check_assign = FALSE)
+  "all"), .unquote_names = TRUE, .homonyms = c("keep", "first", "last",
+  "error"), .check_assign = FALSE)
 }
 \arguments{
 \item{expr}{An expression.}
@@ -61,6 +64,13 @@ last argument is ignored if it is empty.}
 
 \item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
 \code{:=} syntax supports \code{!!} unquoting on the LHS.}
+
+\item{.homonyms}{How to treat arguments with the same name. The
+default, \code{"keep"}, preserves these arguments. Set \code{.homonyms} to
+\code{"first"} to only keep the first occurrences, to \code{"last"} to keep
+the last occurrences, and to \code{"error"} to raise an informative
+error and indicate to the user what arguments have duplicated
+names.}
 
 \item{.check_assign}{Whether to check for \code{<-} calls passed in
 dots. When \code{TRUE} and a \code{<-} call is detected, a warning is

--- a/man/splice.Rd
+++ b/man/splice.Rd
@@ -14,7 +14,8 @@ is_spliced(x)
 is_spliced_bare(x)
 
 dots_splice(..., .ignore_empty = c("trailing", "none", "all"),
-  .preserve_empty = FALSE, .check_assign = FALSE)
+  .preserve_empty = FALSE, .homonyms = c("keep", "first", "last",
+  "error"), .check_assign = FALSE)
 }
 \arguments{
 \item{x}{A list to splice.}
@@ -29,6 +30,13 @@ last argument is ignored if it is empty.}
 were not ignored. If \code{TRUE}, empty arguments are stored with
 \code{\link[=missing_arg]{missing_arg()}} values. If \code{FALSE} (the default) an error is
 thrown when an empty argument is detected.}
+
+\item{.homonyms}{How to treat arguments with the same name. The
+default, \code{"keep"}, preserves these arguments. Set \code{.homonyms} to
+\code{"first"} to only keep the first occurrences, to \code{"last"} to keep
+the last occurrences, and to \code{"error"} to raise an informative
+error and indicate to the user what arguments have duplicated
+names.}
 
 \item{.check_assign}{Whether to check for \code{<-} calls passed in
 dots. When \code{TRUE} and a \code{<-} call is detected, a warning is

--- a/man/tidy-dots.Rd
+++ b/man/tidy-dots.Rd
@@ -7,7 +7,8 @@
 \title{Collect dots tidily}
 \usage{
 dots_list(..., .ignore_empty = c("trailing", "none", "all"),
-  .preserve_empty = FALSE, .check_assign = FALSE)
+  .preserve_empty = FALSE, .homonyms = c("keep", "first", "last",
+  "error"), .check_assign = FALSE)
 
 list2(...)
 }
@@ -22,6 +23,13 @@ last argument is ignored if it is empty.}
 were not ignored. If \code{TRUE}, empty arguments are stored with
 \code{\link[=missing_arg]{missing_arg()}} values. If \code{FALSE} (the default) an error is
 thrown when an empty argument is detected.}
+
+\item{.homonyms}{How to treat arguments with the same name. The
+default, \code{"keep"}, preserves these arguments. Set \code{.homonyms} to
+\code{"first"} to only keep the first occurrences, to \code{"last"} to keep
+the last occurrences, and to \code{"error"} to raise an informative
+error and indicate to the user what arguments have duplicated
+names.}
 
 \item{.check_assign}{Whether to check for \code{<-} calls passed in
 dots. When \code{TRUE} and a \code{<-} call is detected, a warning is
@@ -116,6 +124,19 @@ list3(, )
 
 # The list with preserved empty arguments is equivalent to:
 list(missing_arg())
+
+
+# Arguments with duplicated names are kept by default:
+list2(a = 1, a = 2, b = 3, b = 4, 5, 6)
+
+# Use the `.homonyms` argument to keep only the first of these:
+dots_list(a = 1, a = 2, b = 3, b = 4, 5, 6, .homonyms = "first")
+
+# Or the last:
+dots_list(a = 1, a = 2, b = 3, b = 4, 5, 6, .homonyms = "last")
+
+# Or raise an informative error:
+try(dots_list(a = 1, a = 2, b = 3, b = 4, 5, 6, .homonyms = "error"))
 
 
 # dots_list() can be configured to warn when a `<-` call is

--- a/src/export/exported-tests.c
+++ b/src/export/exported-tests.c
@@ -5,6 +5,12 @@ sexp* rlang_r_string(sexp* str) {
 }
 
 
+// chr.c
+
+sexp* rlang_test_nms_are_duplicated(sexp* nms, sexp* from_last) {
+  return r_nms_are_duplicated(nms, r_lgl_get(from_last, 0));
+}
+
 // cnd.c
 
 sexp* rlang_test_r_warn(sexp* x) {

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -162,6 +162,7 @@ static const r_callable r_callables[] = {
   {"rlang_node_poke_cdar",      (r_fn_ptr_t) &rlang_node_poke_cdar, 2},
   {"rlang_node_poke_cddr",      (r_fn_ptr_t) &rlang_node_poke_cddr, 2},
   {"rlang_new_node",            (r_fn_ptr_t) &rlang_new_node_, 2},
+  {"rlang_nms_are_duplicated",  (r_fn_ptr_t) &r_nms_are_duplicated, 1},
   {"rlang_env_clone",           (r_fn_ptr_t) &r_env_clone, 2},
   {"rlang_env_unbind",          (r_fn_ptr_t) &rlang_env_unbind, 3},
   {"rlang_env_poke_parent",     (r_fn_ptr_t) &rlang_env_poke_parent, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -57,11 +57,11 @@ extern sexp* rlang_capturedots(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_new_call_node(sexp*, sexp*);
 extern sexp* rlang_cnd_signal(sexp*);
 extern sexp* rlang_r_string(sexp*);
-extern sexp* rlang_exprs_interp(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_quos_interp(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_dots_values(sexp*, sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_dots_list(sexp*, sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_dots_flat_list(sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_exprs_interp(sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_quos_interp(sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_dots_values(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_dots_list(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_dots_flat_list(sexp*, sexp*, sexp*, sexp*, sexp*, sexp*);
 extern sexp* r_new_formula(sexp*, sexp*, sexp*);
 extern sexp* rlang_new_quosure(sexp*, sexp*);
 extern sexp* rlang_enexpr(sexp*, sexp*);
@@ -197,11 +197,11 @@ static const r_callable r_callables[] = {
   {"rlang_test_sys_frame",      (r_fn_ptr_t) &rlang_test_sys_frame, 1},
   {"rlang_test_sys_call",       (r_fn_ptr_t) &rlang_test_sys_call, 1},
   {"rlang_r_string",            (r_fn_ptr_t) &rlang_r_string, 1},
-  {"rlang_exprs_interp",        (r_fn_ptr_t) &rlang_exprs_interp, 5},
-  {"rlang_quos_interp",         (r_fn_ptr_t) &rlang_quos_interp, 5},
-  {"rlang_dots_values",         (r_fn_ptr_t) &rlang_dots_values, 6},
-  {"rlang_dots_list",           (r_fn_ptr_t) &rlang_dots_list, 6},
-  {"rlang_dots_flat_list",      (r_fn_ptr_t) &rlang_dots_flat_list, 6},
+  {"rlang_exprs_interp",        (r_fn_ptr_t) &rlang_exprs_interp, 6},
+  {"rlang_quos_interp",         (r_fn_ptr_t) &rlang_quos_interp, 6},
+  {"rlang_dots_values",         (r_fn_ptr_t) &rlang_dots_values, 7},
+  {"rlang_dots_list",           (r_fn_ptr_t) &rlang_dots_list, 7},
+  {"rlang_dots_flat_list",      (r_fn_ptr_t) &rlang_dots_flat_list, 7},
   {"rlang_new_formula",         (r_fn_ptr_t) &r_new_formula, 3},
   {"rlang_new_quosure",         (r_fn_ptr_t) &rlang_new_quosure, 2},
   {"rlang_enexpr",              (r_fn_ptr_t) &rlang_enexpr, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -126,6 +126,7 @@ extern sexp* r_current_frame();
 extern sexp* rlang_test_node_list_clone_until(sexp*, sexp*);
 extern sexp* rlang_test_sys_frame(sexp*);
 extern sexp* rlang_test_sys_call(sexp*);
+extern sexp* rlang_test_nms_are_duplicated(sexp*, sexp*);
 
 static const r_callable r_callables[] = {
   {"rlang_library_load",        (r_fn_ptr_t) &rlang_library_load, 0},
@@ -162,7 +163,7 @@ static const r_callable r_callables[] = {
   {"rlang_node_poke_cdar",      (r_fn_ptr_t) &rlang_node_poke_cdar, 2},
   {"rlang_node_poke_cddr",      (r_fn_ptr_t) &rlang_node_poke_cddr, 2},
   {"rlang_new_node",            (r_fn_ptr_t) &rlang_new_node_, 2},
-  {"rlang_nms_are_duplicated",  (r_fn_ptr_t) &r_nms_are_duplicated, 1},
+  {"rlang_nms_are_duplicated",  (r_fn_ptr_t) &rlang_test_nms_are_duplicated, 2},
   {"rlang_env_clone",           (r_fn_ptr_t) &r_env_clone, 2},
   {"rlang_env_unbind",          (r_fn_ptr_t) &rlang_env_unbind, 3},
   {"rlang_env_poke_parent",     (r_fn_ptr_t) &rlang_env_poke_parent, 2},

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -497,10 +497,10 @@ sexp* dots_expand(sexp* dots, struct dots_capture_info* capture_info) {
   return out;
 }
 
-static sexp* dots_keep_first(sexp* dots, sexp* nms) {
+static sexp* dots_keep(sexp* dots, sexp* nms, bool first) {
   r_ssize n = r_length(dots);
 
-  sexp* dups = r_nms_are_duplicated(nms, false);
+  sexp* dups = r_nms_are_duplicated(nms, !first);
   r_ssize out_n = n - r_lgl_sum(dups);
 
   sexp* out = KEEP(r_new_vector(r_type_list, out_n));
@@ -549,12 +549,12 @@ static sexp* dots_init(struct dots_capture_info* capture_info, sexp* frame_env) 
     dots = KEEP_N(maybe_auto_name(dots, capture_info->named), n_kept);
   }
 
-  case DOTS_HOMONYMS_LAST: r_abort("TODO last"); break;
   sexp* nms = r_vec_names(dots);
   if (nms != r_null) {
     switch (capture_info->homonyms) {
     case DOTS_HOMONYMS_KEEP: break;
-    case DOTS_HOMONYMS_FIRST: dots = dots_keep_first(dots, nms); break;
+    case DOTS_HOMONYMS_FIRST: dots = dots_keep(dots, nms, true); break;
+    case DOTS_HOMONYMS_LAST: dots = dots_keep(dots, nms, false); break;
     case DOTS_HOMONYMS_ERROR: dots_check_homonyms(dots, nms); break;
     }
   }

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -7,6 +7,13 @@
 sexp* rlang_ns_get(const char* name);
 
 
+enum dots_homonyms {
+  DOTS_HOMONYMS_KEEP = 0,
+  DOTS_HOMONYMS_FIRST,
+  DOTS_HOMONYMS_LAST,
+  DOTS_HOMONYMS_ERROR
+};
+
 struct dots_capture_info {
   enum dots_capture_type type;
   r_ssize count;
@@ -15,15 +22,19 @@ struct dots_capture_info {
   int ignore_empty;
   bool preserve_empty;
   bool unquote_names;
+  enum dots_homonyms homonyms;
   bool check_assign;
 };
 
-static int match_ignore_empty_arg(sexp* ignore_empty);
+static int arg_match_ignore_empty(sexp* ignore_empty);
+static enum dots_homonyms arg_match_homonyms(sexp* homonyms);
+
 struct dots_capture_info init_capture_info(enum dots_capture_type type,
                                            sexp* named,
                                            sexp* ignore_empty,
                                            sexp* preserve_empty,
                                            sexp* unquote_names,
+                                           sexp* homonyms,
                                            sexp* check_assign) {
   struct dots_capture_info info;
 
@@ -31,9 +42,10 @@ struct dots_capture_info init_capture_info(enum dots_capture_type type,
   info.count = 0;
   info.needs_expansion = false;
   info.named = named;
-  info.ignore_empty = match_ignore_empty_arg(ignore_empty);
+  info.ignore_empty = arg_match_ignore_empty(ignore_empty);
   info.preserve_empty = r_lgl_get(preserve_empty, 0);
   info.unquote_names = r_as_bool(unquote_names);
+  info.homonyms = arg_match_homonyms(homonyms);
   info.check_assign = r_as_bool(check_assign);
 
   return info;
@@ -347,7 +359,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
 }
 
 
-static int match_ignore_empty_arg(sexp* ignore_empty) {
+static int arg_match_ignore_empty(sexp* ignore_empty) {
   if (r_typeof(ignore_empty) != r_type_character || r_length(ignore_empty) == 0) {
     r_abort("`.ignore_empty` must be a character vector");
   }
@@ -357,7 +369,21 @@ static int match_ignore_empty_arg(sexp* ignore_empty) {
   case 'n': if (!strcmp(arg, "none")) return 0; else break;
   case 'a': if (!strcmp(arg, "all")) return 1; else break;
   }
-  r_abort("`.ignore_empty` should be one of: \"trailing\", \"none\" or \"all\"");
+  r_abort("`.ignore_empty` must be one of: \"trailing\", \"none\", or \"all\"");
+}
+
+static enum dots_homonyms arg_match_homonyms(sexp* homonyms) {
+  if (r_typeof(homonyms) != r_type_character || r_length(homonyms) == 0) {
+    r_abort("`.homonyms` must be a character vector");
+  }
+  const char* arg = r_chr_get_c_string(homonyms, 0);
+  switch(arg[0]) {
+  case 'k': if (!strcmp(arg, "keep")) return DOTS_HOMONYMS_KEEP; else break;
+  case 'f': if (!strcmp(arg, "first")) return DOTS_HOMONYMS_FIRST; else break;
+  case 'l': if (!strcmp(arg, "last")) return DOTS_HOMONYMS_LAST; else break;
+  case 'e': if (!strcmp(arg, "error")) return DOTS_HOMONYMS_ERROR; else break;
+  }
+  r_abort("`.homonyms` must be one of: \"keep\", \"first\", \"last\", or \"error\"");
 }
 
 void signal_soft_deprecated_width() {
@@ -493,6 +519,7 @@ sexp* rlang_exprs_interp(sexp* frame_env,
                          sexp* named,
                          sexp* ignore_empty,
                          sexp* unquote_names,
+                         sexp* homonyms,
                          sexp* check_assign) {
 
   struct dots_capture_info capture_info;
@@ -501,6 +528,7 @@ sexp* rlang_exprs_interp(sexp* frame_env,
                                    ignore_empty,
                                    r_shared_true,
                                    unquote_names,
+                                   homonyms,
                                    check_assign);
 
   sexp* dots = dots_init(&capture_info, frame_env);
@@ -516,6 +544,7 @@ sexp* rlang_quos_interp(sexp* frame_env,
                         sexp* named,
                         sexp* ignore_empty,
                         sexp* unquote_names,
+                        sexp* homonyms,
                         sexp* check_assign) {
   int n_protect = 0;
 
@@ -525,6 +554,7 @@ sexp* rlang_quos_interp(sexp* frame_env,
                                    ignore_empty,
                                    r_shared_true,
                                    unquote_names,
+                                   homonyms,
                                    check_assign);
 
   sexp* dots = KEEP_N(dots_init(&capture_info, frame_env), n_protect);
@@ -569,6 +599,7 @@ static sexp* dots_values_impl(sexp* frame_env,
                               sexp* ignore_empty,
                               sexp* preserve_empty,
                               sexp* unquote_names,
+                              sexp* homonyms,
                               sexp* check_assign,
                               bool (*is_spliced)(sexp*)) {
 
@@ -578,6 +609,7 @@ static sexp* dots_values_impl(sexp* frame_env,
                                    ignore_empty,
                                    preserve_empty,
                                    unquote_names,
+                                   homonyms,
                                    check_assign);
 
   sexp* dots = dots_init(&capture_info, frame_env);
@@ -599,12 +631,14 @@ sexp* rlang_dots_values(sexp* frame_env,
                         sexp* ignore_empty,
                         sexp* preserve_empty,
                         sexp* unquote_names,
+                        sexp* homonyms,
                         sexp* check_assign) {
   return dots_values_impl(frame_env,
                           named,
                           ignore_empty,
                           preserve_empty,
                           unquote_names,
+                          homonyms,
                           check_assign,
                           NULL);
 }
@@ -613,12 +647,14 @@ sexp* rlang_dots_list(sexp* frame_env,
                       sexp* ignore_empty,
                       sexp* preserve_empty,
                       sexp* unquote_names,
+                      sexp* homonyms,
                       sexp* check_assign) {
   return dots_values_impl(frame_env,
                           named,
                           ignore_empty,
                           preserve_empty,
                           unquote_names,
+                          homonyms,
                           check_assign,
                           &is_spliced_dots_value);
 }
@@ -627,6 +663,7 @@ sexp* rlang_dots_flat_list(sexp* frame_env,
                            sexp* ignore_empty,
                            sexp* preserve_empty,
                            sexp* unquote_names,
+                           sexp* homonyms,
                            sexp* check_assign) {
 
   struct dots_capture_info capture_info;
@@ -635,6 +672,7 @@ sexp* rlang_dots_flat_list(sexp* frame_env,
                                    ignore_empty,
                                    preserve_empty,
                                    unquote_names,
+                                   homonyms,
                                    check_assign);
 
   sexp* dots = dots_init(&capture_info, frame_env);

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -500,7 +500,7 @@ sexp* dots_expand(sexp* dots, struct dots_capture_info* capture_info) {
 static sexp* dots_keep_first(sexp* dots, sexp* nms) {
   r_ssize n = r_length(dots);
 
-  sexp* dups = r_nms_are_duplicated(nms);
+  sexp* dups = r_nms_are_duplicated(nms, false);
   r_ssize out_n = n - r_lgl_sum(dups);
 
   sexp* out = KEEP(r_new_vector(r_type_list, out_n));
@@ -524,7 +524,7 @@ static sexp* dots_keep_first(sexp* dots, sexp* nms) {
 
 static sexp* abort_dots_homonyms_call = NULL;
 static void dots_check_homonyms(sexp* dots, sexp* nms) {
-  sexp* dups = KEEP(r_nms_are_duplicated(nms));
+  sexp* dups = KEEP(r_nms_are_duplicated(nms, false));
 
   if (r_lgl_sum(dups)) {
     r_eval_with_xy(abort_dots_homonyms_call, r_base_env, dots, dups);

--- a/src/lib/vec-chr.c
+++ b/src/lib/vec-chr.c
@@ -99,6 +99,26 @@ sexp* chr_append(sexp* chr, sexp* r_str) {
   return out;
 }
 
+sexp* r_nms_are_duplicated(sexp* nms) {
+  if (r_typeof(nms) != r_type_character) {
+    r_abort("Internal error: Expected a character vector of names for checking duplication");
+  }
+  sexp* dups = KEEP(r_vec_are_duplicated(nms));
+
+  r_ssize n = r_length(dups);
+  int* dups_ptr = r_lgl_deref(dups);
+  sexp** nms_ptr = r_chr_deref(nms);
+
+  for (r_ssize i = 0; i < n; ++i, ++dups_ptr, ++nms_ptr) {
+    if (*nms_ptr == r_empty_str || *nms_ptr == r_missing_str) {
+      *dups_ptr = false;
+    }
+  }
+
+  FREE(1);
+  return dups;
+}
+
 
 sexp* r_shared_empty_chr = NULL;
 sexp* r_empty_str = NULL;

--- a/src/lib/vec-chr.c
+++ b/src/lib/vec-chr.c
@@ -99,11 +99,11 @@ sexp* chr_append(sexp* chr, sexp* r_str) {
   return out;
 }
 
-sexp* r_nms_are_duplicated(sexp* nms) {
+sexp* r_nms_are_duplicated(sexp* nms, bool from_last) {
   if (r_typeof(nms) != r_type_character) {
     r_abort("Internal error: Expected a character vector of names for checking duplication");
   }
-  sexp* dups = KEEP(r_vec_are_duplicated(nms));
+  sexp* dups = KEEP(Rf_duplicated(nms, from_last));
 
   r_ssize n = r_length(dups);
   int* dups_ptr = r_lgl_deref(dups);

--- a/src/lib/vec-chr.c
+++ b/src/lib/vec-chr.c
@@ -101,8 +101,11 @@ sexp* chr_append(sexp* chr, sexp* r_str) {
 
 
 sexp* r_shared_empty_chr = NULL;
+sexp* r_empty_str = NULL;
 
 void r_init_library_vec_chr() {
   r_shared_empty_chr = r_chr("");
   r_mark_precious(r_shared_empty_chr);
+
+  r_empty_str = r_chr_get(r_shared_empty_chr, 0);
 }

--- a/src/lib/vec-chr.h
+++ b/src/lib/vec-chr.h
@@ -63,7 +63,7 @@ static inline bool r_chr_has_empty_string_at(sexp* chr, r_ssize i) {
   return r_is_empty_string(r_chr_get(chr, i));
 }
 
-sexp* r_nms_are_duplicated(sexp* nms);
+sexp* r_nms_are_duplicated(sexp* nms, bool from_last);
 
 sexp* r_str_unserialise_unicode(sexp* r_string);
 

--- a/src/lib/vec-chr.h
+++ b/src/lib/vec-chr.h
@@ -63,6 +63,8 @@ static inline bool r_chr_has_empty_string_at(sexp* chr, r_ssize i) {
   return r_is_empty_string(r_chr_get(chr, i));
 }
 
+sexp* r_nms_are_duplicated(sexp* nms);
+
 sexp* r_str_unserialise_unicode(sexp* r_string);
 
 static inline bool r_is_string(sexp* x, const char* string) {

--- a/src/lib/vec-chr.h
+++ b/src/lib/vec-chr.h
@@ -7,6 +7,7 @@
 #define r_missing_str R_NaString
 
 extern sexp* r_shared_empty_chr;
+extern sexp* r_empty_str;
 
 
 static inline sexp* r_chr_get(sexp* chr, r_ssize i) {

--- a/src/lib/vec-lgl.c
+++ b/src/lib/vec-lgl.c
@@ -24,3 +24,22 @@ bool r_is_true(sexp* x) {
     return value == NA_LOGICAL ? 0 : value;
   }
 }
+
+r_ssize r_lgl_sum(sexp* lgl) {
+  if (r_typeof(lgl) != r_type_logical) {
+    r_abort("Internal error: Excepted logical vector for sum");
+  }
+
+  r_ssize n = r_vec_length(lgl);
+
+  r_ssize sum = 0;
+  int* ptr = r_lgl_deref(lgl);
+
+  for (r_ssize i = 0; i < n; ++i, ++ptr) {
+    // This can't overflow since `sum` is necessarily smaller or equal
+    // to the vector length expressed in `r_ssize`.
+    sum += *ptr;
+  }
+
+  return sum;
+}

--- a/src/lib/vec-lgl.h
+++ b/src/lib/vec-lgl.h
@@ -19,5 +19,7 @@ static inline sexp* r_shared_lgl(bool x) {
   }
 }
 
+r_ssize r_lgl_sum(sexp* lgl);
+
 
 #endif

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -1,0 +1,4 @@
+
+nms_are_duplicated <- function(nms) {
+  .Call(rlang_nms_are_duplicated, nms)
+}

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -1,4 +1,4 @@
 
-nms_are_duplicated <- function(nms) {
-  .Call(rlang_nms_are_duplicated, nms)
+nms_are_duplicated <- function(nms, from_last = FALSE) {
+  .Call(rlang_nms_are_duplicated, nms, from_last)
 }

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -403,3 +403,16 @@ test_that("r_warn_deprecated() warns once", {
   expect_no_warning(warn_deprecated("retired", "foo"))
   expect_warning(warn_deprecated("retired", "bar"), "retired")
 })
+
+test_that("r_nms_are_duplicated() detects duplicates", {
+  out <- nms_are_duplicated(letters)
+  expect_identical(out, rep(FALSE, length(letters)))
+
+  out <- nms_are_duplicated(c("a", "b", "a", "a", "c", "c"))
+  expect_identical(out, c(FALSE, FALSE, TRUE, TRUE, FALSE, TRUE))
+})
+
+test_that("r_nms_are_duplicated() handles empty and missing names", {
+  out <- nms_are_duplicated(c("a", NA, NA, "b", "", "", "a"))
+  expect_identical(out, c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE))
+})

--- a/tests/testthat/test-compat.R
+++ b/tests/testthat/test-compat.R
@@ -88,3 +88,11 @@ test_that("trimws() trims", {
   expect_identical(trimws(x, "l"), "foo.  ")
   expect_identical(trimws(x, "r"), "  foo.")
 })
+
+test_that("map2() sets names", {
+  expect_identical(map2(list(foo = NULL, bar = NULL), 1:2, function(...) NULL), list(foo = NULL, bar = NULL))
+})
+
+test_that("map2() discards recycled names", {
+  expect_identical(map2(list(foo = NULL), 1:3, function(...) NULL), new_list(3))
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -196,3 +196,7 @@ test_that("dots collectors never warn for <- when option is set", {
   expect_no_warning(myexprs(a <- 1))
   expect_no_warning(myquos(a <- 1))
 })
+
+test_that("`.homonyms` is matched exactly", {
+  expect_error(dots_list(.homonyms = "k"), "must be one of")
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -216,6 +216,21 @@ test_that("`.homonyms = 'first'` matches first homonym", {
   expect_identical(out, list(a = 1, b = 2, 5, 6))
 })
 
+test_that("`.homonyms = 'last'` matches last homonym", {
+  list_last <- function(...) {
+    dots_list(..., .homonyms = "last")
+  }
+
+  out <- list_last(1, 2)
+  expect_identical(out, named_list(1, 2))
+
+  out <- list_last(a = 1, b = 2, 3, 4)
+  expect_identical(out, list(a = 1, b = 2, 3, 4))
+
+  out <- list_last(a = 1, b = 2, a = 3, a = 4, 5, 6)
+  expect_identical(out, list(b = 2, a = 4, 5, 6))
+})
+
 test_that("`.homonyms` = 'error' fails with homonyms", {
   list_error <- function(...) {
     dots_list(..., .homonyms = "error")

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -215,3 +215,17 @@ test_that("`.homonyms = 'first'` matches first homonym", {
   out <- list_first(a = 1, b = 2, a = 3, a = 4, 5, 6)
   expect_identical(out, list(a = 1, b = 2, 5, 6))
 })
+
+test_that("`.homonyms` = 'error' fails with homonyms", {
+  list_error <- function(...) {
+    dots_list(..., .homonyms = "error")
+  }
+
+  expect_identical(list_error(1, 2), named_list(1, 2))
+  expect_identical(list_error(a = 1, b = 2), list(a = 1, b = 2))
+
+  expect_error(list_error(1, a = 2, a = 3), "multiple arguments named `a` at positions 2 and 3")
+
+  expect_error(list_error(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8), "\\* Multiple arguments named `a` at positions 2 and 8")
+  expect_error(list_error(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8), "\\* Multiple arguments named `b` at positions 3, 5 and 6")
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -200,3 +200,18 @@ test_that("dots collectors never warn for <- when option is set", {
 test_that("`.homonyms` is matched exactly", {
   expect_error(dots_list(.homonyms = "k"), "must be one of")
 })
+
+test_that("`.homonyms = 'first'` matches first homonym", {
+  list_first <- function(...) {
+    dots_list(..., .homonyms = "first")
+  }
+
+  out <- list_first(1, 2)
+  expect_identical(out, named_list(1, 2))
+
+  out <- list_first(a = 1, b = 2, 3, 4)
+  expect_identical(out, list(a = 1, b = 2, 3, 4))
+
+  out <- list_first(a = 1, b = 2, a = 3, a = 4, 5, 6)
+  expect_identical(out, list(a = 1, b = 2, 5, 6))
+})


### PR DESCRIPTION
```r
mylist <- function(...) {
  dots_list(..., .homonyms = "first")
}

mylist(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8)
#> [[1]]
#> [1] 1
#>
#> $a
#> [1] 2
#>
#> $b
#> [1] 3
#>
#> [[4]]
#> [1] 4
#>
#> [[5]]
#> [1] 7
```

```r
mylist <- function(...) {
  dots_list(..., .homonyms = "last")
}

mylist(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8)
#> [[1]]
#> [1] 1
#>
#> [[2]]
#> [1] 4
#>
#> $b
#> [1] 6
#>
#> [[4]]
#> [1] 7
#>
#> $a
#> [1] 8
```

```r
mylist <- function(...) {
  dots_list(..., .homonyms = "error")
}

mylist(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8)
#> Error: Arguments can't have the same name. We found these problems:
#> * Multiple arguments named `a` at positions 2 and 8
#> * Multiple arguments named `b` at positions 3, 5 and 6

mylist(1, a = 2, b = 3, 4, b = 5, b = 6, 7)
#> Error: Arguments can't have the same name.
#> We found multiple arguments named `b` at positions 3, 5 and 6
```