### PR TITLE
Support `.ignore_empty = "all"` in enexprs() and enquos()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
 
 # rlang 0.2.2.9000
 
-* `enexprs()` and `enquos()` now fully support the `.ignore_empty`
-  option, even with named arguments (#414).
+* `enexprs()` and `enquos()` now support `.ignore_empty = "all"`
+  with named arguments as well (#414).
 
 * The `call` argument of `abort()` and condition constructors is now
   deprecated in favour of storing full backtraces.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang 0.2.2.9000
 
+* `enexprs()` and `enquos()` now fully support the `.ignore_empty`
+  option, even with named arguments (#414).
+
 * The `call` argument of `abort()` and condition constructors is now
   deprecated in favour of storing full backtraces.
 

--- a/R/quotation.R
+++ b/R/quotation.R
@@ -360,7 +360,7 @@ endots <- function(call,
       splice(dot_call(capture_dots,
         frame_env = frame_env,
         named = named,
-        ignore_empty = ignore_empty,
+        ignore_empty = "none",
         unquote_names = unquote_names,
         homonyms = homonyms,
         check_assign = check_assign
@@ -373,6 +373,26 @@ endots <- function(call,
   if (splice_dots) {
     dots <- flatten_if(dots, is_spliced)
   }
+
+  ignore_empty <- arg_match(ignore_empty, c("trailing", "none", "all"))
+  if (identical(capture_arg, rlang_enquo)) {
+    dot_is_missing <- quo_is_missing
+  } else {
+    dot_is_missing <- is_missing
+  }
+  dots <- switch(ignore_empty,
+    trailing = {
+      n <- length(dots)
+      if (n && dot_is_missing(dots[[n]])) {
+        dots[-n]
+      } else {
+        dots
+      }
+    },
+    all = keep(dots, negate(dot_is_missing)),
+    none = dots
+  )
+
   if (named) {
     dots <- quos_auto_name(dots)
   }

--- a/man/dots_definitions.Rd
+++ b/man/dots_definitions.Rd
@@ -19,7 +19,10 @@ name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
-last argument is ignored if it is empty.}
+last argument is ignored if it is empty. Note that \code{"trailing"}
+applies only to arguments passed in \code{...}, not to named
+arguments. On the other hand, \code{"all"} also applies to named
+arguments.}
 }
 \description{
 Capture definition objects

--- a/man/quotation.Rd
+++ b/man/quotation.Rd
@@ -60,7 +60,10 @@ name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the
-last argument is ignored if it is empty.}
+last argument is ignored if it is empty. Note that \code{"trailing"}
+applies only to arguments passed in \code{...}, not to named
+arguments. On the other hand, \code{"all"} also applies to named
+arguments.}
 
 \item{.unquote_names}{Whether to treat \code{:=} as \code{=}. Unlike \code{=}, the
 \code{:=} syntax supports \code{!!} unquoting on the LHS.}

--- a/tests/testthat/test-quotation.R
+++ b/tests/testthat/test-quotation.R
@@ -332,13 +332,13 @@ test_that("endots() requires symbols", {
 
 test_that("endots() returns a named list", {
   # enquos()
-  fn <- function(foo, bar) enquos(foo, bar)
+  fn <- function(foo, bar) enquos(foo, bar, .ignore_empty = "none")
   expect_identical(names(fn()), c("", ""))
   fn <- function(arg, ...) enquos(other = arg, ...)
   expect_identical(fn(arg = 1, b = 2), quos(other = 1, b = 2))
 
   # enexprs()
-  fn <- function(foo, bar) enexprs(foo, bar)
+  fn <- function(foo, bar) enexprs(foo, bar, .ignore_empty = "none")
   expect_identical(names(fn()), c("", ""))
   fn <- function(arg, ...) enexprs(other = arg, ...)
   expect_identical(fn(arg = 1, b = 2), exprs(other = 1, b = 2))
@@ -346,13 +346,13 @@ test_that("endots() returns a named list", {
 
 test_that("endots() captures missing arguments", {
   # enquos()
-  fn <- function(foo) enquos(foo)[[1]]
+  fn <- function(foo) enquos(foo, .ignore_empty = "none")[[1]]
   expect_identical(fn(), quo())
   fn <- function(...) enquos(...)
   expect_identical(fn(), quos())
 
   # enexprs()
-  fn <- function(foo) enexprs(foo)[[1]]
+  fn <- function(foo) enexprs(foo, .ignore_empty = "none")[[1]]
   expect_identical(fn(), expr())
   fn <- function(...) enexprs(...)
   expect_identical(fn(), exprs())
@@ -465,4 +465,28 @@ test_that("auto-naming uses type_sum() (#573)", {
 test_that("auto-naming supports the .data pronoun", {
   exprs <- exprs(.data[[toupper("foo")]], .data$bar, .named = TRUE)
   expect_named(exprs, c("FOO", "bar"))
+})
+
+test_that("enexprs() and enquos() fully support `.ignore_empty` (#414)", {
+  myexprs <- function(what, x, y) enexprs(x = x, y = y, .ignore_empty = what)
+  expect_identical(myexprs("none"), exprs(x = , y = ))
+  expect_identical(myexprs("trailing"), exprs(x = ))
+  expect_identical(myexprs("all"), exprs())
+
+  myquos <- function(what, x, y) enquos(x = x, y = y, .ignore_empty = what)
+  expect_identical(myquos("none"), quos(x = , y = ))
+  expect_identical(myquos("trailing"), quos(x = ))
+  expect_identical(myquos("all"), quos())
+})
+
+test_that("enexprs() and enquos() support empty dots", {
+  myexprs <- function(what, ...) enexprs(..., .ignore_empty = what)
+  expect_identical(myexprs("none"), exprs())
+  expect_identical(myexprs("trailing"), exprs())
+  expect_identical(myexprs("all"), exprs())
+
+  myquos <- function(what, ...) enquos(..., .ignore_empty = what)
+  expect_identical(myquos("none"), quos())
+  expect_identical(myquos("trailing"), quos())
+  expect_identical(myquos("all"), quos())
 })

--- a/tests/testthat/test-quotation.R
+++ b/tests/testthat/test-quotation.R
@@ -332,13 +332,13 @@ test_that("endots() requires symbols", {
 
 test_that("endots() returns a named list", {
   # enquos()
-  fn <- function(foo, bar) enquos(foo, bar, .ignore_empty = "none")
+  fn <- function(foo, bar) enquos(foo, bar)
   expect_identical(names(fn()), c("", ""))
   fn <- function(arg, ...) enquos(other = arg, ...)
   expect_identical(fn(arg = 1, b = 2), quos(other = 1, b = 2))
 
   # enexprs()
-  fn <- function(foo, bar) enexprs(foo, bar, .ignore_empty = "none")
+  fn <- function(foo, bar) enexprs(foo, bar)
   expect_identical(names(fn()), c("", ""))
   fn <- function(arg, ...) enexprs(other = arg, ...)
   expect_identical(fn(arg = 1, b = 2), exprs(other = 1, b = 2))
@@ -346,13 +346,13 @@ test_that("endots() returns a named list", {
 
 test_that("endots() captures missing arguments", {
   # enquos()
-  fn <- function(foo) enquos(foo, .ignore_empty = "none")[[1]]
+  fn <- function(foo) enquos(foo)[[1]]
   expect_identical(fn(), quo())
   fn <- function(...) enquos(...)
   expect_identical(fn(), quos())
 
   # enexprs()
-  fn <- function(foo) enexprs(foo, .ignore_empty = "none")[[1]]
+  fn <- function(foo) enexprs(foo)[[1]]
   expect_identical(fn(), expr())
   fn <- function(...) enexprs(...)
   expect_identical(fn(), exprs())
@@ -467,15 +467,15 @@ test_that("auto-naming supports the .data pronoun", {
   expect_named(exprs, c("FOO", "bar"))
 })
 
-test_that("enexprs() and enquos() fully support `.ignore_empty` (#414)", {
+test_that("enexprs() and enquos() support `.ignore_empty = 'all'` (#414)", {
   myexprs <- function(what, x, y) enexprs(x = x, y = y, .ignore_empty = what)
   expect_identical(myexprs("none"), exprs(x = , y = ))
-  expect_identical(myexprs("trailing"), exprs(x = ))
+  expect_identical(myexprs("trailing"), exprs(x = , y = ))
   expect_identical(myexprs("all"), exprs())
 
   myquos <- function(what, x, y) enquos(x = x, y = y, .ignore_empty = what)
   expect_identical(myquos("none"), quos(x = , y = ))
-  expect_identical(myquos("trailing"), quos(x = ))
+  expect_identical(myquos("trailing"), quos(x = , y = ))
   expect_identical(myquos("all"), quos())
 })
 


### PR DESCRIPTION
With this change, `enquos()` now ignore all missing arguments if ignore_empty is set to "all":

```r
myquotingfn <- function(x, y, ...) {
  enquos(x, y, ..., .ignore_empty = "all")
  etc.
}
```

This is meant to simplify code like https://github.com/tidyverse/ggplot2/blob/3e1e6e43af82faf59e37df0724b65c8d829c7b07/R/aes.r#L79.

`"trailing"` still only applies to dots. It doesn't seem to make much sense for named arguments.