### PR TITLE
Deprecate `call` argument of condition ctors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang 0.2.2.9000
 
+* The `call` argument of `abort()` and condition constructors is now
+  deprecated in favour of storing full backtraces.
+
 * It is now possible to unquote strings in function position. This is
   consistent with how the R parser coerces strings to symbols in this
   kind of expressions: `"foo"()`.

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -222,8 +222,10 @@ upcase1 <- function(x) {
 #' * [new_data_mask()]: `parent` argument
 #'
 #' * [env_tail()]: `sentinel` => `last`
-#' * [abort()], [warn()], [inform()]: `msg`, `type` and `call` =>
-#'   `.msg`, `.type` and `.call`
+#'
+#' * [abort()], [warn()], [inform()]: `msg`, `type` => `.msg`, `.type`
+#' * [abort()], [warn()], [inform()], [cnd()], [error_cnd()],
+#'   [warning_cnd()], [message_cnd()]: `call` argument.
 #'
 #'
 #' @section Defunct functions and arguments:

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -15,7 +15,7 @@ warn(message, .subclass = NULL, ..., call = NULL, msg, type)
 
 inform(message, .subclass = NULL, ..., call = NULL, msg, type)
 
-signal(message, .subclass, ..., call = NULL)
+signal(message, .subclass, ...)
 
 interrupt()
 }
@@ -29,8 +29,8 @@ to selectively handle the conditions signalled by your functions.}
 
 \item{trace}{A \code{trace} object created by \code{\link[=trace_back]{trace_back()}}.}
 
-\item{call}{Whether to display the call. If a number \code{n}, the call
-is taken from the nth frame on the \link[=call_stack]{call stack}.}
+\item{call}{Deprecated as of rlang 0.3.0. Storing the full
+backtrace is now preferred to storing a simple call.}
 
 \item{parent}{A parent condition object created by \code{\link[=abort]{abort()}}.}
 

--- a/man/cnd.Rd
+++ b/man/cnd.Rd
@@ -7,14 +7,14 @@
 \alias{message_cnd}
 \title{Create a condition object}
 \usage{
-cnd(.subclass, ..., message = "", call = NULL)
+cnd(.subclass, ..., message = "")
 
-error_cnd(.subclass = NULL, ..., message = "", call = NULL,
-  trace = NULL, parent = NULL)
+error_cnd(.subclass = NULL, ..., message = "", trace = NULL,
+  parent = NULL)
 
-warning_cnd(.subclass = NULL, ..., message = "", call = NULL)
+warning_cnd(.subclass = NULL, ..., message = "")
 
-message_cnd(.subclass = NULL, ..., message = "", call = NULL)
+message_cnd(.subclass = NULL, ..., message = "")
 }
 \arguments{
 \item{.subclass}{The condition subclass.}
@@ -24,9 +24,6 @@ object. These dots are evaluated with \link[=tidy-dots]{explicit splicing}.}
 
 \item{message}{A default message to inform the user about the
 condition when it is signalled.}
-
-\item{call}{A call documenting what expression caused a condition
-to be signalled.}
 
 \item{trace}{A \code{trace} object created by \code{\link[=trace_back]{trace_back()}}.}
 

--- a/man/lifecycle.Rd
+++ b/man/lifecycle.Rd
@@ -163,8 +163,9 @@ like \code{quos()} is soft-deprecated.
 \item \code{\link[=as_data_mask]{as_data_mask()}}: \code{parent} argument
 \item \code{\link[=new_data_mask]{new_data_mask()}}: \code{parent} argument
 \item \code{\link[=env_tail]{env_tail()}}: \code{sentinel} => \code{last}
-\item \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}}: \code{msg}, \code{type} and \code{call} =>
-\code{.msg}, \code{.type} and \code{.call}
+\item \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}}: \code{msg}, \code{type} => \code{.msg}, \code{.type}
+\item \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}}, \code{\link[=cnd]{cnd()}}, \code{\link[=error_cnd]{error_cnd()}},
+\code{\link[=warning_cnd]{warning_cnd()}}, \code{\link[=message_cnd]{message_cnd()}}: \code{call} argument.
 }
 }
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -13,7 +13,7 @@ extern bool rlang_is_quosure(sexp*);
 extern sexp* rlang_is_null(sexp*);
 extern sexp* r_f_lhs(sexp*);
 extern sexp* r_f_rhs(sexp*);
-extern sexp* r_new_condition(sexp*, sexp*, sexp*, sexp*);
+extern sexp* r_new_condition(sexp*, sexp*, sexp*);
 extern sexp* r_env_clone(sexp*, sexp*);
 extern sexp* rlang_env_unbind(sexp*, sexp*);
 extern sexp* rlang_env_poke_parent(sexp*, sexp*);
@@ -133,7 +133,7 @@ static const r_callable r_callables[] = {
   {"rlang_library_unload",      (r_fn_ptr_t) &rlang_library_unload, 0},
   {"r_f_lhs",                   (r_fn_ptr_t) &r_f_lhs, 1},
   {"r_f_rhs",                   (r_fn_ptr_t) &r_f_rhs, 1},
-  {"rlang_new_condition",       (r_fn_ptr_t) &r_new_condition, 4},
+  {"rlang_new_condition",       (r_fn_ptr_t) &r_new_condition, 3},
   {"rlang_replace_na",          (r_fn_ptr_t) &rlang_replace_na, 2},
   {"rlang_capturearginfo",      (r_fn_ptr_t) &rlang_capturearginfo, 4},
   {"rlang_capturedots",         (r_fn_ptr_t) &rlang_capturedots, 4},

--- a/src/lib/cnd.c
+++ b/src/lib/cnd.c
@@ -124,19 +124,18 @@ static sexp* new_condition_names(sexp* data) {
 
   sexp* data_nms = r_vec_names(data);
 
-  if (r_chr_has_any(data_nms, (const char* []) { "message", "call", NULL })) {
-    r_abort("Conditions can't have `message` or `call` data fields");
+  if (r_chr_has_any(data_nms, (const char* []) { "message", NULL })) {
+    r_abort("Conditions can't have a `message` data field");
   }
 
-  sexp* nms = KEEP(r_new_vector(r_type_character, r_length(data) + 2));
+  sexp* nms = KEEP(r_new_vector(r_type_character, r_length(data) + 1));
   r_chr_poke(nms, 0, r_string("message"));
-  r_chr_poke(nms, 1, r_string("call"));
-  r_vec_poke_n(nms, 2, data_nms, 0, r_length(nms) - 2);
+  r_vec_poke_n(nms, 1, data_nms, 0, r_length(nms) - 1);
 
   FREE(1);
   return nms;
 }
-sexp* r_new_condition(sexp* subclass, sexp* msg, sexp* call, sexp* data) {
+sexp* r_new_condition(sexp* subclass, sexp* msg, sexp* data) {
   if (msg == r_null) {
     msg = r_shared_empty_chr;
   } else if (!r_is_scalar_character(msg)) {
@@ -144,11 +143,10 @@ sexp* r_new_condition(sexp* subclass, sexp* msg, sexp* call, sexp* data) {
   }
 
   r_ssize n_data = r_length(data);
-  sexp* cnd = KEEP(r_new_vector(VECSXP, n_data + 2));
+  sexp* cnd = KEEP(r_new_vector(VECSXP, n_data + 1));
 
   r_list_poke(cnd, 0, msg);
-  r_list_poke(cnd, 1, call);
-  r_vec_poke_n(cnd, 2, data, 0, r_length(cnd) - 2);
+  r_vec_poke_n(cnd, 1, data, 0, r_length(cnd) - 1);
 
   r_poke_names(cnd, KEEP(new_condition_names(data)));
   r_poke_class(cnd, KEEP(chr_append(subclass, KEEP(r_string("condition")))));

--- a/src/lib/cnd.h
+++ b/src/lib/cnd.h
@@ -15,7 +15,7 @@ void r_abort_defunct(const char* fmt, ...);
 
 sexp* r_interp_str(const char* fmt, ...);
 
-sexp* r_new_condition(sexp* type, sexp* msg, sexp* call, sexp* data);
+sexp* r_new_condition(sexp* type, sexp* msg, sexp* data);
 
 static inline bool r_is_condition(sexp* x) {
   return TYPEOF(x) == VECSXP && Rf_inherits(x, "condition");

--- a/tests/testthat/test-cnd-error-str.txt
+++ b/tests/testthat/test-cnd-error-str.txt
@@ -1,7 +1,7 @@
 <error>
 * Message: "The high-level error message"
 * Class: `rlang_error`
-* Fields: `message`, `call`, `trace` and `parent`
+* Fields: `message`, `trace` and `parent`
 * Backtrace:
 █
 ├─catch_cnd(a())
@@ -18,7 +18,7 @@
 <error: parent>
 * Message: "The low-level error message"
 * Class: `rlang_error`
-* Fields: `message`, `call`, `trace`, `parent` and `foo`
+* Fields: `message`, `trace`, `parent` and `foo`
 * Backtrace:
 █
 └─f()

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -18,74 +18,6 @@ test_that("cnd_signal() creates muffle restarts", {
   )
 })
 
-test_that("signal() includes call info", {
-  fn <- function(...) signal("msg", "cnd", call = call)
-
-  call <- NULL
-  with_handlers(fn(foo(bar)), cnd = calling(function(c) {
-    expect_null(conditionCall(c))
-  }))
-
-  call <- TRUE
-  with_handlers(fn(foo(bar)), cnd = calling(function(c) {
-    expect_identical(conditionCall(c), quote(fn(foo(bar))))
-  }))
-
-
-  wrapper <- function(...) fn(...)
-
-  call <- 1
-  with_handlers(wrapper(foo(bar)), cnd = calling(function(c) {
-    expect_equal(conditionCall(c), quote(fn(...)))
-  }))
-
-  call <- 2
-  with_handlers(wrapper(foo(bar)), cnd = calling(function(c) {
-    expect_equal(conditionCall(c), quote(wrapper(foo(bar))))
-  }))
-})
-
-test_that("abort() includes call info", {
-  fn <- function(...) abort("abort", "cnd", call = call)
-
-  call <- NULL
-  with_handlers(fn(foo(bar)), cnd = exiting(function(c) {
-    expect_null(conditionCall(c))
-  }))
-
-  call <- TRUE
-  with_handlers(fn(foo(bar)), cnd = exiting(function(c) {
-    expect_identical(conditionCall(c), quote(fn(foo(bar))))
-  }))
-})
-
-test_that("abort() accepts call number", {
-  fn <- function(...) abort("abort", "cnd", call = call)
-  wrapper <- function(...) fn(...)
-
-  call <- FALSE
-  with_handlers(wrapper(foo(bar)), cnd = exiting(function(c) {
-    expect_null(conditionCall(c))
-  }))
-
-  call <- TRUE
-  with_handlers(wrapper(foo(bar)), cnd = exiting(function(c) {
-    expect_equal(conditionCall(c), quote(fn(...)))
-  }))
-
-  call <- 1
-  with_handlers(wrapper(foo(bar)), cnd = exiting(function(c) {
-    expect_equal(conditionCall(c), quote(fn(...)))
-  }))
-
-  call <- 2
-  with_handlers(wrapper(foo(bar)), cnd = exiting(function(c) {
-    expect_equal(conditionCall(c), quote(wrapper(foo(bar))))
-  }))
-
-  expect_error(abort("foo", call = na_int), "scalar logical or number")
-})
-
 test_that("error when msg is not a string", {
   expect_error(warn(letters), "must be a string")
 })
@@ -445,12 +377,12 @@ test_that("deprecated arguments of abort() etc still work", {
   msgs <- pluck_conditions_msgs(cnds)
 
   warnings_msgs <- msgs$warnings
-  expect_length(warnings_msgs, 2L)
+  expect_length(warnings_msgs, 3L)
   expect_match(warnings_msgs[[1]], "`msg` has been renamed to `message`")
   expect_match(warnings_msgs[[2]], "`type` has been renamed to `.subclass`")
+  expect_match(warnings_msgs[[3]], "`call` is deprecated")
 
   expect_match(msgs$error, "foo")
-  expect_identical(conditionCall(cnds$error), quote(foo()))
 })
 
 test_that("deprecated arguments of cnd_signal() still work", {


### PR DESCRIPTION
Since it's superseded by backtraces.

Directly deprecated because there are likely very few users of this argument, if any, and it should be harmless to ignore it in most cases.

Closes #520