### PR TITLE
Require environment in as_quosure()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # rlang 0.2.2.9000
 
+* `as_quosure()` now requires an explicit environment for symbols and
+  calls. This should typically be the environment in which the
+  expression was created.
+
 * `as_data_pronoun()` now accepts data masks. If the mask has multiple
   environments, all of these are looked up when subsetting the pronoun.
   Function objects stored in the mask are bypassed.

--- a/man/as_quosure.Rd
+++ b/man/as_quosure.Rd
@@ -5,7 +5,7 @@
 \alias{new_quosure}
 \title{Coerce object to quosure}
 \usage{
-as_quosure(x, env = caller_env())
+as_quosure(x, env = NULL)
 
 new_quosure(expr, env = caller_env())
 }
@@ -13,7 +13,9 @@ new_quosure(expr, env = caller_env())
 \item{x}{An object to convert. Either an \link[=is_expression]{expression} or a
 formula.}
 
-\item{env}{The original context of the context expression.}
+\item{env}{The environment in which the expression should be
+evaluated. Only used for symbols and calls. This should typically
+be the environment in which the expression was created.}
 
 \item{expr}{The expression wrapped by the quosure.}
 }
@@ -25,8 +27,8 @@ converts formulas and quosures and does not double-wrap.
 \section{Life cycle}{
 
 \itemize{
-\item Like the rest of the rlang package, \code{new_quosure()} and
-\code{as_quosure()} are maturing.
+\item \code{as_quosure()} now requires an explicit default environment for
+creating quosures from symbols and calls.
 \item \code{as_quosureish()} is deprecated as of rlang 0.2.0. This function
 assumes that quosures are formulas which is currently true but
 might not be in the future.
@@ -36,21 +38,16 @@ might not be in the future.
 \examples{
 # as_quosure() converts expressions or any R object to a validly
 # scoped quosure:
-as_quosure(quote(expr), base_env())
-as_quosure(10L, base_env())
+env <- env(var = "thing")
+as_quosure(quote(var), env)
 
 
-# Sometimes you get unscoped formulas because of quotation:
-f <- ~~expr
-inner_f <- f_rhs(f)
-str(inner_f)
+# The environment is ignored for formulas:
+as_quosure(~foo, env)
+as_quosure(~foo)
 
-# In that case testing for a scoped formula returns FALSE:
-is_formula(inner_f, scoped = TRUE)
-
-# With as_quosure() you ensure that this kind of unscoped formulas
-# will be granted a default environment:
-as_quosure(inner_f, base_env())
+# However you must supply it for symbols and calls:
+try(as_quosure(quote(var)))
 }
 \seealso{
 \code{\link[=quo]{quo()}}, \code{\link[=is_quosure]{is_quosure()}}

--- a/man/is_quosureish.Rd
+++ b/man/is_quosureish.Rd
@@ -16,7 +16,9 @@ as_quosureish(x, env = caller_env())
 that is, has a valid environment attribute. If \code{NULL}, the scope
 is not inspected.}
 
-\item{env}{The original context of the context expression.}
+\item{env}{The environment in which the expression should be
+evaluated. Only used for symbols and calls. This should typically
+be the environment in which the expression was created.}
 }
 \description{
 \Sexpr[results=rd, stage=render]{rlang:::lifecycle("defunct")}

--- a/tests/testthat/test-quo.R
+++ b/tests/testthat/test-quo.R
@@ -239,3 +239,11 @@ test_that("quosures fail with common operations (#478, tidyverse/dplyr#3476)", {
   expect_error(stats::median(q), "median\\(!!myquosure\\)")
   expect_error(stats::quantile(q), "quantile\\(!!myquosure\\)")
 })
+
+
+# Lifecycle ----------------------------------------------------------
+
+test_that("as_quosure() still provides default env", {
+  quo <- expect_warning(as_quosure(quote(foo)), "explicit environment")
+  expect_reference(quo_get_env(quo), current_env())
+})


### PR DESCRIPTION
And fail when formula does not contain an environment. This seems safer because if an unevaluated formula turns up it likely means something went wrong earlier.

Closes #433