### PR TITLE
Documentation of expression deparsers

### DIFF
--- a/R/expr.R
+++ b/R/expr.R
@@ -113,6 +113,10 @@ is_symbolic <- function(x) {
 
 #' Turn an expression to a label
 #'
+#' @description
+#'
+#' \Sexpr[results=rd, stage=render]{rlang:::lifecycle("questioning")}
+#'
 #' `expr_text()` turns the expression into a single string, which
 #' might be multi-line. `expr_name()` is suitable for formatting
 #' names. It works best with symbols and scalar types, but also
@@ -120,7 +124,12 @@ is_symbolic <- function(x) {
 #' in messages.
 #'
 #' @param expr An expression to labellise.
-#' @export
+#'
+#' @section Life cycle:
+#'
+#' These functions are in the questioning stage because they are
+#' redundant with the `quo_` variants and do not handle quosures.
+#'
 #' @examples
 #' # To labellise a function argument, first capture it with
 #' # substitute():
@@ -139,6 +148,7 @@ is_symbolic <- function(x) {
 #'   1 + 2
 #'   print(x)
 #' })))
+#' @export
 expr_label <- function(expr) {
   if (is.character(expr)) {
     encodeString(expr, quote = '"')

--- a/R/lifecycle.R
+++ b/R/lifecycle.R
@@ -130,6 +130,7 @@ upcase1 <- function(x) {
 #'   [rst_maybe_jump()], [rst_abort()]. It is not clear yet whether we
 #'   want to recommend restarts as a style of programming in R.
 #' * [return_from()] and [return_to()].
+#' * [expr_label()], [expr_name()], and [expr_text()].
 #'
 #'
 #' **In the questioning stage as of rlang 0.2.0**

--- a/R/quo.R
+++ b/R/quo.R
@@ -368,13 +368,22 @@ quo_squash <- function(quo, warn = FALSE) {
 #'
 #' @description
 #'
-#' * `quo_text()` and `quo_label()` are equivalent to [expr_text()],
-#'   [expr_label()], etc, but they first squash all quosures with
-#'   [quo_squash()] so they print more nicely.
+#' These functions take an arbitrary R object, typically an
+#' [expression][is_expression], and represent it as a string.
 #'
-#' * `quo_name()` squashes a quosure and transforms it into a simple
-#'   string. It is suitable to give an unnamed quosure a default name,
-#'   for instance a column name in a data frame.
+#' * `quo_name()` returns an abbreviated representation of the object
+#'   as a single line string. It is suitable for default names.
+#'
+#' * `quo_text()` returns a multiline string. For instance block
+#'   expressions like `{ foo; bar }` are represented on 4 lines (one
+#'   for each symbol, and the curly braces on their own lines).
+#'
+#' These deparsers are only suitable for creating default names or
+#' printing output at the console. The behaviour of your functions
+#' should not depend on deparsed objects. If you are looking for a way
+#' of transforming symbols to strings, use [as_string()] instead of
+#' `quo_name()`. Unlike deparsing, the transformation between symbols
+#' and strings is non-lossy and well defined.
 #'
 #' @inheritParams quo_squash
 #' @inheritParams expr_label

--- a/man/expr_label.Rd
+++ b/man/expr_label.Rd
@@ -20,12 +20,21 @@ expr_text(expr, width = 60L, nlines = Inf)
 \item{nlines}{Maximum number of lines to extract.}
 }
 \description{
+\Sexpr[results=rd, stage=render]{rlang:::lifecycle("questioning")}
+
 \code{expr_text()} turns the expression into a single string, which
 might be multi-line. \code{expr_name()} is suitable for formatting
 names. It works best with symbols and scalar types, but also
 accepts calls. \code{expr_label()} formats the expression nicely for use
 in messages.
 }
+\section{Life cycle}{
+
+
+These functions are in the questioning stage because they are
+redundant with the \code{quo_} variants and do not handle quosures.
+}
+
 \examples{
 # To labellise a function argument, first capture it with
 # substitute():

--- a/man/lifecycle.Rd
+++ b/man/lifecycle.Rd
@@ -79,6 +79,7 @@ changes.
 \code{\link[=rst_maybe_jump]{rst_maybe_jump()}}, \code{\link[=rst_abort]{rst_abort()}}. It is not clear yet whether we
 want to recommend restarts as a style of programming in R.
 \item \code{\link[=return_from]{return_from()}} and \code{\link[=return_to]{return_to()}}.
+\item \code{\link[=expr_label]{expr_label()}}, \code{\link[=expr_name]{expr_name()}}, and \code{\link[=expr_text]{expr_text()}}.
 }
 
 \strong{In the questioning stage as of rlang 0.2.0}

--- a/man/quo_label.Rd
+++ b/man/quo_label.Rd
@@ -20,14 +20,22 @@ quo_name(quo)
 \item{nlines}{Maximum number of lines to extract.}
 }
 \description{
+These functions take an arbitrary R object, typically an
+\link[=is_expression]{expression}, and represent it as a string.
 \itemize{
-\item \code{quo_text()} and \code{quo_label()} are equivalent to \code{\link[=expr_text]{expr_text()}},
-\code{\link[=expr_label]{expr_label()}}, etc, but they first squash all quosures with
-\code{\link[=quo_squash]{quo_squash()}} so they print more nicely.
-\item \code{quo_name()} squashes a quosure and transforms it into a simple
-string. It is suitable to give an unnamed quosure a default name,
-for instance a column name in a data frame.
+\item \code{quo_name()} returns an abbreviated representation of the object
+as a single line string. It is suitable for default names.
+\item \code{quo_text()} returns a multiline string. For instance block
+expressions like \code{{ foo; bar }} are represented on 4 lines (one
+for each symbol, and the curly braces on their own lines).
 }
+
+These deparsers are only suitable for creating default names or
+printing output at the console. The behaviour of your functions
+should not depend on deparsed objects. If you are looking for a way
+of transforming symbols to strings, use \code{\link[=as_string]{as_string()}} instead of
+\code{quo_name()}. Unlike deparsing, the transformation between symbols
+and strings is non-lossy and well defined.
 }
 \examples{
 # Quosures can contain nested quosures:


### PR DESCRIPTION
* Improve explanation of `quo_name()` and `quo_text()`. Mention they should not be used for programming and point to `as_string()` for symbol to text conversion. I noticed in the revdeps many people use `quo_name()` and even `quo_text()` for converting symbols to strings.

* Put `expr_` deparsers in the questioning stage. Perhaps the `quo_` deparsers should too? I thought not because we still mention them a lot in the tidy eval docs.