### PR TITLE
Allow subsetting .data with symbols

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,10 @@ transform the warning to a failure.
   .data[["name"]])` and `group_by(df, name)` produce the same column
   name.
 
+* `.data[[` now supports symbols, just like you can use symbols to
+  subset regular R vectors. This makes it easy to use the pronoun with
+  variables quoted with `ensym()`.
+
 * Automatic naming of expressions now uses a new deparser (still
   unexported) instead of `quo_text()`. Following this change,
   automatic naming is now compatible with all object types (via

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -376,8 +376,8 @@ new_data_mask <- function(bottom, top = bottom, parent = NULL) {
 }
 #' @export
 `[[.rlang_data_pronoun` <- function(x, i, ...) {
-  if (!is_string(i)) {
-    abort("Must subset the data pronoun with a string")
+  if (!is_string(i) && !is_symbol(i)) {
+    abort("Must subset the data pronoun with a string or symbol")
   }
   data_pronoun_get(x, i)
 }

--- a/src/internal/expr-interp.c
+++ b/src/internal/expr-interp.c
@@ -265,6 +265,13 @@ static sexp* bang_bang(struct expansion_info info, sexp* env) {
   sexp* value = r_eval(info.operand, env);
   return bang_bang_teardown(value, info);
 }
+static sexp* bang_bang_dot_data(struct expansion_info info, sexp* env) {
+  sexp* value = r_eval(info.operand, env);
+  if (r_typeof(value) == r_type_symbol) {
+    value = r_chr(r_sym_get_c_string(value));
+  }
+  return bang_bang_teardown(value, info);
+}
 static sexp* bang_bang_expression(struct expansion_info info, sexp* env) {
   sexp* value = KEEP(r_eval(info.operand, env));
 
@@ -369,8 +376,9 @@ sexp* call_interp_impl(sexp* x, sexp* env, struct expansion_info info) {
       return out;
     }
   case OP_EXPAND_UQ:
-  case OP_EXPAND_DOT_DATA:
     return bang_bang(info, env);
+  case OP_EXPAND_DOT_DATA:
+    return bang_bang_dot_data(info, env);
   case OP_EXPAND_UQE:
     return bang_bang_expression(info, env);
   case OP_EXPAND_FIXUP:

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -404,6 +404,12 @@ test_that("quosures look for data masks lexically", {
   expect_identical(out, list(mtcars$cyl, mtcars$disp))
 })
 
+test_that("can subset data pronoun with a symbol", {
+  var <- quote(cyl)
+  expect_identical(expr(.data[[var]]), expr(.data[["cyl"]]))
+  expect_identical(eval_tidy(quote(.data[[var]]), mtcars), mtcars$cyl)
+})
+
 
 # Lifecycle ----------------------------------------------------------
 


### PR DESCRIPTION
I noticed that lists and data frames can be subsetted with symbols. It makes sense to allow it for data pronouns as well, then we get:

```r
quoting_fn <- function(data, var) {
  var <- ensym(var)
  mutate(data, .data[[var]])
}
```