### PR TITLE
Add `trim` argument to trace_back()

### DIFF
--- a/man/trace_back.Rd
+++ b/man/trace_back.Rd
@@ -4,7 +4,7 @@
 \alias{trace_back}
 \title{Capture a call trace.}
 \usage{
-trace_back(to = NULL)
+trace_back(to = NULL, trim = 1)
 }
 \arguments{
 \item{to}{If non-null, this should be a frame environment. The
@@ -13,6 +13,12 @@ in particular when you call \code{trace_back()} indirectly or from a
 larger context, for example in tests or inside an RMarkdown
 document where you don't want all of the knitr evaluation mechanisms
 to appear in the backtrace.}
+
+\item{trim}{The number of parent contexts to trim from the bottom
+of the backtrace, starting from the rightmost leaf (the newest
+call frame in the tree). Contexts containing several frames
+(these appear as sibling nodes in the backtrace tree) are fully
+trimmed from the backtrace.}
 }
 \description{
 A call trace captures the sequence of calls that lead to the current function,

--- a/man/trace_back.Rd
+++ b/man/trace_back.Rd
@@ -4,21 +4,26 @@
 \alias{trace_back}
 \title{Capture a call trace.}
 \usage{
-trace_back(to = NULL, trim = 1)
+trace_back(top = NULL, bottom = NULL)
 }
 \arguments{
-\item{to}{If non-null, this should be a frame environment. The
-backtrace will only be recorded up to that frame. This is needed
-in particular when you call \code{trace_back()} indirectly or from a
-larger context, for example in tests or inside an RMarkdown
-document where you don't want all of the knitr evaluation mechanisms
-to appear in the backtrace.}
+\item{top}{The first frame environment to be included in the
+backtrace. This becomes the top of the backtrace tree and
+represents the oldest call in the backtrace.
 
-\item{trim}{The number of parent contexts to trim from the bottom
-of the backtrace, starting from the rightmost leaf (the newest
-call frame in the tree). Contexts containing several frames
-(these appear as sibling nodes in the backtrace tree) are fully
-trimmed from the backtrace.}
+This is needed in particular when you call \code{trace_back()}
+indirectly or from a larger context, for example in tests or
+inside an RMarkdown document where you don't want all of the
+knitr evaluation mechanisms to appear in the backtrace.}
+
+\item{bottom}{The last frame environment to be included in the
+backtrace. This becomes the rightmost leaf of the backtrace tree
+and represents the youngest call in the backtrace.
+
+Set this when you would like to capture a backtrace without the
+capture context.
+
+Can also be an integer that will be passed to \code{\link[=caller_env]{caller_env()}}.}
 }
 \description{
 A call trace captures the sequence of calls that lead to the current function,
@@ -64,7 +69,7 @@ conn <- textConnection("f()")
 source(conn, echo = TRUE)
 close(conn)
 
-# To automatically strip this off, pass `to = globalenv()`.
+# To automatically strip this off, pass `top = globalenv()`.
 # This will automatically trim off calls prior to the last appearance
 # of the global environment on the stack
 h <- function() trace_back(globalenv())

--- a/tests/testthat/helper-trace.R
+++ b/tests/testthat/helper-trace.R
@@ -16,3 +16,8 @@ expect_known_trace_output <- function(trace,
 expect_trace_length <- function(x, n) {
   expect_equal(trace_length(x), n)
 }
+
+expect_equal_trace <- function(x, y) {
+  expect_identical(x$parents, y$parents)
+  expect_equal(x$calls, y$calls)
+}

--- a/tests/testthat/test-trace-collapse-eval.txt
+++ b/tests/testthat/test-trace-collapse-eval.txt
@@ -4,17 +4,13 @@ Full:
   ├─base::eval(quote(g()))
   │ └─base::eval(quote(g()))
   └─rlang:::g()
-    └─base::eval(quote(trace_back(e)))
-      └─base::eval(quote(trace_back(e)))
 
 Collapsed:
 █
 └─rlang:::f()
   ├─[ base::eval(...) ] with 1 more call
   └─rlang:::g()
-    └─[ base::eval(...) ] with 1 more call
 
 Branch:
  ─rlang:::f()
  ─rlang:::g()
- ─[ base::eval(...) ] with 1 more call

--- a/tests/testthat/test-trace-collapse-eval.txt
+++ b/tests/testthat/test-trace-collapse-eval.txt
@@ -4,9 +4,9 @@ Full:
   ├─base::eval(quote(g()))
   │ └─base::eval(quote(g()))
   └─rlang:::g()
-    ├─base::eval(quote(trace_back(e, trim = 0)))
-    │ └─base::eval(quote(trace_back(e, trim = 0)))
-    └─rlang::trace_back(e, trim = 0)
+    ├─base::eval(quote(trace_back(e, bottom = 0)))
+    │ └─base::eval(quote(trace_back(e, bottom = 0)))
+    └─rlang::trace_back(e, bottom = 0)
 
 Collapsed:
 █
@@ -14,9 +14,9 @@ Collapsed:
   ├─[ base::eval(...) ] with 1 more call
   └─rlang:::g()
     ├─[ base::eval(...) ] with 1 more call
-    └─rlang::trace_back(e, trim = 0)
+    └─rlang::trace_back(e, bottom = 0)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g()
- ─rlang::trace_back(e, trim = 0)
+ ─rlang::trace_back(e, bottom = 0)

--- a/tests/testthat/test-trace-collapse-eval.txt
+++ b/tests/testthat/test-trace-collapse-eval.txt
@@ -4,13 +4,19 @@ Full:
   ├─base::eval(quote(g()))
   │ └─base::eval(quote(g()))
   └─rlang:::g()
+    ├─base::eval(quote(trace_back(e, trim = 0)))
+    │ └─base::eval(quote(trace_back(e, trim = 0)))
+    └─rlang::trace_back(e, trim = 0)
 
 Collapsed:
 █
 └─rlang:::f()
   ├─[ base::eval(...) ] with 1 more call
   └─rlang:::g()
+    ├─[ base::eval(...) ] with 1 more call
+    └─rlang::trace_back(e, trim = 0)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g()
+ ─rlang::trace_back(e, trim = 0)

--- a/tests/testthat/test-trace-collapse-evalq.txt
+++ b/tests/testthat/test-trace-collapse-evalq.txt
@@ -4,9 +4,9 @@ Full:
   ├─base::evalq(g())
   │ └─base::evalq(g())
   └─rlang:::g()
-    ├─base::evalq(trace_back(e, trim = 0))
-    │ └─base::evalq(trace_back(e, trim = 0))
-    └─rlang::trace_back(e, trim = 0)
+    ├─base::evalq(trace_back(e, bottom = 0))
+    │ └─base::evalq(trace_back(e, bottom = 0))
+    └─rlang::trace_back(e, bottom = 0)
 
 Collapsed:
 █
@@ -14,9 +14,9 @@ Collapsed:
   ├─[ base::evalq(...) ] with 1 more call
   └─rlang:::g()
     ├─[ base::evalq(...) ] with 1 more call
-    └─rlang::trace_back(e, trim = 0)
+    └─rlang::trace_back(e, bottom = 0)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g()
- ─rlang::trace_back(e, trim = 0)
+ ─rlang::trace_back(e, bottom = 0)

--- a/tests/testthat/test-trace-collapse-evalq.txt
+++ b/tests/testthat/test-trace-collapse-evalq.txt
@@ -4,17 +4,13 @@ Full:
   ├─base::evalq(g())
   │ └─base::evalq(g())
   └─rlang:::g()
-    └─base::evalq(trace_back(e))
-      └─base::evalq(trace_back(e))
 
 Collapsed:
 █
 └─rlang:::f()
   ├─[ base::evalq(...) ] with 1 more call
   └─rlang:::g()
-    └─[ base::evalq(...) ] with 1 more call
 
 Branch:
  ─rlang:::f()
  ─rlang:::g()
- ─[ base::evalq(...) ] with 1 more call

--- a/tests/testthat/test-trace-collapse-evalq.txt
+++ b/tests/testthat/test-trace-collapse-evalq.txt
@@ -4,13 +4,19 @@ Full:
   ├─base::evalq(g())
   │ └─base::evalq(g())
   └─rlang:::g()
+    ├─base::evalq(trace_back(e, trim = 0))
+    │ └─base::evalq(trace_back(e, trim = 0))
+    └─rlang::trace_back(e, trim = 0)
 
 Collapsed:
 █
 └─rlang:::f()
   ├─[ base::evalq(...) ] with 1 more call
   └─rlang:::g()
+    ├─[ base::evalq(...) ] with 1 more call
+    └─rlang::trace_back(e, trim = 0)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g()
+ ─rlang::trace_back(e, trim = 0)

--- a/tests/testthat/test-trace-collapsed1.txt
+++ b/tests/testthat/test-trace-collapsed1.txt
@@ -15,6 +15,9 @@ Full:
       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
       └─rlang:::i()
+        ├─base::tryCatch(trace_back(e, trim = 0)) testthat/test-trace.R:48:20
+        │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
+        └─rlang::trace_back(e, trim = 0)
 
 Collapsed:
 █
@@ -24,9 +27,12 @@ Collapsed:
     └─rlang:::h()
       ├─[ base::tryCatch(...) ] with 3 more calls testthat/test-trace.R:47:20
       └─rlang:::i()
+        ├─[ base::tryCatch(...) ] with 1 more call testthat/test-trace.R:48:20
+        └─rlang::trace_back(e, trim = 0)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g() testthat/test-trace.R:45:20
  ─rlang:::h()
  ─rlang:::i()
+ ─rlang::trace_back(e, trim = 0)

--- a/tests/testthat/test-trace-collapsed1.txt
+++ b/tests/testthat/test-trace-collapsed1.txt
@@ -15,8 +15,6 @@ Full:
       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
       └─rlang:::i()
-        └─base::tryCatch(trace_back(e)) testthat/test-trace.R:48:20
-          └─base:::tryCatchList(expr, classes, parentenv, handlers)
 
 Collapsed:
 █
@@ -26,13 +24,9 @@ Collapsed:
     └─rlang:::h()
       ├─[ base::tryCatch(...) ] with 3 more calls testthat/test-trace.R:47:20
       └─rlang:::i()
-        └─base::tryCatch(trace_back(e)) testthat/test-trace.R:48:20
-          └─base:::tryCatchList(expr, classes, parentenv, handlers)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g() testthat/test-trace.R:45:20
  ─rlang:::h()
  ─rlang:::i()
- ─base::tryCatch(trace_back(e)) testthat/test-trace.R:48:20
- ─base:::tryCatchList(expr, classes, parentenv, handlers)

--- a/tests/testthat/test-trace-collapsed1.txt
+++ b/tests/testthat/test-trace-collapsed1.txt
@@ -15,9 +15,9 @@ Full:
       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
       └─rlang:::i()
-        ├─base::tryCatch(trace_back(e, trim = 0)) testthat/test-trace.R:48:20
+        ├─base::tryCatch(trace_back(e, bottom = 0)) testthat/test-trace.R:48:20
         │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
-        └─rlang::trace_back(e, trim = 0)
+        └─rlang::trace_back(e, bottom = 0)
 
 Collapsed:
 █
@@ -28,11 +28,11 @@ Collapsed:
       ├─[ base::tryCatch(...) ] with 3 more calls testthat/test-trace.R:47:20
       └─rlang:::i()
         ├─[ base::tryCatch(...) ] with 1 more call testthat/test-trace.R:48:20
-        └─rlang::trace_back(e, trim = 0)
+        └─rlang::trace_back(e, bottom = 0)
 
 Branch:
  ─rlang:::f()
  ─rlang:::g() testthat/test-trace.R:45:20
  ─rlang:::h()
  ─rlang:::i()
- ─rlang::trace_back(e, trim = 0)
+ ─rlang::trace_back(e, bottom = 0)

--- a/tests/testthat/test-trace-trim.txt
+++ b/tests/testthat/test-trace-trim.txt
@@ -1,0 +1,36 @@
+No trimming:
+█
+└─rlang:::f(0)
+  ├─base::identity(identity(g(n)))
+  ├─base::identity(g(n))
+  └─rlang:::g(n)
+    ├─base::identity(identity(h(n)))
+    ├─base::identity(h(n))
+    └─rlang:::h(n)
+      ├─base::identity(identity(trace_back(e, trim = n)))
+      ├─base::identity(trace_back(e, trim = n))
+      └─rlang::trace_back(e, trim = n)
+
+
+One layer (the default):
+█
+└─rlang:::f(1)
+  ├─base::identity(identity(g(n)))
+  ├─base::identity(g(n))
+  └─rlang:::g(n)
+    ├─base::identity(identity(h(n)))
+    ├─base::identity(h(n))
+    └─rlang:::h(n)
+
+
+Two layers:
+█
+└─rlang:::f(2)
+  ├─base::identity(identity(g(n)))
+  ├─base::identity(g(n))
+  └─rlang:::g(n)
+
+
+Three layers:
+█
+└─rlang:::f(3)

--- a/tests/testthat/test-trace-trim.txt
+++ b/tests/testthat/test-trace-trim.txt
@@ -7,9 +7,9 @@ No trimming:
     ├─base::identity(identity(h(n)))
     ├─base::identity(h(n))
     └─rlang:::h(n)
-      ├─base::identity(identity(trace_back(e, trim = n)))
-      ├─base::identity(trace_back(e, trim = n))
-      └─rlang::trace_back(e, trim = n)
+      ├─base::identity(identity(trace_back(e, bottom = n)))
+      ├─base::identity(trace_back(e, bottom = n))
+      └─rlang::trace_back(e, bottom = n)
 
 
 One layer (the default):

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -45,7 +45,7 @@ test_that("can print tree with collapsed branches", {
   f <- function() { g() }
   g <- function() { tryCatch(h(), foo = identity, bar = identity) }
   h <- function() { tryCatch(i(), baz = identity) }
-  i <- function() { tryCatch(trace_back(e, trim = 0)) }
+  i <- function() { tryCatch(trace_back(e, bottom = 0)) }
   trace <- eval(quote(f()))
 
   expect_known_trace_output(trace,
@@ -192,13 +192,13 @@ test_that("eval() frames are collapsed", {
 
   e <- current_env()
   f <- function() base::eval(quote(g()))
-  g <- function() eval(quote(trace_back(e, trim = 0)))
+  g <- function() eval(quote(trace_back(e, bottom = 0)))
   trace <- f()
 
   expect_known_trace_output(trace, file = "test-trace-collapse-eval.txt")
 
   f <- function() base::evalq(g())
-  g <- function() evalq(trace_back(e, trim = 0))
+  g <- function() evalq(trace_back(e, bottom = 0))
   trace <- f()
 
   expect_known_trace_output(trace, file = "test-trace-collapse-evalq.txt")
@@ -494,7 +494,7 @@ test_that("can trim layers of backtraces", {
   e <- current_env()
   f <- function(n) identity(identity(g(n)))
   g <- function(n) identity(identity(h(n)))
-  h <- function(n) identity(identity(trace_back(e, trim = n)))
+  h <- function(n) identity(identity(trace_back(e, bottom = n)))
 
   trace0 <- f(0)
   trace1 <- f(1)
@@ -521,7 +521,7 @@ test_that("can trim layers of backtraces", {
   e <- current_env()
   f <- function(n) identity(identity(g(n)))
   g <- function(n) identity(identity(h(n)))
-  h <- function(n) identity(identity(trace_back(e, trim = caller_env(n - 1L))))
+  h <- function(n) identity(identity(trace_back(e, bottom = caller_env(n - 1L))))
 
   trace1_env <- f(1)
   trace2_env <- f(2)

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -487,3 +487,33 @@ test_that("global functions have `global::` prefix", {
 
   expect_known_trace_output(trace, file = "test-trace-global-prefix.txt")
 })
+
+test_that("can trim layers of backtraces", {
+  skip_on_os("windows")
+
+  e <- current_env()
+  f <- function(n) identity(identity(g(n)))
+  g <- function(n) identity(identity(h(n)))
+  h <- function(n) identity(identity(trace_back(e, trim = n)))
+
+  trace0 <- f(0)
+  trace1 <- f(1)
+  trace2 <- f(2)
+  trace3 <- f(3)
+
+  expect_known_output(file = test_path("test-trace-trim.txt"), {
+    scoped_options(rlang_trace_format_srcrefs = FALSE)
+
+    cat_line("No trimming:")
+    summary(trace0)
+
+    cat_line("", "", "One layer (the default):")
+    summary(trace1)
+
+    cat_line("", "", "Two layers:")
+    summary(trace2)
+
+    cat_line("", "", "Three layers:")
+    summary(trace3)
+  })
+})

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -516,4 +516,18 @@ test_that("can trim layers of backtraces", {
     cat_line("", "", "Three layers:")
     summary(trace3)
   })
+
+  # Test that trimming with frame environment is equivalent
+  e <- current_env()
+  f <- function(n) identity(identity(g(n)))
+  g <- function(n) identity(identity(h(n)))
+  h <- function(n) identity(identity(trace_back(e, trim = caller_env(n - 1L))))
+
+  trace1_env <- f(1)
+  trace2_env <- f(2)
+  trace3_env <- f(3)
+
+  expect_equal_trace(trace1, trace1_env)
+  expect_equal_trace(trace2, trace2_env)
+  expect_equal_trace(trace3, trace3_env)
 })

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -45,7 +45,7 @@ test_that("can print tree with collapsed branches", {
   f <- function() { g() }
   g <- function() { tryCatch(h(), foo = identity, bar = identity) }
   h <- function() { tryCatch(i(), baz = identity) }
-  i <- function() { tryCatch(trace_back(e)) }
+  i <- function() { tryCatch(trace_back(e, trim = 0)) }
   trace <- eval(quote(f()))
 
   expect_known_trace_output(trace,
@@ -192,13 +192,13 @@ test_that("eval() frames are collapsed", {
 
   e <- current_env()
   f <- function() base::eval(quote(g()))
-  g <- function() eval(quote(trace_back(e)))
+  g <- function() eval(quote(trace_back(e, trim = 0)))
   trace <- f()
 
   expect_known_trace_output(trace, file = "test-trace-collapse-eval.txt")
 
   f <- function() base::evalq(g())
-  g <- function() evalq(trace_back(e))
+  g <- function() evalq(trace_back(e, trim = 0))
   trace <- f()
 
   expect_known_trace_output(trace, file = "test-trace-collapse-evalq.txt")


### PR DESCRIPTION
~Includes #660 to avoid merge conflicts with the namespaced backtraces.~

Closes #491
Closes #521