### PR TITLE
Take `.fn` argument in `exec()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang 0.3.0.9000
 
+* `exec()` takes `.fn` as first argument instead of `f`, for
+  consistency with other rlang functions.
+
 * Fixed infinite loop with quosures created inside a data mask.
 
 * Base errors set as `parent` of rlang errors are now printed

--- a/R/exec.R
+++ b/R/exec.R
@@ -1,8 +1,9 @@
 #' Execute a function
 #'
 #' @description
-#' This function constructs and evaluates a call to `f`.
-#' It was two primary uses:
+#'
+#' This function constructs and evaluates a call to `.fn`.
+#' It has two primary uses:
 #'
 #' * To call a function with arguments stored in a list (if the function
 #'   doesn't support [tidy-dots])
@@ -10,7 +11,7 @@
 #' * To call every function stored in a list (in conjunction with `map()`/
 #'   [lapply()])
 #'
-#' @param f A function, or function name as a string.
+#' @param .fn A function, or function name as a string.
 #' @param ... Arguments to function.
 #'
 #'   These dots support [tidy-dots] features.
@@ -42,11 +43,11 @@
 #' # with carefully constructed bindings
 #' data_env <- env(data = mtcars)
 #' eval(expr(lm(!!f, data)), data_env)
-exec <- function(f, ..., .env = caller_env()) {
+exec <- function(.fn, ..., .env = caller_env()) {
   args <- list2(...)
   args <- map(args, sym_protect)
 
-  do.call(f, args, envir = .env)
+  do.call(.fn, args, envir = .env)
 }
 
 sym_protect <- function(x) {
@@ -56,4 +57,3 @@ sym_protect <- function(x) {
     x
   }
 }
-

--- a/man/exec.Rd
+++ b/man/exec.Rd
@@ -4,10 +4,10 @@
 \alias{exec}
 \title{Execute a function}
 \usage{
-exec(f, ..., .env = caller_env())
+exec(.fn, ..., .env = caller_env())
 }
 \arguments{
-\item{f}{A function, or function name as a string.}
+\item{.fn}{A function, or function name as a string.}
 
 \item{...}{Arguments to function.
 
@@ -17,8 +17,8 @@ These dots support \link{tidy-dots} features.}
 most useful if \code{f} is a string, or the function has side-effects.}
 }
 \description{
-This function constructs and evaluates a call to \code{f}.
-It was two primary uses:
+This function constructs and evaluates a call to \code{.fn}.
+It has two primary uses:
 \itemize{
 \item To call a function with arguments stored in a list (if the function
 doesn't support \link{tidy-dots})


### PR DESCRIPTION
Small overlook, the argument to `exec()` isn't prefixed with a dot and uses the particle for formulas instead of function. Shouldn't have any consequences on revdeps since that's a new function and only the first argument is renamed.