### PR TITLE
Add default argument to maybe_missing()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
+* `maybe_missing()` gains a `default` argument.
 
 # rlang 0.3.2.9000
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -91,8 +91,8 @@ chr_enumerate <- function(chr, sep = ", ", final = "or") {
 #'   lists.
 #'
 #' * `maybe_missing()` is useful to pass down an input that might be
-#'   missing to another function. It avoids triggering an
-#'   "argument is missing" error.
+#'   missing to another function, potentially substituting by a
+#'   default value. It avoids triggering an "argument is missing" error.
 #'
 #'
 #' @section Other ways to reify the missing argument:
@@ -202,10 +202,12 @@ is_missing <- function(x) {
 }
 
 #' @rdname missing_arg
+#' @param default The object to return if the input is missing,
+#'   defaults to `missing_arg()`.
 #' @export
-maybe_missing <- function(x) {
+maybe_missing <- function(x, default = missing_arg()) {
   if (is_missing(x)) {
-    missing_arg()
+    default
   } else {
     x
   }

--- a/man/missing_arg.Rd
+++ b/man/missing_arg.Rd
@@ -10,10 +10,13 @@ missing_arg()
 
 is_missing(x)
 
-maybe_missing(x)
+maybe_missing(x, default = missing_arg())
 }
 \arguments{
 \item{x}{An object that might be the missing argument.}
+
+\item{default}{The object to return if the input is missing,
+defaults to \code{missing_arg()}.}
 }
 \description{
 These functions help using the missing argument as a regular R
@@ -24,8 +27,8 @@ object.
 testing for missing arguments contained in other objects like
 lists.
 \item \code{maybe_missing()} is useful to pass down an input that might be
-missing to another function. It avoids triggering an
-"argument is missing" error.
+missing to another function, potentially substituting by a
+default value. It avoids triggering an "argument is missing" error.
 }
 }
 \section{Other ways to reify the missing argument}{


### PR DESCRIPTION
Occasionally it's useful to substitute missing values by other values, e.g. explicit `NULL`.