### PR TITLE
Add `r_on_exit_callback()`

### DIFF
--- a/R/rlang.R
+++ b/R/rlang.R
@@ -17,3 +17,7 @@ is_same_body <- NULL
 .onUnload <- function(lib) {
   .Call(rlang_library_unload)
 }
+
+callback <- function(fn, data) {
+  .Call(rlang_callback, fn, data)
+}

--- a/src/Makevars
+++ b/src/Makevars
@@ -37,6 +37,7 @@ internal-files = \
         internal/expr-interp-rotate.c \
         internal/internal.c \
         internal/quo.c \
+        internal/stack.c \
         internal/utils.c
 
 export-files = \

--- a/src/export/exported-tests.c
+++ b/src/export/exported-tests.c
@@ -4,6 +4,17 @@ sexp* rlang_r_string(sexp* str) {
   return STRING_ELT(str, 0);
 }
 
+static void cb(void* data) {
+  const char* msg = (const char*) data;
+  r_inform(msg);
+}
+
+sexp* rlang_test_onexit() {
+  r_on_exit_callback(cb, "foo");
+  r_on_exit_callback(cb, "bar");
+  r_abort("tilt");
+}
+
 
 // chr.c
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -112,6 +112,8 @@ extern sexp* rlang_env_inherits(sexp*, sexp*);
 extern sexp* rlang_eval_top(sexp*, sexp*);
 extern sexp* rlang_attrib(sexp*);
 extern sexp* rlang_named(sexp*, sexp*);
+extern sexp* rlang_callback(sexp*, sexp*);
+extern void rlang_on_exit_callback(void (*fn)(void*), void* data);
 
 // Library initialisation defined below
 sexp* rlang_library_load();
@@ -135,6 +137,7 @@ extern sexp* rlang_test_Rf_warningcall(sexp*, sexp*);
 extern sexp* rlang_test_Rf_errorcall(sexp*, sexp*);
 extern sexp* rlang_test_lgl_sum(sexp*, sexp*);
 extern sexp* rlang_test_lgl_which(sexp*, sexp*);
+extern sexp* rlang_test_onexit();
 
 static const r_callable r_callables[] = {
   {"r_init_library",                    (r_fn_ptr) &r_init_library, 0},
@@ -263,6 +266,8 @@ static const r_callable r_callables[] = {
   {"rlang_eval_top",                    (r_fn_ptr) &rlang_eval_top, 2},
   {"rlang_attrib",                      (r_fn_ptr) &rlang_attrib, 1},
   {"rlang_named",                       (r_fn_ptr) &rlang_named, 2},
+  {"rlang_callback",                    (r_fn_ptr) &rlang_callback, 2},
+  {"rlang_test_onexit",                 (r_fn_ptr) &rlang_test_onexit, 0},
   {NULL, NULL, 0}
 };
 
@@ -284,6 +289,9 @@ void R_init_rlang(r_dll_info* dll) {
 
   // eval_tidy() is stable
   r_register_c_callable("rlang", "rlang_eval_tidy", (r_fn_ptr) &rlang_eval_tidy);
+
+  // Experimental
+  r_register_c_callable("rlang", "rlang_on_exit_callback", (r_fn_ptr) &rlang_on_exit_callback);
 
   // Experimental method for exporting C function pointers as actual R objects
   rlang_register_pointer("rlang", "rlang_test_is_spliceable", (r_fn_ptr) &rlang_is_clevel_spliceable);

--- a/src/internal.c
+++ b/src/internal.c
@@ -7,4 +7,5 @@
 #include "internal/expr-interp-rotate.c"
 #include "internal/internal.c"
 #include "internal/quo.c"
+#include "internal/stack.c"
 #include "internal/utils.c"

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -10,11 +10,13 @@ sexp* as_list_s4_call = NULL;
 void rlang_init_dots();
 void rlang_init_expr_interp();
 void rlang_init_eval_tidy();
+void rlang_init_stack();
 
 void rlang_init_internal() {
   rlang_init_dots();
   rlang_init_expr_interp();
   rlang_init_eval_tidy();
+  rlang_init_stack();
 
   rlang_zap = rlang_ns_get("zap!");
 

--- a/src/internal/stack.c
+++ b/src/internal/stack.c
@@ -1,0 +1,20 @@
+#include <rlang.h>
+
+// Initialised at load time
+static sexp* fns_callback;
+
+
+void rlang_on_exit_callback(void (*fn)(void*), void* data) {
+  sexp* fn_extptr = KEEP(R_MakeExternalPtrFn((r_fn_ptr) fn, r_null, r_null));
+  sexp* data_extptr = KEEP(R_MakeExternalPtr(data, r_null, r_null));
+  sexp* call = KEEP(Rf_lang3(fns_callback, fn_extptr, data_extptr));
+
+  sexp* frame = KEEP(r_current_frame());
+  r_on_exit(call, frame);
+
+  FREE(4);
+}
+
+void rlang_init_stack() {
+  fns_callback = rlang_ns_get("callback");
+}

--- a/src/internal/utils.c
+++ b/src/internal/utils.c
@@ -19,3 +19,12 @@ void signal_soft_deprecated(const char* msg) {
     r_warn(msg);
   }
 }
+
+sexp* rlang_callback(sexp* ptr, sexp* data) {
+  void (*fn_ptr)(void*) = (void (*)(void*)) R_ExternalPtrAddrFn(ptr);
+  void* data_ptr = EXTPTR_PTR(data);
+
+  fn_ptr(data_ptr);
+
+  return r_null;
+}

--- a/src/internal/utils.h
+++ b/src/internal/utils.h
@@ -6,6 +6,7 @@ sexp* new_preserved_empty_list();
 void signal_soft_deprecated(const char* msg);
 sexp* rlang_ns_get(const char* name);
 sexp* rlang_enquo(sexp* sym, sexp* frame);
+sexp* rlang_callback(sexp* ptr, sexp* data);
 
 
 #endif

--- a/src/lib/rlang.c
+++ b/src/lib/rlang.c
@@ -81,6 +81,8 @@ SEXP r_init_library() {
   r_quo_get_env = (sexp* (*)(sexp*)) r_peek_c_callable("rlang", "rlang_quo_get_env");
   r_quo_set_env = (sexp* (*)(sexp*, sexp*)) r_peek_c_callable("rlang", "rlang_quo_set_env");
 
+  r_on_exit_callback = (void (*)(void (*)(void*), void*)) r_peek_c_callable("rlang", "rlang_on_exit_callback");
+
   /* parse.c - r_ops_precedence[] */
   RLANG_ASSERT((sizeof(r_ops_precedence) / sizeof(struct r_op_precedence)) == R_OP_MAX);
 

--- a/src/lib/stack.h
+++ b/src/lib/stack.h
@@ -3,6 +3,8 @@
 
 
 void r_on_exit(sexp* expr, sexp* frame);
+void (*r_on_exit_callback)(void (*fn)(void*), void* data);
+
 
 sexp* r_current_frame();
 sexp* r_sys_frame(int n, sexp* frame);

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -446,3 +446,14 @@ test_that("r_lgl_which() handles empty vectors", {
   expect_identical(r_lgl_which(lgl(), TRUE), int())
   expect_identical(r_lgl_which(lgl(), FALSE), int())
 })
+
+test_that("r_on_exit_callback() calls back", {
+  test_onexit <- function() .Call(rlang_test_onexit)
+
+  msg <- NULL
+  withCallingHandlers(
+    message = function(cnd) msg <<- c(msg, cnd$message),
+    expect_error(test_onexit())
+  )
+  expect_identical(msg, c("foo\n", "bar\n"))
+})


### PR DESCRIPTION
`rlang_on_exit_callback` is an exported C callable that pushes an `on_exit()` event in the current call frame (typically the `.Call()` wrapper) to call back a C function with data.

The C library exposes it as `r_on_exit_callback()`.

It could be renamed to `r_on_exit()` if we find a better name for the version that takes R code to evaluate. In general it seems simpler to pass a C callback because you don't need to worry about scoping of the R code then, so the callback variant might end up more useful.