### PR TITLE
Emphasize `.x` (over `.`) in as_function() docs

### DIFF
--- a/R/fn.R
+++ b/R/fn.R
@@ -379,9 +379,9 @@ fn_env <- function(fn) {
 #'
 #' \Sexpr[results=rd, stage=render]{rlang:::lifecycle("stable")}
 #'
-#' * `as_function()` transform objects to functions. It fetches
-#'   functions by name if supplied a string or transforms formulas to
-#'   function.
+#' * `as_function()` transforms an object into a function. It fetches
+#'   the function by name, for string input, or turns a one-sided formula
+#'   into a function.
 #'
 #' * `as_closure()` first passes its argument to `as_function()`. If
 #'   the result is a primitive function, it regularises it to a proper
@@ -392,7 +392,9 @@ fn_env <- function(fn) {
 #'   If a **function**, it is used as is.
 #'
 #'   If a **formula**, e.g. `~ .x + 2`, it is converted to a function
-#'   with two arguments, `.x` or `.` and `.y`. This allows you to
+#'   with up to two arguments: `.x` (single argument) or `.x` and `.y`
+#'   (two arguments). The `.` placeholder can be used instead of `.x`.
+#'   This allows you to
 #'   create very compact anonymous functions with up to two inputs.
 #'   Functions created from formulas have a special class. Use
 #'   `is_lambda()` to test for it.
@@ -400,8 +402,14 @@ fn_env <- function(fn) {
 #'   is a string.
 #' @export
 #' @examples
-#' f <- as_function(~ . + 1)
+#' f <- as_function(~ .x + 1)
 #' f(10)
+#'
+#' g <- as_function(~ -1 * .)
+#' g(4)
+#'
+#' h <- as_function(~ .x - .y)
+#' h(6, 3)
 #'
 #' # Functions created from a formula have a special class:
 #' is_lambda(f)

--- a/R/fn.R
+++ b/R/fn.R
@@ -394,10 +394,9 @@ fn_env <- function(fn) {
 #'   If a **formula**, e.g. `~ .x + 2`, it is converted to a function
 #'   with up to two arguments: `.x` (single argument) or `.x` and `.y`
 #'   (two arguments). The `.` placeholder can be used instead of `.x`.
-#'   This allows you to
-#'   create very compact anonymous functions with up to two inputs.
-#'   Functions created from formulas have a special class. Use
-#'   `is_lambda()` to test for it.
+#'   This allows you to create very compact anonymous functions with up
+#'   to two inputs. Functions created from formulas have a special
+#'   class. Use `is_lambda()` to test for it.
 #' @param env Environment in which to fetch the function in case `x`
 #'   is a string.
 #' @export

--- a/man/as_function.Rd
+++ b/man/as_function.Rd
@@ -18,7 +18,9 @@ as_closure(x, env = caller_env())
 If a \strong{function}, it is used as is.
 
 If a \strong{formula}, e.g. \code{~ .x + 2}, it is converted to a function
-with two arguments, \code{.x} or \code{.} and \code{.y}. This allows you to
+with up to two arguments: \code{.x} (single argument) or \code{.x} and \code{.y}
+(two arguments). The \code{.} placeholder can be used instead of \code{.x}.
+This allows you to
 create very compact anonymous functions with up to two inputs.
 Functions created from formulas have a special class. Use
 \code{is_lambda()} to test for it.}
@@ -29,17 +31,23 @@ is a string.}
 \description{
 \Sexpr[results=rd, stage=render]{rlang:::lifecycle("stable")}
 \itemize{
-\item \code{as_function()} transform objects to functions. It fetches
-functions by name if supplied a string or transforms formulas to
-function.
+\item \code{as_function()} transforms an object into a function. It fetches
+the function by name, for string input, or turns a one-sided formula
+into a function.
 \item \code{as_closure()} first passes its argument to \code{as_function()}. If
 the result is a primitive function, it regularises it to a proper
 \link{closure} (see \code{\link[=is_function]{is_function()}} about primitive functions).
 }
 }
 \examples{
-f <- as_function(~ . + 1)
+f <- as_function(~ .x + 1)
 f(10)
+
+g <- as_function(~ -1 * .)
+g(4)
+
+h <- as_function(~ .x - .y)
+h(6, 3)
 
 # Functions created from a formula have a special class:
 is_lambda(f)

--- a/man/as_function.Rd
+++ b/man/as_function.Rd
@@ -20,10 +20,9 @@ If a \strong{function}, it is used as is.
 If a \strong{formula}, e.g. \code{~ .x + 2}, it is converted to a function
 with up to two arguments: \code{.x} (single argument) or \code{.x} and \code{.y}
 (two arguments). The \code{.} placeholder can be used instead of \code{.x}.
-This allows you to
-create very compact anonymous functions with up to two inputs.
-Functions created from formulas have a special class. Use
-\code{is_lambda()} to test for it.}
+This allows you to create very compact anonymous functions with up
+to two inputs. Functions created from formulas have a special
+class. Use \code{is_lambda()} to test for it.}
 
 \item{env}{Environment in which to fetch the function in case \code{x}
 is a string.}


### PR DESCRIPTION
Some recent discussions elsewhere have affirmed my sense that `.x` is better to emphasize in anonymous function, as opposed to `.`. Specifically, in dplyr pipelines, I think it's best if people associate `.` with the primary data frame that is being piped and use `.x` when writing a lambda in scoped verbs.
