### PR TITLE
Allow %|% to work when y is of same length as x

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # rlang 0.4.0.9000
 
+## Bugfixes and small improvements
+
+* `x %|% y` now also works when `y` is of same length as `x` (@rcannood, #806).
+
 # rlang 0.4.0
 
 ## Tidy evaluation

--- a/R/operators.R
+++ b/R/operators.R
@@ -20,14 +20,17 @@
 #' and provides a default value for missing elements. It is faster
 #' than using [base::ifelse()] and does not perform type conversions.
 #'
-#' @param x,y `y` for elements of `x` that are NA; otherwise, `x`.
+#' @param x The original values.
+#' @param y The replacement values. Must be of length 1 or the same length as `x`.
 #' @export
 #' @name op-na-default
 #' @seealso [op-null-default]
 #' @examples
 #' c("a", "b", NA, "c") %|% "default"
+#' c(1L, NA, 3L, NA, NA) %|% (6L:10L)
 `%|%` <- function(x, y) {
-  stopifnot(is_atomic(x) && is_scalar_atomic(y))
+  stopifnot(is_atomic(x) && is_atomic(y))
+  stopifnot(length(y) == 1 || length(y) == length(x))
   stopifnot(typeof(x) == typeof(y))
   .Call(rlang_replace_na, x, y)
 }

--- a/man/op-na-default.Rd
+++ b/man/op-na-default.Rd
@@ -8,7 +8,9 @@
 x \%|\% y
 }
 \arguments{
-\item{x, y}{\code{y} for elements of \code{x} that are NA; otherwise, \code{x}.}
+\item{x}{The original values.}
+
+\item{y}{The replacement values. Must be of length 1 or the same length as \code{x}.}
 }
 \description{
 This infix function is similar to \code{\%||\%} but is vectorised
@@ -17,6 +19,7 @@ than using \code{\link[base:ifelse]{base::ifelse()}} and does not perform type c
 }
 \examples{
 c("a", "b", NA, "c") \%|\% "default"
+c(1L, NA, 3L, NA, NA) \%|\% (6L:10L)
 }
 \seealso{
 \link{op-null-default}

--- a/src/lib/replace-na.c
+++ b/src/lib/replace-na.c
@@ -1,6 +1,7 @@
 #include "rlang.h"
 
 static sexp* replace_na_(sexp* x, sexp* replacement, int start);
+static sexp* replace_na_vec_(sexp* x, sexp* replacement, int start);
 
 sexp* rlang_replace_na(sexp* x, sexp* replacement) {
   int n = r_length(x);
@@ -62,10 +63,12 @@ sexp* rlang_replace_na(sexp* x, sexp* replacement) {
   }
   }
 
-  if (i < n) {
+  if (i == n) {
+    return x;
+  } else if (r_length(replacement) == 1) {
     return replace_na_(x, replacement, i);
   } else {
-    return x;
+    return replace_na_vec_(x, replacement, i);
   }
 }
 
@@ -124,6 +127,70 @@ static sexp* replace_na_(sexp* x, sexp* replacement, int i) {
     for (; i < n; ++i) {
       if (ISNA(arr[i].r)) {
         arr[i] = new_value;
+      }
+    }
+    break;
+  }
+
+  default: {
+    r_abort("Don't know how to handle object of type", Rf_type2char(r_typeof(x)));
+  }
+  }
+
+  FREE(1);
+  return x;
+}
+
+
+static sexp* replace_na_vec_(sexp* x, sexp* replacement, int i) {
+  KEEP(x = Rf_duplicate(x));
+  int n = r_length(x);
+
+  switch(r_typeof(x)) {
+  case LGLSXP: {
+    int* arr = LOGICAL(x);
+    for (; i < n; ++i) {
+      if (arr[i] == NA_LOGICAL) {
+        arr[i] = LOGICAL(replacement)[i];
+      }
+    }
+    break;
+  }
+
+  case INTSXP: {
+    int* arr = INTEGER(x);
+    for (; i < n; ++i) {
+      if (arr[i] == NA_INTEGER) {
+        arr[i] = INTEGER(replacement)[i];
+      }
+    }
+    break;
+  }
+
+  case REALSXP: {
+    double* arr = REAL(x);
+    for (; i < n; ++i) {
+      if (ISNA(arr[i])) {
+        arr[i] = REAL(replacement)[i];
+      }
+    }
+    break;
+  }
+
+  case STRSXP: {
+    for (; i < n; ++i) {
+      if (STRING_ELT(x, i) == NA_STRING) {
+        SET_STRING_ELT(x, i, STRING_ELT(replacement, i));
+      }
+    }
+    break;
+  }
+
+  case CPLXSXP: {
+    r_complex_t* arr = COMPLEX(x);
+    for (; i < n; ++i) {
+      if (ISNA(arr[i].r)) {
+        arr[i] = COMPLEX(replacement)[i];
       }
     }
     break;

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -17,9 +17,31 @@ test_that("%|% returns default value", {
   expect_equal(cpx, c(1i, 2i, 3i, 4i))
 })
 
+test_that("%|% also works when y is of same length as x", {
+  lgl <- c(TRUE, TRUE, NA, FALSE) %|% c(TRUE, TRUE, FALSE, TRUE)
+  expect_identical(lgl, c(TRUE, TRUE, FALSE, FALSE))
+
+  int <- c(1L, 2L, NA, 4L) %|% c(10L, 11L, 12L, 13L)
+  expect_identical(int, c(1L, 2L, 12L, 4L))
+
+  dbl <- c(1, 2, NA, 4) %|% c(10, 11, 12, 13)
+  expect_identical(dbl, c(1, 2, 12, 4))
+
+  chr <- c("1", "2", NA, "4") %|% c("10", "11", "12", "13")
+  expect_identical(chr, c("1", "2", "12", "4"))
+
+  cpx <- c(1i, 2i, NA, 4i) %|% c(10i, 11i, 12i, 13i)
+  expect_equal(cpx, c(1i, 2i, 12i, 4i))
+})
+
 test_that("%|% fails with wrong types", {
   expect_error(c(1L, NA) %|% 2)
   expect_error(c(1, NA) %|% "")
+})
+
+test_that("%|% fails with wrong length", {
+  expect_error(c(1L, NA) %|% 1:3)
+  expect_error(1:10 %|% 1:4)
 })
 
 test_that("%@% returns attribute", {


### PR DESCRIPTION
These changes allow `x %|% y` when `y` is of same length as `x`. For example:
```r
> c(1L, NA, 3L, NA, NA) %|% 0L # usual use case
[1] 1 0 3 0 0
> c(1L, NA, 3L, NA, NA) %|% (6L:10L) # modified use case
[1]  1  7  3  9 10
```

Changes: 
 * `R/operators.R`: I modified the documentation of %|% to reflect the changes in behaviour of this function. I also modified the `stopifnot()` checks accordingly.
 * `src/lib/replace-na.c`: Rather than looking at the length of `y` in `replace_na_()`, I created a separate function `replace_na_vec_()` and call the correct function depending on the length of `y`, as not to sacrifice speed by having more if/else statements.
 * `tests/testthat/test-operators.R`: I added tests to check whether `x %|% y` is working correctly when `length(y) == length(x)`, and also that it produces an error when it is not.