### PR TITLE
changed outdated doc reference to fn_fmls

### DIFF
--- a/R/fn.R
+++ b/R/fn.R
@@ -224,15 +224,13 @@ fn_body_node <- function(fn) {
 #' partial matching, etc). One practical consequence of the special
 #' way in which primitives are passed arguments is that they
 #' technically do not have formal arguments, and [formals()] will
-#' return `NULL` if called on a primitive function. See [fn_fmls()]
-#' for a function that returns a representation of formal arguments
-#' for primitive functions. Finally, primitive functions can either
-#' take arguments lazily, like R closures do, or evaluate them eagerly
-#' before being passed on to the C code. The former kind of primitives
-#' are called "special" in R terminology, while the latter is referred
-#' to as "builtin". `is_primitive_eager()` and `is_primitive_lazy()`
-#' allow you to check whether a primitive function evaluates arguments
-#' eagerly or lazily.
+#' return `NULL` if called on a primitive function. Finally, primitive 
+#' functions can either take arguments lazily, like R closures do, 
+#' or evaluate them eagerly before being passed on to the C code. 
+#' The former kind of primitives are called "special" in R terminology, 
+#' while the latter is referred to as "builtin". `is_primitive_eager()` 
+#' and `is_primitive_lazy()` allow you to check whether a primitive 
+#' function evaluates arguments eagerly or lazily.
 #'
 #' You will also encounter the distinction between primitive and
 #' internal functions in technical documentation. Like primitive

--- a/man/is_function.Rd
+++ b/man/is_function.Rd
@@ -46,15 +46,13 @@ argument matching (dealing with positional versus named arguments,
 partial matching, etc). One practical consequence of the special
 way in which primitives are passed arguments is that they
 technically do not have formal arguments, and \code{\link[=formals]{formals()}} will
-return \code{NULL} if called on a primitive function. See \code{\link[=fn_fmls]{fn_fmls()}}
-for a function that returns a representation of formal arguments
-for primitive functions. Finally, primitive functions can either
-take arguments lazily, like R closures do, or evaluate them eagerly
-before being passed on to the C code. The former kind of primitives
-are called "special" in R terminology, while the latter is referred
-to as "builtin". \code{is_primitive_eager()} and \code{is_primitive_lazy()}
-allow you to check whether a primitive function evaluates arguments
-eagerly or lazily.
+return \code{NULL} if called on a primitive function. Finally, primitive
+functions can either take arguments lazily, like R closures do,
+or evaluate them eagerly before being passed on to the C code.
+The former kind of primitives are called "special" in R terminology,
+while the latter is referred to as "builtin". \code{is_primitive_eager()}
+and \code{is_primitive_lazy()} allow you to check whether a primitive
+function evaluates arguments eagerly or lazily.
 
 You will also encounter the distinction between primitive and
 internal functions in technical documentation. Like primitive


### PR DESCRIPTION
The `is_function()` documentation refers to `fn_fmls()` as a "function that returns a representation of formal arguments for primitive functions", which is no longer true as of rlang v 0.4.0 (but was true for rlang v0.3.1). `fn_fmls()` currently throw an error for primitives. 

From the `fn_fmls()` doc page: 

> Unlike `formals()`, these helpers throw an error with primitive functions instead of returning NULL.

As a side note, I'm a little salty about this loss of functionality. Does `rlang` now not have a way of accessing primitive function arguments?