### PR TITLE
Simplify branch backtraces further

### DIFF
--- a/R/trace.R
+++ b/R/trace.R
@@ -524,6 +524,17 @@ is_eval_call <- function(call) {
   is_call(call, c("eval", "evalq"), ns = c("", "base"))
 }
 
+lexical_parent <- function(parents, id) {
+  parent <- parents[[id]]
+
+  # `eval()` frame cause XXX
+  if (is.na(parent) || parent >= id) {
+    NA
+  } else {
+    parent
+  }
+}
+
 trace_simplify_branch <- function(trace) {
   parents <- trace$parents
   lexical_parents <- trace$clo_parents
@@ -543,7 +554,7 @@ trace_simplify_branch <- function(trace) {
       id <- next_id
     }
 
-    while (!is.na(lexical_parent <- lexical_parents[[id]])) {
+    while (!is.na(lexical_parent <- lexical_parent(lexical_parents, id))) {
       id <- lexical_parent
     }
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -88,7 +88,9 @@ trace_back <- function(top = NULL, bottom = NULL) {
   envs <- map(frames, env_label)
 
   clo_parents <- map_chr(idx, function(i) env_label(fn_env(sys.function(i))))
-  clo_parents <- match(clo_parents, envs)
+  global <- clo_parents == "global"
+  clo_parents <- match(clo_parents, as.character(envs))
+  clo_parents[global] <- 1L
 
   trace <- new_trace(calls, parents, envs, clo_parents)
   trace <- trace_trim_env(trace, top)

--- a/R/trace.R
+++ b/R/trace.R
@@ -647,6 +647,7 @@ trail_uncollapse_pipe <- function(trace) {
 
 trace_simplify_branch <- function(trace) {
   parents <- trace$parents
+  lexical_parents <- trace$clo_parents
   path <- int()
   id <- length(parents)
 
@@ -661,6 +662,10 @@ trace_simplify_branch <- function(trace) {
       parents[[id + 1L]] <- next_id
 
       id <- next_id
+    }
+
+    while (!is.na(lexical_parent <- lexical_parents[[id]])) {
+      id <- lexical_parent
     }
 
     if (!is_uninformative_call(trace$calls[[id]])) {

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -327,13 +327,13 @@ test_that("on_error option can be tweaked", {
 test_that("format_onerror_backtrace handles empty and size 1 traces", {
   scoped_options(rlang_backtrace_on_error = "branch")
 
-  trace <- new_trace(list(), int(), chr())
+  trace <- new_trace(list(), int(), chr(), int())
   expect_identical(format_onerror_backtrace(trace), NULL)
 
-  trace <- new_trace(list(quote(foo)), int(0), chr(""))
+  trace <- new_trace(list(quote(foo)), int(0), chr(""), int(NA))
   expect_identical(format_onerror_backtrace(trace), NULL)
 
-  trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1), chr("", ""))
+  trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1), chr("", ""), int(NA, NA))
   expect_match(format_onerror_backtrace(trace), "foo.*bar")
 })
 

--- a/tests/testthat/test-trace-collapse-magrittr-before-after1.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-before-after1.txt
@@ -14,10 +14,15 @@ Full:
 Collapsed:
      █
   1. ├─[ rlang:::F(...) ]
-  2. └─[ NA %>% T() ] with 7 more calls
- 10.   └─rlang:::T(.)
+  2. └─NA %>% T()
+  3.   ├─[ base::withVisible(...) ]
+  4.   └─[ base::eval(...) ] with 1 more call
+  6.     └─rlang:::`_fseq`(`_lhs`)
+  7.       └─magrittr::freduce(value, `_function_list`)
+  8.         ├─[ base::withVisible(...) ]
+  9.         └─function_list[[k]](value)
+ 10.           └─rlang:::T(.)
 
 Branch:
   1. rlang:::F(NA %>% T())
-  2. rlang:::T(.)
- 10. rlang:::F(NA %>% T())
+ 10. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr-before-after2.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-before-after2.txt
@@ -13,11 +13,16 @@ Full:
 
 Collapsed:
      █
-  1. └─[ NA %>% C() ] with 7 more calls
-  9.   └─rlang:::C(.)
- 10.     └─rlang:::f()
+  1. └─NA %>% C()
+  2.   ├─[ base::withVisible(...) ]
+  3.   └─[ base::eval(...) ] with 1 more call
+  5.     └─rlang:::`_fseq`(`_lhs`)
+  6.       └─magrittr::freduce(value, `_function_list`)
+  7.         ├─[ base::withVisible(...) ]
+  8.         └─function_list[[k]](value)
+  9.           └─rlang:::C(.)
+ 10.             └─rlang:::f()
 
 Branch:
-  1. rlang:::C(.)
-  9. rlang:::f()
- 10. rlang:::C(.)
+  9. rlang:::C(.)
+ 10. rlang:::f()

--- a/tests/testthat/test-trace-collapse-magrittr-before-after3.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-before-after3.txt
@@ -15,12 +15,17 @@ Full:
 Collapsed:
      █
   1. ├─[ rlang:::F(...) ]
-  2. └─[ NA %>% C() ] with 7 more calls
- 10.   └─rlang:::C(.)
- 11.     └─rlang:::f()
+  2. └─NA %>% C()
+  3.   ├─[ base::withVisible(...) ]
+  4.   └─[ base::eval(...) ] with 1 more call
+  6.     └─rlang:::`_fseq`(`_lhs`)
+  7.       └─magrittr::freduce(value, `_function_list`)
+  8.         ├─[ base::withVisible(...) ]
+  9.         └─function_list[[k]](value)
+ 10.           └─rlang:::C(.)
+ 11.             └─rlang:::f()
 
 Branch:
   1. rlang:::F(NA %>% C())
-  2. rlang:::C(.)
- 10. rlang:::f()
- 11. rlang:::F(NA %>% C())
+ 10. rlang:::C(.)
+ 11. rlang:::f()

--- a/tests/testthat/test-trace-collapse-magrittr-children.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-children.txt
@@ -14,14 +14,18 @@ Full:
 
 Collapsed:
      █
-  1. └─[ NA %>% F() %>% G() %>% H() ] with 7 more calls
-  9.   └─rlang:::H(.)
- 10.     └─rlang:::f()
- 11.       └─rlang:::h()
+  1. └─NA %>% F() %>% G() %>% H()
+  2.   ├─[ base::withVisible(...) ]
+  3.   └─[ base::eval(...) ] with 1 more call
+  5.     └─rlang:::`_fseq`(`_lhs`)
+  6.       └─magrittr::freduce(value, `_function_list`)
+  7.         ├─[ base::withVisible(...) ]
+  8.         └─function_list[[k]](value)
+  9.           └─rlang:::H(.)
+ 10.             └─rlang:::f()
+ 11.               └─rlang:::h()
 
 Branch:
-  1. rlang:::F(.)
-  9. rlang:::G(.)
- 10. rlang:::H(.)
- 11. rlang:::f()
-  1. rlang:::h()
+  9. rlang:::H(.)
+ 10. rlang:::f()
+ 11. rlang:::h()

--- a/tests/testthat/test-trace-collapse-magrittr-complete-leading1.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-complete-leading1.txt
@@ -12,9 +12,14 @@ Full:
 
 Collapsed:
     █
- 1. └─[ F(NA) %>% T() ] with 7 more calls
- 9.   └─rlang:::T(.)
+ 1. └─F(NA) %>% T()
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         ├─[ base::withVisible(...) ]
+ 8.         └─function_list[[k]](value)
+ 9.           └─rlang:::T(.)
 
 Branch:
- 1. rlang:::F(NA)
  9. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr-complete-leading2.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-complete-leading2.txt
@@ -12,10 +12,14 @@ Full:
 
 Collapsed:
     █
- 1. └─[ F(NA) %>% F() %>% T() ] with 7 more calls
- 9.   └─rlang:::T(.)
+ 1. └─F(NA) %>% F() %>% T()
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         ├─[ base::withVisible(...) ]
+ 8.         └─function_list[[k]](value)
+ 9.           └─rlang:::T(.)
 
 Branch:
- 1. rlang:::F(NA)
- 9. rlang:::F(.)
- 1. rlang:::T(.)
+ 9. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr-complete1.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-complete1.txt
@@ -12,9 +12,14 @@ Full:
 
 Collapsed:
     █
- 1. └─[ NA %>% T() ] with 7 more calls
- 9.   └─rlang:::T(.)
+ 1. └─NA %>% T()
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         ├─[ base::withVisible(...) ]
+ 8.         └─function_list[[k]](value)
+ 9.           └─rlang:::T(.)
 
 Branch:
- 1. rlang:::T(.)
  9. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr-complete2.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-complete2.txt
@@ -12,9 +12,14 @@ Full:
 
 Collapsed:
     █
- 1. └─[ NA %>% F() %>% T() ] with 7 more calls
- 9.   └─rlang:::T(.)
+ 1. └─NA %>% F() %>% T()
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         ├─[ base::withVisible(...) ]
+ 8.         └─function_list[[k]](value)
+ 9.           └─rlang:::T(.)
 
 Branch:
- 1. rlang:::F(.)
  9. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr-incomplete-leading2.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-incomplete-leading2.txt
@@ -11,10 +11,13 @@ Full:
 
 Collapsed:
     █
- 1. └─[ F(NA) %>% F() %>% T() %>% F() %>% F() ] with 6 more calls
- 8.   └─rlang:::T(.)
+ 1. └─F(NA) %>% F() %>% T() %>% F() %>% F()
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         └─function_list[[i]](value)
+ 8.           └─rlang:::T(.)
 
 Branch:
- 1. rlang:::F(NA)
- 8. rlang:::F(.)
- 1. rlang:::T(.)
+ 8. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr-incomplete.txt
+++ b/tests/testthat/test-trace-collapse-magrittr-incomplete.txt
@@ -11,9 +11,13 @@ Full:
 
 Collapsed:
     █
- 1. └─[ NA %>% F() %>% T() %>% F() %>% F() ] with 6 more calls
- 8.   └─rlang:::T(.)
+ 1. └─NA %>% F() %>% T() %>% F() %>% F()
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         └─function_list[[i]](value)
+ 8.           └─rlang:::T(.)
 
 Branch:
- 1. rlang:::F(.)
  8. rlang:::T(.)

--- a/tests/testthat/test-trace-collapse-magrittr.txt
+++ b/tests/testthat/test-trace-collapse-magrittr.txt
@@ -12,10 +12,14 @@ Full:
 
 Collapsed:
     █
- 1. └─[ NULL %>% f() %>% g(1, 2) %>% h(3, ., 4) ] with 7 more calls
- 9.   └─rlang:::h(3, ., 4)
+ 1. └─NULL %>% f() %>% g(1, 2) %>% h(3, ., 4)
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         ├─[ base::withVisible(...) ]
+ 8.         └─function_list[[k]](value)
+ 9.           └─rlang:::h(3, ., 4)
 
 Branch:
- 1. rlang:::f(.)
- 9. rlang:::g(., 1, 2)
- 1. rlang:::h(3, ., 4)
+ 9. rlang:::h(3, ., 4)

--- a/tests/testthat/test-trace-collapse-magrittr2.txt
+++ b/tests/testthat/test-trace-collapse-magrittr2.txt
@@ -12,10 +12,14 @@ Full:
 
 Collapsed:
     █
- 1. └─[ f(NULL) %>% g(list(.)) %>% h(3, ., list(.)) ] with 7 more calls
- 9.   └─rlang:::h(3, ., list(.))
+ 1. └─f(NULL) %>% g(list(.)) %>% h(3, ., list(.))
+ 2.   ├─[ base::withVisible(...) ]
+ 3.   └─[ base::eval(...) ] with 1 more call
+ 5.     └─rlang:::`_fseq`(`_lhs`)
+ 6.       └─magrittr::freduce(value, `_function_list`)
+ 7.         ├─[ base::withVisible(...) ]
+ 8.         └─function_list[[k]](value)
+ 9.           └─rlang:::h(3, ., list(.))
 
 Branch:
- 1. rlang:::f(NULL)
- 9. rlang:::g(., list(.))
- 1. rlang:::h(3, ., list(.))
+ 9. rlang:::h(3, ., list(.))

--- a/tests/testthat/test-trace-collapse-magrittr3.txt
+++ b/tests/testthat/test-trace-collapse-magrittr3.txt
@@ -14,10 +14,15 @@ Full:
 Collapsed:
      █
   1. ├─[ rlang:::f(...) ]
-  2. └─[ g(NULL %>% f()) %>% h() ] with 7 more calls
- 10.   └─rlang:::h(.)
+  2. └─g(NULL %>% f()) %>% h()
+  3.   ├─[ base::withVisible(...) ]
+  4.   └─[ base::eval(...) ] with 1 more call
+  6.     └─rlang:::`_fseq`(`_lhs`)
+  7.       └─magrittr::freduce(value, `_function_list`)
+  8.         ├─[ base::withVisible(...) ]
+  9.         └─function_list[[k]](value)
+ 10.           └─rlang:::h(.)
 
 Branch:
   1. rlang:::f(g(NULL %>% f()) %>% h())
-  2. rlang:::g(NULL %>% f())
  10. rlang:::h(.)

--- a/tests/testthat/test-trace-lexical-eval-frame-global.txt
+++ b/tests/testthat/test-trace-lexical-eval-frame-global.txt
@@ -12,5 +12,4 @@ Collapsed:
 
 Branch:
  1. rlang:::dothis()
- 2. base::eval(expr(dothat(!!e)), globalenv())
- 3. base::eval(expr(dothat(!!e)), globalenv())
+ 4. global::dothat(<environment>)

--- a/tests/testthat/test-trace-lexical-eval-frame-global.txt
+++ b/tests/testthat/test-trace-lexical-eval-frame-global.txt
@@ -1,0 +1,16 @@
+Full:
+    █
+ 1. ├─rlang:::dothis()
+ 2. │ └─base::eval(expr(dothat(!!e)), globalenv())
+ 3. │   └─base::eval(expr(dothat(!!e)), globalenv())
+ 4. └─global::dothat(<environment>)
+
+Collapsed:
+    █
+ 1. ├─[ rlang:::dothis() ] with 2 more calls
+ 4. └─global::dothat(<environment>)
+
+Branch:
+ 1. rlang:::dothis()
+ 2. base::eval(expr(dothat(!!e)), globalenv())
+ 3. base::eval(expr(dothat(!!e)), globalenv())

--- a/tests/testthat/test-trace-lexical-eval-frame.txt
+++ b/tests/testthat/test-trace-lexical-eval-frame.txt
@@ -1,0 +1,10 @@
+Full:
+    █
+ 1. └─rlang:::dothat()
+
+Collapsed:
+    █
+ 1. └─rlang:::dothat()
+
+Branch:
+ 1. rlang:::dothat()

--- a/tests/testthat/test-trace-lexical-named.txt
+++ b/tests/testthat/test-trace-lexical-named.txt
@@ -1,0 +1,14 @@
+Full:
+    █
+ 1. └─rlang:::f()
+ 2.   └─rlang:::g()
+ 3.     └─rlang:::h()
+
+Collapsed:
+    █
+ 1. └─rlang:::f()
+ 2.   └─rlang:::g()
+ 3.     └─rlang:::h()
+
+Branch:
+ 1. rlang:::f()

--- a/tests/testthat/test-trace-lexical-nested.txt
+++ b/tests/testthat/test-trace-lexical-nested.txt
@@ -1,0 +1,18 @@
+Full:
+    █
+ 1. └─rlang:::f()
+ 2.   └─base::lapply(NA, function(x) lapply(NA, function(y) trace_back(e)))
+ 3.     └─rlang:::FUN(X[[i]], ...)
+ 4.       └─base::lapply(NA, function(y) trace_back(e))
+ 5.         └─rlang:::FUN(X[[i]], ...)
+
+Collapsed:
+    █
+ 1. └─rlang:::f()
+ 2.   └─base::lapply(NA, function(x) lapply(NA, function(y) trace_back(e)))
+ 3.     └─rlang:::FUN(X[[i]], ...)
+ 4.       └─base::lapply(NA, function(y) trace_back(e))
+ 5.         └─rlang:::FUN(X[[i]], ...)
+
+Branch:
+ 1. rlang:::f()

--- a/tests/testthat/test-trace-lexical.txt
+++ b/tests/testthat/test-trace-lexical.txt
@@ -1,0 +1,14 @@
+Full:
+    █
+ 1. └─rlang:::f()
+ 2.   └─base::lapply(NA, function(x) trace_back(e))
+ 3.     └─rlang:::FUN(X[[i]], ...)
+
+Collapsed:
+    █
+ 1. └─rlang:::f()
+ 2.   └─base::lapply(NA, function(x) trace_back(e))
+ 3.     └─rlang:::FUN(X[[i]], ...)
+
+Branch:
+ 1. rlang:::f()

--- a/tests/testthat/test-trace-parasite-eval.txt
+++ b/tests/testthat/test-trace-parasite-eval.txt
@@ -1,0 +1,15 @@
+Full:
+    █
+ 1. └─rlang:::f()
+ 2.   ├─base::eval(quote(g()))
+ 3.   │ └─base::eval(quote(g()))
+ 4.   └─rlang:::g()
+
+Collapsed:
+    █
+ 1. └─rlang:::f()
+ 2.   ├─[ base::eval(...) ] with 1 more call
+ 4.   └─rlang:::g()
+
+Branch:
+ 1. rlang:::f()

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -266,26 +266,6 @@ test_that("children of collapsed frames are rechained to correct parent", {
   })
 })
 
-test_that("pipe_collect_calls() collects calls", {
-  exprs2 <- function(...) unname(exprs(...))
-  placeholder <- function() NULL
-
-  call <- quote(a(A %>% B) %>% b)
-  out <- pipe_collect_calls(call, placeholder)
-  expect_identical(out$calls, exprs2(rlang:::a(A %>% B), rlang:::b(.)))
-  expect_true(out$leading)
-
-  call <- quote(a %>% b %>% c)
-  out <- pipe_collect_calls(call, placeholder)
-  expect_identical(out$calls, exprs2(rlang:::b(.), rlang:::c(.)))
-  expect_false(out$leading)
-
-  call <- quote(a() %>% b %>% c)
-  out <- pipe_collect_calls(call, placeholder)
-  expect_identical(out$calls, exprs2(rlang:::a(), rlang:::b(.), rlang:::c(.)))
-  expect_true(out$leading)
-})
-
 test_that("combinations of incomplete and leading pipes collapse properly", {
   skip_unless_utf8()
   skip_if_not_installed("magrittr")

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -623,3 +623,27 @@ test_that("caught error does not display backtrace in knitted files", {
   error_line <- lines[[length(lines)]]
   expect_match(error_line, "foo$")
 })
+
+test_that("branch backtraces respect lexical contexts", {
+  skip_unless_utf8()
+
+  e <- environment()
+
+  f <- function() lapply(NA, function(x) trace_back(e))
+  trace <- f()[[1]]
+  expect_known_trace_output(trace, file = "test-trace-lexical.txt")
+
+  f <- function() lapply(NA, function(x) lapply(NA, function(y) trace_back(e)))
+  trace <- f()[[1]][[1]]
+  expect_known_trace_output(trace, file = "test-trace-lexical-nested.txt")
+
+  f <- function() {
+    g <- function(x) {
+      h <- function(y) trace_back(e)
+      h()
+    }
+    g()
+  }
+  trace <- f()
+  expect_known_trace_output(trace, file = "test-trace-lexical-named.txt")
+})

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -406,13 +406,13 @@ test_that("collapsing of eval() frames detects when error occurs within eval()",
 test_that("can print degenerate backtraces", {
   skip_unless_utf8()
 
-  trace_sym <- new_trace(list(quote(foo)), int(0), chr(""))
+  trace_sym <- new_trace(list(quote(foo)), int(0), chr(""), int(NA))
   expect_known_trace_output(trace_sym, file = "test-trace-degenerate-sym.txt")
 
-  trace_null <- new_trace(list(NULL), int(0), chr(""))
+  trace_null <- new_trace(list(NULL), int(0), chr(""), int(NA))
   expect_known_trace_output(trace_null, file = "test-trace-degenerate-null.txt")
 
-  trace_scalar <- new_trace(list(1L), int(0), chr(""))
+  trace_scalar <- new_trace(list(1L), int(0), chr(""), int(NA))
   expect_known_trace_output(trace_scalar, file = "test-trace-degenerate-scalar.txt")
 })
 


### PR DESCRIPTION
This increases the simplification of branch backtraces by keeping track of lexical contexts of local closures. If a call frame A is hosted by a closure that was created on the stack at frame B, the latter frame is treated as the parent of A.

The main effect of this change is to merge all frames implicated in the invokation of the local closure, as well as the frame of the closure itself. It's as if the code was run from the function that created the closure:

```r
f <- function() lapply(NA, function(x) trace_back())
trace <- f()[[1]]

trace
#>     █
#>  1. └─global::f()
#>  2.   └─base::lapply(NA, function(x) trace_back())
#>  3.     └─FUN(X[[i]], ...)

print(trace, simplify = "branch")
#>  1. global::f()

```

This behaviour is recursive:

```r
f <- function() lapply(NA, function(x) lapply(NA, function(y) trace_back()))
trace <- f()[[1]][[1]]

trace
#>     █
#>  1. └─global::f()
#>  2.   └─base::lapply(NA, function(x) lapply(NA, function(y) trace_back()))
#>  3.     └─FUN(X[[i]], ...)
#>  4.       └─base::lapply(NA, function(y) trace_back())
#>  5.         └─FUN(X[[i]], ...)

print(trace, simplify = "branch")
#>  1. global::f()
```

This also applies to named local closures:

```r
f <- function() {
  g <- function(x) {
    h <- function(y) trace_back()
    h()
  }
  g()
}
trace <- f()

trace
#>     █
#>  1. └─global::f()
#>  2.   └─g()
#>  3.     └─h()

print(trace, simplify = "branch")
#>  1. global::f()
```

I think ideally we'd preserve the call frames of named closures, however R does not allow distinguishing between named and anonymous functions.

This automatically simplifies magrittr backtraces in a range of cases, though not all of them. I have removed the complex, difficult to maintain and buggy unrolling code in favour a simpler frame trimming to take care of the remaining cases of complex magrittr backtraces. This way we can experiment with terser backtraces, and if unrolling turns out better we could tackle it as part of tidyverse/magrittr#175.