### PR TITLE
Add entrace to index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -64,6 +64,7 @@ reference:
       - signal
       - trace_back
       - with_abort
+      - entrace
   - title: Evaluate expressions
     contents:
       - eval_tidy


### PR DESCRIPTION
There is a bunch of other functions missing:

Warning: Topics missing from index: are_na, as_label, as_name, as_string, as_utf8_character, caller_fn, catch_cnd, cnd, cnd_muffle, cnd_signal, cnd_type, done, dots_n, dots_values, env_bury, env_lock, has_length, has_name, is_callable, is_condition, is_copyable, is_named, is_reference, is_stack, lang_head, last_error, lifecycle, missing, new-vector-along-retired, new-vector, pairlist2, prim_name, restarting, return_from, rlang_backtrace_on_error, rst_abort, rst_list, string, with_env, with_restarts

For questioning/deprecated functions, do we want a "Retired functions" section, or do we use `@keywords internal`?