### PR TITLE
Improve display of backtraces of parent errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 
 # rlang (development)
 
+* The display of rlang errors derived from parent errors has been
+  improved. The simplified backtrace (as printed by
+  `rlang::last_error()`) no longer includes the parent errors. On the
+  other hand, the full backtrace (as printed by `rlang::last_trace()`)
+  now includes the backtraces of the parent errors.
+
 * `cnd_signal()` has improved support for rlang errors created with
   `error_cnd()`. It now records a backtrace if there isn't one
   already, and saves the error so it can be inspected with

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -583,6 +583,9 @@ print.rlang_error <- function(x,
                               child = NULL,
                               simplify = c("branch", "collapse", "none"),
                               fields = FALSE) {
+  # Allow overwriting default display via condition field
+  simplify <- x$print_simplify %||% simplify
+
   class <- class(x)[[1]]
   if (class != "error") {
     class <- paste0("error/", class)
@@ -627,13 +630,13 @@ print.rlang_error <- function(x,
     cat_line(trace_lines)
   }
 
-  if (!is_null(x$parent)) {
+  if (simplify != "branch" && !is_null(x$parent)) {
     print.rlang_error(x$parent, ..., child = x, simplify = simplify, fields = fields)
   }
 
   # Recommend printing the full backtrace. Only do it after having
   # printed all parent errors first.
-  if (simplify == "branch" && is_null(x$parent) && !is_null(trace)) {
+  if (simplify == "branch" && is_null(child) && !is_null(trace)) {
     cat_line(silver("Call `rlang::last_trace()` to see the full backtrace."))
   }
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -769,7 +769,9 @@ last_error <- function() {
 #' @rdname last_error
 #' @export
 last_trace <- function() {
-  last_error()$trace
+  err <- last_error()
+  err$print_simplify <- "none"
+  err
 }
 
 

--- a/tests/testthat/test-cnd-error-parent-default.txt
+++ b/tests/testthat/test-cnd-error-parent-default.txt
@@ -5,12 +5,6 @@ Backtrace:
   8. rlang:::a()
   9. rlang:::b()
  10. rlang:::c()
-<parent: error/foobar>
-Low-level message
-Backtrace:
- 1. rlang:::f()
- 2. rlang:::g()
- 3. rlang:::h()
 Call `rlang::last_trace()` to see the full backtrace.
 <error/rlang_error>
 High-level message
@@ -19,10 +13,4 @@ Backtrace:
   9. rlang:::a()
  10. rlang:::b()
  11. rlang:::c()
-<parent: error/foobar>
-Low-level message
-Backtrace:
- 1. rlang:::f()
- 2. rlang:::g()
- 3. rlang:::h()
 Call `rlang::last_trace()` to see the full backtrace.

--- a/tests/testthat/test-cnd-error-parent-full.txt
+++ b/tests/testthat/test-cnd-error-parent-full.txt
@@ -1,4 +1,3 @@
-Full:
 <error/rlang_error>
 High-level message
 Backtrace:
@@ -20,30 +19,3 @@ Backtrace:
  1. └─rlang:::f()
  2.   └─rlang:::g()
  3.     └─rlang:::h()
-
-Collapsed:
-<error/rlang_error>
-High-level message
-Backtrace:
-     █
-  1. ├─[ rlang::catch_cnd(...) ] with 6 more calls
-  8. └─rlang:::a()
-  9.   └─rlang:::b()
- 10.     └─rlang:::c()
-<parent: error/foobar>
-Low-level message
-Backtrace:
-    █
- 1. └─rlang:::f()
- 2.   └─rlang:::g()
- 3.     └─rlang:::h()
-
-Branch:
-<error/rlang_error>
-High-level message
-Backtrace:
-  1. rlang::catch_cnd(a())
-  8. rlang:::a()
-  9. rlang:::b()
- 10. rlang:::c()
-Call `rlang::last_trace()` to see the full backtrace.

--- a/tests/testthat/test-cnd-error-print-base-parent.txt
+++ b/tests/testthat/test-cnd-error-print-base-parent.txt
@@ -1,3 +1,1 @@
 <error/bar>
-<parent: error/simpleError>
-foo

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -303,6 +303,9 @@ test_that("error is printed with parent backtrace", {
     print(err)
     print(err_force)
   })
+  expect_known_output(file = test_path("test-cnd-error-parent-full.txt"), {
+    print(err, simplify = "none")
+  })
   expect_known_trace_output(err, file = "test-cnd-error-parent-trace.txt")
 })
 

--- a/tests/testthat/test-with-abort.txt
+++ b/tests/testthat/test-with-abort.txt
@@ -7,13 +7,6 @@ Backtrace:
   9. rlang:::a()
  10. rlang:::b()
  11. rlang:::c()
-<parent: error/rlang_error>
-Low-level message
-Backtrace:
- 1. rlang::with_abort(f())
- 3. rlang:::f()
- 4. rlang:::g()
- 5. rlang:::h()
 Call `rlang::last_trace()` to see the full backtrace.
 
 


### PR DESCRIPTION
The current display logic of the backtraces is kind of backwards when errors have parents.

Say we have this error which has one parent and one grand-parent:

```r
tidyselect::vars_rename(letters, new = 1.5)
#> Error: Must select with column names or positions.
#> x Lossy cast from `i` <double> to <integer>.
```

The simplified backtrace currently displays as:

```r
last_error()
#> <error/tidyselect_error_index_bad_type>
#> Must select with column names or positions.
#> x Lossy cast from `i` <double> to <integer>.
#> Backtrace:
#>  1. tidyselect::vars_rename(letters, new = 1.5)
#>  2. purrr::map_if(...) /Users/lionel/Dropbox/Projects/R/tidyverse/tidyselect/R/vars-rename.R:12:2
#>  3. purrr::map(.x[!sel], .else, ...)
#>  4. tidyselect:::.f(.x[[i]], ...)
#>  5. tidyselect::as_indices(., .vars)
#> <parent: error/vctrs_error_position_bad_type>
#> Must extract with a single position or name.
#> x Lossy cast from `i` <double> to <integer>.
#> Backtrace:
#>  1. vctrs::vec_coerce_position(x)
#>  2. vctrs:::maybe_get(vec_maybe_coerce_position(i)) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:229:2
#> <parent: error/vctrs_error_cast_lossy>
#> Lossy cast from `i` <double> to <integer>.
#> Locations: 1
#> Backtrace:
#>   1. rlang::is_null(x$error) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/utils.R:96:2
#>  13. vctrs:::vec_cast.integer.double(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/type-bare.R:198:2
#>  14. vctrs::maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/type-bare.R:218:2
#>  18. vctrs:::stop_lossy_cast(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/conditions.R:235:2
#>  19. vctrs:::stop_vctrs(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/conditions.R:259:2
```

While the full backtrace only shows the high level error:

```r
last_trace()
#>     █
#>  1. └─tidyselect::vars_rename(letters, new = 1.5)
#>  2.   └─purrr::map_if(...) /Users/lionel/Dropbox/Projects/R/tidyverse/tidyselect/R/vars-rename.R:12:2
#>  3.     └─purrr::map(.x[!sel], .else, ...)
#>  4.       └─tidyselect:::.f(.x[[i]], ...)
#>  5.         └─tidyselect::as_indices(., .vars)
```

This PR reverses the situation:

```r
last_error()
#> <error/tidyselect_error_index_bad_type>
#> Must select with column names or positions.
#> Backtrace:
#>  1. tidyselect::vars_rename(letters, new = 1.5)
#>  2. purrr::map_if(...) /Users/lionel/Dropbox/Projects/R/tidyverse/tidyselect/R/vars-rename.R:12:2
#>  3. purrr::map(.x[!sel], .else, ...)
#>  4. tidyselect:::.f(.x[[i]], ...)
#>  5. tidyselect::as_indices(., .vars)

last_trace()
#> <error/tidyselect_error_index_bad_type>
#> Must select with column names or positions.
#> Backtrace:
#>     █
#>  1. └─tidyselect::vars_rename(letters, new = 1.5)
#>  2.   └─purrr::map_if(...) /Users/lionel/Dropbox/Projects/R/tidyverse/tidyselect/R/vars-rename.R:12:2
#>  3.     └─purrr::map(.x[!sel], .else, ...)
#>  4.       └─tidyselect:::.f(.x[[i]], ...)
#>  5.         └─tidyselect::as_indices(., .vars)
#> <parent: error/vctrs_error_position_bad_type>
#> Backtrace:
#>     █
#>  1. └─vctrs::vec_coerce_position(x)
#>  2.   └─vctrs:::maybe_get(vec_maybe_coerce_position(i)) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:229:2
#> <parent: error/vctrs_error_cast_lossy>
#> Lossy cast from `i` <double> to <integer>.
#> Locations: 1
#> Backtrace:
#>      █
#>   1. ├─rlang::is_null(x$error) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/utils.R:96:2
#>   2. ├─vctrs:::vec_maybe_coerce_position(i) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:229:2
#>   3. │ └─vctrs:::vec_maybe_coerce_index(i) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:237:2
#>   4. │   ├─base::tryCatch(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:205:4
#>   5. │   │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>   6. │   │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>   7. │   │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>   8. │   ├─vctrs:::maybe(vec_coercible_cast(i, int(), x_arg = "i", to_arg = "")) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:205:4
#>   9. │   │ └─base::structure(list(value = value, error = error), class = "rlang_maybe") /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/utils.R:90:2
#>  10. │   └─vctrs:::vec_coercible_cast(i, int(), x_arg = "i", to_arg = "") /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/slice.R:205:4
#>  11. ├─vctrs:::vec_cast_dispatch(x = x, to = to, x_arg = x_arg, to_arg = to_arg) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/cast.R:153:2
#>  12. ├─vctrs::vec_cast.integer(x = x, to = to, x_arg = x_arg, to_arg = to_arg) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/cast.R:131:2
#>  13. └─vctrs:::vec_cast.integer.double(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/type-bare.R:198:2
#>  14.   └─vctrs::maybe_lossy_cast(out, x, to, lossy, x_arg = x_arg, to_arg = to_arg) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/type-bare.R:218:2
#>  15.     ├─base::withRestarts(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/conditions.R:235:2
#>  16.     │ └─base:::withOneRestart(expr, restarts[[1L]])
#>  17.     │   └─base:::doWithOneRestart(return(expr), restart)
#>  18.     └─vctrs:::stop_lossy_cast(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/conditions.R:235:2
#>  19.       └─vctrs:::stop_vctrs(...) /Users/lionel/Dropbox/Projects/R/hadley/vctrs/R/conditions.R:259:2
```