### PR TITLE
Warn on load when downstream dep is incompatible

### DIFF
--- a/R/rlang.R
+++ b/R/rlang.R
@@ -10,6 +10,14 @@ downstream_deps <- list(
 )
 
 check_downstream_dep <- function(dep, pkg) {
+  if (!isNamespaceLoaded(pkg)) {
+    setHook(
+      packageEvent(pkg, "onLoad"),
+      function(...) check_downstream_dep(dep, pkg)
+    )
+    return()
+  }
+
   min <- dep[["min"]]
   from <- dep[["from"]]
   stopifnot(

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -24,11 +24,26 @@ check_downstream_dep <- function(dep, pkg) {
 
   rlang_ver <- packageVersion("rlang")
 
-  warn(c(
-    sprintf("As of rlang %s, %s must be at least %s.", from, pkg, min),
-    x = sprintf("%s %s is not compatible with rlang %s.", pkg, ver, rlang_ver),
-    i = sprintf("Please update %s with `install.packages(\"%s\")`.", pkg, pkg)
-  ))
+  msg <- c(
+    sprintf("As of rlang %s, %s must be at least version %s.", from, pkg, min),
+    x = sprintf("%s %s is not compatible with rlang %s.", pkg, ver, rlang_ver)
+  )
+
+  os <- tolower(Sys.info()[["sysname"]])
+  if (os == "windows") {
+    url <- "https://github.com/jennybc/what-they-forgot/issues/62"
+    howto <- c(
+      i = "Updating packages requires precautions on Windows.",
+      i = sprintf("See <%s>.", url)
+    )
+  } else {
+    howto <- c(
+      i = sprintf("Please update %s with `install.packages(\"%s\")`.", pkg, pkg)
+    )
+  }
+  msg <- c(msg, howto)
+
+  warn(msg)
 }
 
 .onLoad <- function(lib, pkg) {

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -34,15 +34,15 @@ check_downstream_dep <- function(dep, pkg) {
 
   msg <- c(
     sprintf("As of rlang %s, %s must be at least version %s.", from, pkg, min),
-    x = sprintf("%s %s is not compatible with rlang %s.", pkg, ver, rlang_ver)
+    x = sprintf("%s %s is too old for rlang %s.", pkg, ver, rlang_ver)
   )
 
   os <- tolower(Sys.info()[["sysname"]])
   if (os == "windows") {
     url <- "https://github.com/jennybc/what-they-forgot/issues/62"
     howto <- c(
-      i = "Updating packages requires precautions on Windows.",
-      i = sprintf("See <%s>.", url)
+      i = sprintf("Please update %s to the latest version.", pkg),
+      i = sprintf("Updating packages on Windows requires precautions:\n  <%s>", url)
     )
   } else {
     howto <- c(

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -4,6 +4,33 @@ NULL
 # For cnd.R
 is_same_body <- NULL
 
+
+downstream_deps <- list(
+  dplyr = c(min = "0.8.0", from = "0.4.0")
+)
+
+check_downstream_dep <- function(dep, pkg) {
+  min <- dep[["min"]]
+  from <- dep[["from"]]
+  stopifnot(
+    !is_null(min),
+    !is_null(from)
+  )
+
+  ver <- packageVersion(pkg)
+  if (ver >= min) {
+    return()
+  }
+
+  rlang_ver <- packageVersion("rlang")
+
+  warn(c(
+    sprintf("As of rlang %s, %s must be at least %s.", from, pkg, min),
+    x = sprintf("%s %s is not compatible with rlang %s.", pkg, ver, rlang_ver),
+    i = sprintf("Please update %s with `install.packages(\"%s\")`.", pkg, pkg)
+  ))
+}
+
 .onLoad <- function(lib, pkg) {
   if (getRversion() < "3.5") {
     is_same_body <<- function(x, y) identical(x, y)
@@ -16,6 +43,8 @@ is_same_body <- NULL
 
   s3_register("pillar::pillar_shaft", "quosures", pillar_shaft.quosures)
   s3_register("pillar::type_sum", "quosures", type_sum.quosures)
+
+  map2(downstream_deps, names(downstream_deps), check_downstream_dep)
 }
 .onUnload <- function(lib) {
   .Call(rlang_library_unload)


### PR DESCRIPTION
A user mentioned a forward compatibility issue between rlang 0.4.0 and dplyr 0.7.8: https://github.com/tidyverse/dplyr/issues/4600.

As I'm about to release rlang 0.4.1, I'd like to experiment with a load-time warning to detect packages known to be forward-incompatible. Loading rlang with an old dplyr would give this warning:

```
Warning message:
As of rlang 0.4.0, dplyr must be at least version 0.8.0.
✖ dplyr 0.7.8 is too old for rlang 0.4.1.
ℹ Please update dplyr with `install.packages("dplyr")`.
```

On Windows platforms, we link to https://github.com/jennybc/what-they-forgot/issues/62 where the second comment provide a rough guide on proper updating of packages.

```
Warning message:
As of rlang 0.4.0, dplyr must be at least version 0.8.0.
✖ dplyr 0.7.8 is too old for rlang 0.4.1.
ℹ Please update dplyr to the latest version.
ℹ Updating packages on Windows requires precautions:
  <https://github.com/jennybc/what-they-forgot/issues/62>.
```
