### PR TITLE
Fix `class` parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 # rlang 0.4.2
 
+* The `.subclass` argument of `abort()`, `warn()` and `inform()` has
+  been renamed to `class`. This is for consistency with our
+  conventions for class constructors documented in
+  https://adv-r.hadley.nz/s3.html#s3-subclassing.
+
 * `inform()` now prints messages to the standard output by default in
   interactive sessions. This makes them appear more like normal output
   in IDEs such as RStudio. In non-interactive sessions, messages are

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -65,13 +65,17 @@
 #'   Experimental: Can also be a named character vector, in which case
 #'   the message is assembled as a list of bullets. See
 #'   [cnd_message()] to learn how names control the bulleted output.
-#' @param .subclass Subclass of the condition. This allows your users
+#' @param class Subclass of the condition. This allows your users
 #'   to selectively handle the conditions signalled by your functions.
 #' @param ... Additional data to be stored in the condition object.
 #' @param call Defunct as of rlang 0.4.0. Storing the full
 #'   backtrace is now preferred to storing a simple call.
 #' @param msg,type These arguments were renamed to `message` and
 #'   `.subclass` and are defunct as of rlang 0.4.0.
+#' @param .subclass This argument was renamed to `class` in rlang
+#'   0.4.2.  It will be deprecated in the next major version. This is
+#'   for consistency with our conventions for class constructors
+#'   documented in <https://adv-r.hadley.nz/s3.html#s3-subclassing>.
 #'
 #' @seealso [with_abort()] to convert all errors to rlang errors.
 #' @examples
@@ -129,13 +133,13 @@
 #' }
 #' @export
 abort <- function(message = "",
-                  .subclass = NULL,
+                  class = NULL,
                   ...,
                   trace = NULL,
-                  call = NULL,
+                  call,
                   parent = NULL,
-                  msg, type) {
-  validate_signal_args(msg, type, call)
+                  msg, type, .subclass) {
+  validate_signal_args(msg, type, call, .subclass)
 
   if (is_null(trace) && is_null(peek_option("rlang__disable_trace_capture"))) {
     # Prevents infloops when rlang throws during trace capture
@@ -153,7 +157,7 @@ abort <- function(message = "",
 
   message <- collapse_cnd_message(message)
 
-  cnd <- error_cnd(.subclass,
+  cnd <- error_cnd(class,
     ...,
     message = message,
     parent = parent,

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -91,11 +91,11 @@ validate_cnd_signal_args <- function(cnd, .cnd, .mufflable,
 
 #' @rdname abort
 #' @export
-warn <- function(message, .subclass = NULL, ..., call = NULL, msg, type) {
-  validate_signal_args(msg, type, call)
+warn <- function(message, class = NULL, ..., call, msg, type, .subclass) {
+  validate_signal_args(msg, type, call, .subclass)
 
   message <- collapse_cnd_message(message)
-  cnd <- warning_cnd(.subclass, ..., message = message)
+  cnd <- warning_cnd(class, ..., message = message)
   warning(cnd)
 }
 #' @rdname abort
@@ -108,16 +108,17 @@ warn <- function(message, .subclass = NULL, ..., call = NULL, msg, type) {
 #'   still filter out the messages easily by redirecting `stderr`.
 #' @export
 inform <- function(message,
-                   .subclass = NULL,
+                   class = NULL,
                    ...,
-                   call = NULL,
                    file = NULL,
+                   call,
                    msg,
-                   type) {
-  validate_signal_args(msg, type, call)
+                   type,
+                   .subclass) {
+  validate_signal_args(msg, type, call, .subclass)
 
   message <- collapse_cnd_message(message)
-  cnd <- message_cnd(.subclass, ..., message = message)
+  cnd <- message_cnd(class, ..., message = message)
 
   withRestarts(muffleMessage = function() NULL, {
     signalCondition(cnd)
@@ -128,22 +129,34 @@ inform <- function(message,
 }
 #' @rdname abort
 #' @export
-signal <- function(message, .subclass, ...) {
+signal <- function(message, class, ..., .subclass) {
+  if (!missing(.subclass)) {
+    deprecate_subclass(.subclass)
+  }
   message <- collapse_cnd_message(message)
-  cnd <- cnd(.subclass, ..., message = message)
+  cnd <- cnd(class, ..., message = message)
   cnd_signal(cnd)
 }
-validate_signal_args <- function(msg, type, call) {
+
+validate_signal_args <- function(msg, type, call, subclass, env = caller_env()) {
   if (!missing(msg)) {
     stop_defunct("`msg` has been renamed to `message` and is deprecated as of rlang 0.3.0")
   }
   if (!missing(type)) {
     stop_defunct("`type` has been renamed to `.subclass` and is deprecated as of rlang 0.3.0")
   }
-  if (!is_null(call)) {
+  if (!missing(call)) {
     stop_defunct("`call` is deprecated as of rlang 0.3.0")
   }
+  if (!missing(subclass)) {
+    deprecate_subclass(subclass, env = env)
+  }
 }
+# Allow until next major version
+deprecate_subclass <- function(subclass, env = caller_env()) {
+  env_bind(env, class = subclass)
+}
+
 #' @rdname abort
 #' @export
 interrupt <- function() {

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -13,7 +13,7 @@
 #' The `.type` and `.msg` arguments have been renamed to `.subclass`
 #' and `message`. They are deprecated as of rlang 0.3.0.
 #'
-#' @param .subclass The condition subclass.
+#' @param class The condition subclass.
 #' @param ... Named data fields stored inside the condition
 #'   object. These dots are evaluated with [explicit
 #'   splicing][tidy-dots].
@@ -21,6 +21,7 @@
 #'   condition when it is signalled.
 #' @param trace A `trace` object created by [trace_back()].
 #' @param parent A parent condition object created by [abort()].
+#' @inheritParams abort
 #' @seealso [cnd_signal()], [with_handlers()].
 #'
 #' @keywords internal
@@ -43,21 +44,30 @@
 #' # Signalling an error condition aborts the current computation:
 #' err <- error_cnd("foo", message = "I am an error")
 #' try(cnd_signal(err))
-cnd <- function(.subclass, ..., message = "") {
-  if (missing(.subclass)) {
+cnd <- function(class, ..., message = "", .subclass) {
+  if (!missing(.subclass)) {
+    deprecate_subclass(.subclass)
+  }
+  if (missing(class)) {
     abort("Bare conditions must be subclassed")
   }
-  .Call(rlang_new_condition, .subclass, message, dots_list(...))
+  .Call(rlang_new_condition, class, message, dots_list(...))
 }
 #' @rdname cnd
 #' @export
-warning_cnd <- function(.subclass = NULL, ..., message = "") {
-  .Call(rlang_new_condition, c(.subclass, "warning"), message, dots_list(...))
+warning_cnd <- function(class = NULL, ..., message = "", .subclass) {
+  if (!missing(.subclass)) {
+    deprecate_subclass(.subclass)
+  }
+  .Call(rlang_new_condition, c(class, "warning"), message, dots_list(...))
 }
 #' @rdname cnd
 #' @export
-message_cnd <- function(.subclass = NULL, ..., message = "") {
-  .Call(rlang_new_condition, c(.subclass, "message"), message, dots_list(...))
+message_cnd <- function(class = NULL, ..., message = "", .subclass) {
+  if (!missing(.subclass)) {
+    deprecate_subclass(.subclass)
+  }
+  .Call(rlang_new_condition, c(class, "message"), message, dots_list(...))
 }
 
 #' Is object a condition?

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -8,15 +8,15 @@
 \alias{interrupt}
 \title{Signal an error, warning, or message}
 \usage{
-abort(message = "", .subclass = NULL, ..., trace = NULL,
-  call = NULL, parent = NULL, msg, type)
+abort(message = "", class = NULL, ..., trace = NULL, call,
+  parent = NULL, msg, type, .subclass)
 
-warn(message, .subclass = NULL, ..., call = NULL, msg, type)
+warn(message, class = NULL, ..., call, msg, type, .subclass)
 
-inform(message, .subclass = NULL, ..., call = NULL, file = NULL, msg,
-  type)
+inform(message, class = NULL, ..., file = NULL, call, msg, type,
+  .subclass)
 
-signal(message, .subclass, ...)
+signal(message, class, ..., .subclass)
 
 interrupt()
 }
@@ -27,7 +27,7 @@ Experimental: Can also be a named character vector, in which case
 the message is assembled as a list of bullets. See
 \code{\link[=cnd_message]{cnd_message()}} to learn how names control the bulleted output.}
 
-\item{.subclass}{Subclass of the condition. This allows your users
+\item{class}{Subclass of the condition. This allows your users
 to selectively handle the conditions signalled by your functions.}
 
 \item{...}{Additional data to be stored in the condition object.}
@@ -41,6 +41,11 @@ backtrace is now preferred to storing a simple call.}
 
 \item{msg, type}{These arguments were renamed to \code{message} and
 \code{.subclass} and are defunct as of rlang 0.4.0.}
+
+\item{.subclass}{This argument was renamed to \code{class} in rlang
+0.4.2.  It will be deprecated in the next major version. This is
+for consistency with our conventions for class constructors
+documented in \url{https://adv-r.hadley.nz/s3.html#s3-subclassing}.}
 
 \item{file}{Where the message is printed. This should be a
 connection or character string which will be passed to \code{\link[=cat]{cat()}}.

--- a/man/cnd.Rd
+++ b/man/cnd.Rd
@@ -10,14 +10,17 @@
 error_cnd(.subclass = NULL, ..., message = "", trace = NULL,
   parent = NULL)
 
-cnd(.subclass, ..., message = "")
+cnd(class, ..., message = "", .subclass)
 
-warning_cnd(.subclass = NULL, ..., message = "")
+warning_cnd(class = NULL, ..., message = "", .subclass)
 
-message_cnd(.subclass = NULL, ..., message = "")
+message_cnd(class = NULL, ..., message = "", .subclass)
 }
 \arguments{
-\item{.subclass}{The condition subclass.}
+\item{.subclass}{This argument was renamed to \code{class} in rlang
+0.4.2.  It will be deprecated in the next major version. This is
+for consistency with our conventions for class constructors
+documented in \url{https://adv-r.hadley.nz/s3.html#s3-subclassing}.}
 
 \item{...}{Named data fields stored inside the condition
 object. These dots are evaluated with \link[=tidy-dots]{explicit splicing}.}
@@ -28,6 +31,8 @@ condition when it is signalled.}
 \item{trace}{A \code{trace} object created by \code{\link[=trace_back]{trace_back()}}.}
 
 \item{parent}{A parent condition object created by \code{\link[=abort]{abort()}}.}
+
+\item{class}{The condition subclass.}
 }
 \description{
 These constructors make it easy to create subclassed conditions.

--- a/tests/testthat/test-cnd-signal.R
+++ b/tests/testthat/test-cnd-signal.R
@@ -87,3 +87,13 @@ test_that("deprecated arguments of cnd_signal() still work", {
     foo = calling(function(cnd) expect_true(rst_exists("rlang_muffle")))
   )
 })
+
+test_that("can still use `.subclass`", {
+  expect_error(abort("foo", .subclass = "baz"), class = "baz")
+  expect_warning(warn("foo", .subclass = "baz"), class = "baz")
+  expect_message(inform("foo", .subclass = "baz"), class = "baz")
+  expect_is(cnd(.subclass = "baz"), "baz")
+  expect_is(error_cnd(.subclass = "baz"), "baz")
+  expect_is(warning_cnd(.subclass = "baz"), "baz")
+  expect_is(message_cnd(.subclass = "baz"), "baz")
+})


### PR DESCRIPTION
Branched from #865.
Progress towards #862.

Renames `.subclass` to `class` in condition constructors. The old arguments are still fully allowed because this is a patch release.