### PR TITLE
Parameterize truncation when deparsing vectors and lists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -313,6 +313,9 @@
 
 * Infix operators now stick to their LHS when deparsed by
   `expr_deparse()` (#890).
+  
+* `expr_print()` and `expr_deparse()` accept the optional argument
+  `max_elements` to control truncation of vectors and lists (@ianmcook, #897)
 
 
 # rlang 0.4.2

--- a/R/expr.R
+++ b/R/expr.R
@@ -390,11 +390,14 @@ expr_print <- function(x, ...) {
 }
 #' @rdname expr_print
 #' @export
-  deparser <- new_quo_deparser(width = width)
-  quo_deparse(x, deparser, max_elements)
 expr_deparse <- function(x,
                          ...,
                          width = peek_option("width"),
                          max_elements = 5L) {
   check_dots_empty(...)
+  deparser <- new_quo_deparser(
+    width = width,
+    max_elements = max_elements
+  )
+  quo_deparse(x, deparser)
 }

--- a/R/expr.R
+++ b/R/expr.R
@@ -354,6 +354,8 @@ switch_expr <- function(.x, ...) {
 #' @param x An object or expression to print.
 #' @param width The width of the deparsed or printed expression.
 #'   Defaults to the global option `width`.
+#' @param max_elements Maximum length of a vector or list before truncation
+#'   occurs. Defaults to 5L.
 #'
 #' @export
 #' @examples
@@ -382,12 +384,12 @@ switch_expr <- function(.x, ...) {
 #'
 #' wrapper_quo <- local(quo(bar(!!local_quo, baz)))
 #' expr_print(wrapper_quo)
-expr_print <- function(x, width = peek_option("width")) {
-  cat_line(expr_deparse(x, width = width))
+expr_print <- function(x, width = peek_option("width"), max_elements = 5L) {
+  cat_line(expr_deparse(x, width = width, max_elements = max_elements))
 }
 #' @rdname expr_print
 #' @export
-expr_deparse <- function(x, width = peek_option("width")) {
+expr_deparse <- function(x, width = peek_option("width"), max_elements = 5L) {
   deparser <- new_quo_deparser(width = width)
-  quo_deparse(x, deparser)
+  quo_deparse(x, deparser, max_elements)
 }

--- a/R/expr.R
+++ b/R/expr.R
@@ -354,6 +354,7 @@ switch_expr <- function(.x, ...) {
 #' @param x An object or expression to print.
 #' @param width The width of the deparsed or printed expression.
 #'   Defaults to the global option `width`.
+#' @param ... Arguments passed to `expr_deparse()`.
 #' @param max_elements Maximum length of a vector or list before truncation
 #'   occurs. Defaults to 5L.
 #'
@@ -384,12 +385,16 @@ switch_expr <- function(.x, ...) {
 #'
 #' wrapper_quo <- local(quo(bar(!!local_quo, baz)))
 #' expr_print(wrapper_quo)
-expr_print <- function(x, width = peek_option("width"), max_elements = 5L) {
-  cat_line(expr_deparse(x, width = width, max_elements = max_elements))
+expr_print <- function(x, ...) {
+  cat_line(expr_deparse(x, ...))
 }
 #' @rdname expr_print
 #' @export
-expr_deparse <- function(x, width = peek_option("width"), max_elements = 5L) {
   deparser <- new_quo_deparser(width = width)
   quo_deparse(x, deparser, max_elements)
+expr_deparse <- function(x,
+                         ...,
+                         width = peek_option("width"),
+                         max_elements = 5L) {
+  check_dots_empty(...)
 }

--- a/R/quo.R
+++ b/R/quo.R
@@ -570,9 +570,9 @@ base_deparse <- function(x) {
   deparse(x, control = "keepInteger")
 }
 
-quo_deparse <- function(x, lines = new_quo_deparser(),  max_elements = 5L) {
+quo_deparse <- function(x, lines = new_quo_deparser()) {
   if (!is_quosure(x)) {
-    return(sexp_deparse(x, lines = lines, max_elements = max_elements))
+    return(sexp_deparse(x, lines = lines))
   }
 
   env <- quo_get_env(x)
@@ -580,7 +580,7 @@ quo_deparse <- function(x, lines = new_quo_deparser(),  max_elements = 5L) {
 
   lines$push("^")
   lines$make_next_sticky()
-  sexp_deparse(quo_get_expr(x), lines = lines, max_elements = max_elements)
+  sexp_deparse(quo_get_expr(x), lines = lines)
 
   lines$quo_reset_colour()
 
@@ -588,8 +588,13 @@ quo_deparse <- function(x, lines = new_quo_deparser(),  max_elements = 5L) {
 }
 
 new_quo_deparser <- function(width = peek_option("width"),
+                             max_elements = 5L,
                              crayon = has_crayon()) {
-  lines <- new_lines(width = width, deparser = quo_deparse)
+  lines <- new_lines(
+    width = width,
+    max_elements = max_elements,
+    deparser = quo_deparse
+  )
 
   child_r6lite(lines,
     has_colour = crayon,

--- a/R/quo.R
+++ b/R/quo.R
@@ -570,9 +570,9 @@ base_deparse <- function(x) {
   deparse(x, control = "keepInteger")
 }
 
-quo_deparse <- function(x, lines = new_quo_deparser()) {
+quo_deparse <- function(x, lines = new_quo_deparser(),  max_elements = 5L) {
   if (!is_quosure(x)) {
-    return(sexp_deparse(x, lines = lines))
+    return(sexp_deparse(x, lines = lines, max_elements = max_elements))
   }
 
   env <- quo_get_env(x)
@@ -580,7 +580,7 @@ quo_deparse <- function(x, lines = new_quo_deparser()) {
 
   lines$push("^")
   lines$make_next_sticky()
-  sexp_deparse(quo_get_expr(x), lines)
+  sexp_deparse(quo_get_expr(x), lines = lines, max_elements = max_elements)
 
   lines$quo_reset_colour()
 

--- a/man/expr_print.Rd
+++ b/man/expr_print.Rd
@@ -5,12 +5,14 @@
 \alias{expr_deparse}
 \title{Print an expression}
 \usage{
-expr_print(x, width = peek_option("width"), max_elements = 5L)
+expr_print(x, ...)
 
-expr_deparse(x, width = peek_option("width"), max_elements = 5L)
+expr_deparse(x, ..., width = peek_option("width"), max_elements = 5L)
 }
 \arguments{
 \item{x}{An object or expression to print.}
+
+\item{...}{Arguments passed to \code{expr_deparse()}.}
 
 \item{width}{The width of the deparsed or printed expression.
 Defaults to the global option \code{width}.}

--- a/man/expr_print.Rd
+++ b/man/expr_print.Rd
@@ -5,15 +5,18 @@
 \alias{expr_deparse}
 \title{Print an expression}
 \usage{
-expr_print(x, width = peek_option("width"))
+expr_print(x, width = peek_option("width"), max_elements = 5L)
 
-expr_deparse(x, width = peek_option("width"))
+expr_deparse(x, width = peek_option("width"), max_elements = 5L)
 }
 \arguments{
 \item{x}{An object or expression to print.}
 
 \item{width}{The width of the deparsed or printed expression.
 Defaults to the global option \code{width}.}
+
+\item{max_elements}{Maximum length of a vector or list before truncation
+occurs. Defaults to 5L.}
 }
 \description{
 \code{expr_print()}, powered by \code{expr_deparse()}, is an alternative

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -256,9 +256,19 @@ test_that("literal lists are deparsed", {
   expect_identical(sexp_deparse(list(TRUE, b = 2L, 3, d = "4", as.raw(5))), "<list: TRUE, b = 2L, 3, d = \"4\", <raw: 05>>")
 })
 
-test_that("long vectors are truncated", {
+test_that("long vectors are truncated by default", {
   expect_identical(sexp_deparse(1:10), "<int: 1L, 2L, 3L, 4L, 5L, ...>")
   expect_identical(sexp_deparse(as.list(1:10)), "<list: 1L, 2L, 3L, 4L, 5L, ...>")
+})
+
+test_that("long vectors are truncated when max_elements = 0L", {
+  expect_identical(sexp_deparse(1:10, max_elements = 0L), "<int: ...>")
+  expect_identical(sexp_deparse(as.list(1:10), max_elements = 0L), "<list: ...>")
+})
+
+test_that("long vectors are not truncated when max_elements = NULL", {
+  expect_identical(sexp_deparse(1:10, max_elements = NULL), "<int: 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L>")
+  expect_identical(sexp_deparse(as.list(1:10), max_elements = NULL), "<list: 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L>")
 })
 
 test_that("other objects are deparsed with base deparser", {

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -262,13 +262,19 @@ test_that("long vectors are truncated by default", {
 })
 
 test_that("long vectors are truncated when max_elements = 0L", {
-  expect_identical(sexp_deparse(1:10, max_elements = 0L), "<int: ...>")
-  expect_identical(sexp_deparse(as.list(1:10), max_elements = 0L), "<list: ...>")
+  lines <- new_lines(max_elements = 0L)
+  expect_identical(sexp_deparse(1:10, lines), "<int: ...>")
+
+  lines <- new_lines(max_elements = 0L)
+  expect_identical(sexp_deparse(as.list(1:10), lines), "<list: ...>")
 })
 
 test_that("long vectors are not truncated when max_elements = NULL", {
-  expect_identical(sexp_deparse(1:10, max_elements = NULL), "<int: 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L>")
-  expect_identical(sexp_deparse(as.list(1:10), max_elements = NULL), "<list: 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L>")
+  lines <- new_lines(max_elements = NULL)
+  expect_identical(sexp_deparse(1:10, lines), "<int: 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L>")
+
+  lines <- new_lines(max_elements = NULL)
+  expect_identical(sexp_deparse(as.list(1:10), lines), "<list: 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L>")
 })
 
 test_that("other objects are deparsed with base deparser", {


### PR DESCRIPTION
I maintain the [tidyquery](https://github.com/ianmcook/tidyquery) package which uses `rlang::expr_deparse()` to power the `show_dplyr()` function. I would like to be able to disable the truncation of deparsed vectors and lists. This PR adds a new argument `max_len` (edit: renamed `max_elements`) to control this. Thank you!