### PR TITLE
Resolve promise in .data$<x> when <x> is a promise in the mask.

### DIFF
--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -209,13 +209,17 @@ static sexp* mask_find(sexp* env, sexp* sym) {
     // to a simple environment whose ancestry shouldn't be looked up.
     top_env = env;
   }
-  KEEP(top_env); // Help rchk
+  int n_kept = 0;
+  KEEP_N(top_env, n_kept); // Help rchk
 
   sexp* cur = env;
   do {
     sexp* obj = r_env_find(cur, sym);
+    if (TYPEOF(obj) == PROMSXP) {
+      obj = KEEP_N(r_eval(obj, r_empty_env), n_kept);
+    }
     if (obj != r_unbound_sym && !r_is_function(obj)) {
-      FREE(1);
+      FREE(n_kept);
       return obj;
     }
 
@@ -226,7 +230,7 @@ static sexp* mask_find(sexp* env, sexp* sym) {
     }
   } while (cur != r_empty_env);
 
-  FREE(1);
+  FREE(n_kept);
   return r_unbound_sym;
 }
 sexp* rlang_data_pronoun_get(sexp* pronoun, sexp* sym) {

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -453,6 +453,13 @@ test_that("eval_tidy() does not infloop when the quosure inherits from the mask"
   expect_identical(eval_tidy(quo, mask), 1)
 })
 
+test_that(".data pronoun handles promises (#908)", {
+  e <- env()
+  env_bind_lazy(e, a = c(1))
+  mask <- new_data_mask(e)
+  mask$.data <- as_data_pronoun(mask)
+  expect_equal(eval_tidy(expr(.data$a * 2), mask), 2)
+})
 
 # Lifecycle ----------------------------------------------------------
 


### PR DESCRIPTION
``` r
library(rlang)

e <- env()
env_bind_lazy(e, a = c(1, 2, 3))
msk <- new_data_mask(e)
msk$.data <- as_data_pronoun(msk)
eval_tidy(expr(.data$a * 2), msk)
#> [1] 2 4 6
```

I'll add tests ... if I'm on the right track @lionel-. 