### PR TITLE
Make arg_match require single argument if given

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # rlang (development version)
 
-* arg_match now gives an error if argument is of length greater than 1 and doesn't exactly match the values input, similar to base `match.arg`.  
+* arg_match now gives an error if argument is of length greater than 1 and doesn't exactly match the values input, similar to base `match.arg`. Added as part of Tidyverse Developer Day (#914, @AliciaSchep) 
 
 # rlang 0.4.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
 # rlang (development version)
 
+* arg_match now gives an error if argument is of length greater than 1 and doesn't exactly match the values input, similar to base `match.arg`.  
 
 # rlang 0.4.3
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -41,6 +41,9 @@ arg_match <- function(arg, values = NULL) {
   if (!is_character(arg)) {
     abort(paste0(chr_quoted(arg_nm), " must be a character vector"))
   }
+  if (length(arg) > 1 && !identical(arg, values)) {
+    abort(paste0(chr_quoted(arg_nm), " must be a character vector of length 1."))
+  }
 
   arg <- arg[[1]]
   i <- match(arg, values)

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -26,6 +26,7 @@ print.rlang_error <- function(x,
                               ...,
                               simplify = c("branch", "collapse", "none"),
                               fields = FALSE) {
+  simplify <- arg_match(simplify)
   cat_line(format(x, simplify = simplify, fields = fields))
   invisible(x)
 }
@@ -52,7 +53,7 @@ format.rlang_error <- function(x,
   )
 
   trace <- x$trace
-  simplify <- arg_match(simplify, c("collapse", "branch", "none"))
+  simplify <- arg_match(simplify)
 
   if (!is_null(trace) && trace_length(trace)) {
     out <- paste_line(out, bold("Backtrace:"))

--- a/R/trace.R
+++ b/R/trace.R
@@ -401,6 +401,7 @@ print.rlang_trace <- function(x,
                               max_frames = NULL,
                               dir = getwd(),
                               srcrefs = NULL) {
+  simplify <- arg_match(simplify)
   cat_line(format(x, ...,
     simplify = simplify,
     max_frames = max_frames,

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -1,10 +1,18 @@
 context("arg")
 
 test_that("matches arg", {
-  myarg <- c("foo", "baz")
+  myarg <- "foo"
   expect_identical(arg_match(myarg, c("bar", "foo")), "foo")
   expect_error(
     regex = "`myarg` must be one of \"bar\" or \"baz\"",
+    arg_match(myarg, c("bar", "baz"))
+  )
+})
+
+test_that("gives an error with more than one arg", {
+  myarg <- c("bar","fun")
+  expect_error(
+    regex = "`myarg` must be a character vector of length 1.",
     arg_match(myarg, c("bar", "baz"))
   )
 })

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -17,6 +17,11 @@ test_that("gives an error with more than one arg", {
   )
 })
 
+test_that("uses first value when called with all values", {
+  myarg <- c("bar","baz")
+  expect_identical(arg_match(myarg, c("bar", "baz")), "bar")
+})
+
 test_that("informative error message on partial match", {
   myarg <- "f"
   expect_error(


### PR DESCRIPTION
This matches the logic of match.arg -- if length of argument is greater than 1, it must be identical to the values argument.

Fixes #874 

A few places in code base need to now call `arg_match` before passing to subsequent functions that have the options list in a different order so as to be robust to this stricter test. If other packages also rely on the less strict behavior, perhaps it would be safer to introduce this as a warning first?