### PR TITLE
Add `check_downstream_deps()`

### DIFF
--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -20,12 +20,14 @@ check_downstream_deps <- local({
     }
   }
 
+  is_string <- function(x) is.character(x) && length(x) == 1 && !is.na(x)
+
   check_downstream_dep <- function(pkg, dep_pkg, dep_data, with_rlang) {
     min <- dep_data[["min"]]
     from <- dep_data[["from"]]
     stopifnot(
-      !is.null(min),
-      !is.null(from)
+      is_string(min),
+      is_string(from)
     )
 
     ver <- utils::packageVersion(dep_pkg)

--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -1,0 +1,65 @@
+# nocov start --- compat-downstream-deps --- 2020-02-24 Mon 12:59 CET
+
+
+check_downstream_deps <- local({
+
+  check_downstream_dep <- function(dep, pkg) {
+    min <- dep[["min"]]
+    from <- dep[["from"]]
+    stopifnot(
+      !is_null(min),
+      !is_null(from)
+    )
+
+    ver <- utils::packageVersion(pkg)
+    if (ver >= min) {
+      return()
+    }
+
+    rlang_ver <- utils::packageVersion("rlang")
+
+    msg <- c(
+      sprintf("As of rlang %s, %s must be at least version %s.", from, pkg, min),
+      x = sprintf("%s %s is too old for rlang %s.", pkg, ver, rlang_ver)
+    )
+
+    os <- tolower(Sys.info()[["sysname"]])
+    if (os == "windows") {
+      url <- "https://github.com/jennybc/what-they-forgot/issues/62"
+      howto <- c(
+        i = sprintf("Please update %s to the latest version.", pkg),
+        i = sprintf("Updating packages on Windows requires precautions:\n  <%s>", url)
+      )
+    } else {
+      howto <- c(
+        i = sprintf("Please update %s with `install.packages(\"%s\")` and restart R.", pkg, pkg)
+      )
+    }
+    msg <- c(msg, howto)
+
+    warn(msg)
+  }
+
+  on_package_load <- function(pkg, expr) {
+    if (isNamespaceLoaded(pkg)) {
+      expr
+    } else {
+      thunk <- function(...) expr
+      setHook(packageEvent(pkg, "onLoad"), thunk)
+    }
+  }
+
+  function(deps) {
+    Map(
+      function(dep, pkg) {
+        force(dep)
+        on_package_load(pkg, check_downstream_dep(dep, pkg))
+      },
+      deps,
+      names(deps)
+    )
+  }
+})
+
+
+#nocov end

--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -1,7 +1,24 @@
-# nocov start --- compat-downstream-deps --- 2020-02-24 Mon 12:59 CET
+# nocov start --- compat-downstream-deps --- 2020-02-24 Mon 13:05 CET
 
 
 check_downstream_deps <- local({
+
+  # Keep in sync with compat-linked-version.R
+  howto_reinstall_msg <- function(pkg) {
+    os <- tolower(Sys.info()[["sysname"]])
+
+    if (os == "windows") {
+      url <- "https://github.com/jennybc/what-they-forgot/issues/62"
+      c(
+        i = sprintf("Please update %s to the latest version.", pkg),
+        i = sprintf("Updating packages on Windows requires precautions:\n  <%s>", url)
+      )
+    } else {
+      c(
+        i = sprintf("Please update %s with `install.packages(\"%s\")` and restart R.", pkg, pkg)
+      )
+    }
+  }
 
   check_downstream_dep <- function(dep, pkg) {
     min <- dep[["min"]]
@@ -23,21 +40,7 @@ check_downstream_deps <- local({
       x = sprintf("%s %s is too old for rlang %s.", pkg, ver, rlang_ver)
     )
 
-    os <- tolower(Sys.info()[["sysname"]])
-    if (os == "windows") {
-      url <- "https://github.com/jennybc/what-they-forgot/issues/62"
-      howto <- c(
-        i = sprintf("Please update %s to the latest version.", pkg),
-        i = sprintf("Updating packages on Windows requires precautions:\n  <%s>", url)
-      )
-    } else {
-      howto <- c(
-        i = sprintf("Please update %s with `install.packages(\"%s\")` and restart R.", pkg, pkg)
-      )
-    }
-    msg <- c(msg, howto)
-
-    warn(msg)
+    warn(c(msg, howto_reinstall_msg(pkg)))
   }
 
   on_package_load <- function(pkg, expr) {

--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -63,7 +63,14 @@ check_downstream_deps <- local({
     }
   }
 
-  function(pkg, deps, with_rlang = requireNamespace("rlang")) {
+  function(pkg, ..., with_rlang = requireNamespace("rlang")) {
+    deps <- list(...)
+    nms <- names(deps)
+
+    if (is.null(nms)) {
+      stop("Downstream dependencies should be named.", call. = FALSE)
+    }
+
     Map(
       function(dep_pkg, dep_data) {
         force(dep_data)
@@ -74,7 +81,7 @@ check_downstream_deps <- local({
           with_rlang = with_rlang
         ))
       },
-      names(deps),
+      nms,
       deps
     )
   }

--- a/R/compat-linked-version.R
+++ b/R/compat-linked-version.R
@@ -1,8 +1,9 @@
-# nocov start --- compat-linked-version --- 2020-02-24 Mon 12:55 CET
+# nocov start --- compat-linked-version --- 2020-02-24 Mon 13:05 CET
 
 
 check_linked_version <- local({
 
+  # Keep in sync with compat-downstream-deps.R
   howto_reinstall_msg <- function(pkg) {
     os <- tolower(Sys.info()[["sysname"]])
 

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -21,7 +21,7 @@ base_pkg_env <- NULL
   }
 
   check_linked_version(pkg, with_rlang = FALSE)
-  check_downstream_deps(downstream_deps)
+  check_downstream_deps(pkg, downstream_deps, with_rlang = FALSE)
 
   on_package_load("glue", .Call(rlang_glue_is_there))
 

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -5,11 +5,6 @@ NULL
 is_same_body <- NULL
 
 
-downstream_deps <- list(
-  dplyr = c(min = "0.8.0", from = "0.4.0")
-)
-
-
 base_ns_env <- NULL
 base_pkg_env <- NULL
 
@@ -21,7 +16,12 @@ base_pkg_env <- NULL
   }
 
   check_linked_version(pkg, with_rlang = FALSE)
-  check_downstream_deps(pkg, downstream_deps, with_rlang = FALSE)
+
+  check_downstream_deps(
+    pkg,
+    dplyr = c(min = "0.8.0", from = "0.4.0"),
+    with_rlang = FALSE
+  )
 
   on_package_load("glue", .Call(rlang_glue_is_there))
 


### PR DESCRIPTION
Branched from #926. Implemented in a standalone compat file that can be copied in zero-dep packages, but will eventually be exported from rlang as well.

Sometimes a package is updated with known breaking changes. Broken downstream dependencies can then be updated to fix the breakage and bump the required version of the upstream package in their DESCRIPTION file. However that doesn't cover the common case of updating the upstream dependencies independently. Since there is no way of specifying minimal versions of downstream dependencies in DESCRIPTION, the downstream packages won't be updated even though they are no longer compatible. This can result in surprising and hard to debug behaviour.

The goal of `check_downstream_deps()` is to reduce friction when breaking updates are released with known downstream dependencies requirements. One instance where these requirements are known ahead of time is when the maintainer owns both the upstream and downstream packages and coordinates a joint release to CRAN.

`check_downstream_deps()` takes named vectors of `min` and `from` components. `min` is the minimum version of the downstream package that is compatible with the upstream package. `from` is the earliest version of the upstream package that is compatible with that minimum version. For instance here is the downstream-deps spec for rlang:

```r
.onLoad <- function(lib, pkg) {
  check_downstream_deps(
    pkg,
    dplyr = c(min = "0.8.0", from = "0.4.0")
  )
}
```

If the user has updated rlang but not dplyr, they get this warning once the load is complete:

```r
suppressMessages(library(dplyr))
#> Warning message:
#> As of rlang 0.4.0, dplyr must be at least version 0.8.0.
#> ✖ dplyr 0.7.2 is too old for rlang 0.4.4.
#> ℹ Please update dplyr with `install.packages("dplyr")` and restart R.
```

As in #926, Windows users receive specific advice about safe installation on that platform:

```r
suppressMessages(library(dplyr))
#> Warning message:
#> As of rlang 0.4.0, dplyr must be at least version 0.8.0.
#> ✖ dplyr 0.7.2 is too old for rlang 0.4.4.
#> ℹ Please update dplyr to the latest version.
#> ℹ Updating packages on Windows requires precautions:
#>   <https://github.com/jennybc/what-they-forgot/issues/62>
```