### PR TITLE
Replace `stopifnot()` calls with C level checks in `%|%`

### DIFF
--- a/R/operators.R
+++ b/R/operators.R
@@ -29,9 +29,6 @@
 #' c("a", "b", NA, "c") %|% "default"
 #' c(1L, NA, 3L, NA, NA) %|% (6L:10L)
 `%|%` <- function(x, y) {
-  stopifnot(is_atomic(x) && is_atomic(y))
-  stopifnot(length(y) == 1 || length(y) == length(x))
-  stopifnot(typeof(x) == typeof(y))
   .Call(rlang_replace_na, x, y)
 }
 

--- a/src/lib/replace-na.c
+++ b/src/lib/replace-na.c
@@ -80,7 +80,7 @@ sexp* rlang_replace_na(sexp* x, sexp* replacement) {
   }
 
   default: {
-    r_abort("Don't know how to handle object of type", Rf_type2char(x_type));
+    r_abort("Internal error: Don't know how to handle object of type %s", Rf_type2char(x_type));
   }
   }
 
@@ -154,7 +154,7 @@ static sexp* replace_na_(sexp* x, sexp* replacement, int i) {
   }
 
   default: {
-    r_abort("Don't know how to handle object of type", Rf_type2char(r_typeof(x)));
+    r_abort("Internal error: Don't know how to handle object of type %s", Rf_type2char(r_typeof(x)));
   }
   }
 
@@ -218,7 +218,7 @@ static sexp* replace_na_vec_(sexp* x, sexp* replacement, int i) {
   }
 
   default: {
-    r_abort("Don't know how to handle object of type", Rf_type2char(r_typeof(x)));
+    r_abort("Internal error: Don't know how to handle object of type %s", Rf_type2char(r_typeof(x)));
   }
   }
 

--- a/src/lib/replace-na.c
+++ b/src/lib/replace-na.c
@@ -15,10 +15,7 @@ sexp* rlang_replace_na(sexp* x, sexp* replacement) {
   }
 
   if (x_type != replacement_type) {
-    r_abort("The replacement values, which have type %s, must have the same "
-            "type as the original values, which have type %s",
-            Rf_type2char(replacement_type),
-            Rf_type2char(x_type));
+    r_abort("Replacement values must have type %s, not type %s", Rf_type2char(x_type), Rf_type2char(replacement_type));
   }
 
   if (n_replacement != 1 && n_replacement != n) {

--- a/tests/testthat/helper-output.R
+++ b/tests/testthat/helper-output.R
@@ -1,0 +1,2 @@
+# Dummy until implemented in testthat
+verify_errors <- identity

--- a/tests/testthat/test-operators-replace-na.txt
+++ b/tests/testthat/test-operators-replace-na.txt
@@ -1,0 +1,33 @@
+
+%|% fails on non-atomic original values
+=======================================
+
+> call("fn") %|% 1
+Error: Cannot replace missing values in an object of type language
+
+
+%|% fails with wrong types
+==========================
+
+> c(1L, NA) %|% 2
+Error: The replacement values, which have type double, must have the same type as the original values, which have type integer
+
+> c(1, NA) %|% ""
+Error: The replacement values, which have type character, must have the same type as the original values, which have type double
+
+> c(1, NA) %|% call("fn")
+Error: The replacement values, which have type language, must have the same type as the original values, which have type double
+
+
+%|% fails with wrong length
+===========================
+
+> c(1L, NA) %|% 1:3
+Error: The replacement values must have size 1 or 2, not 3
+
+> 1:10 %|% 1:4
+Error: The replacement values must have size 1 or 10, not 4
+
+> 1L %|% 1:4
+Error: The replacement values must have size 1, not 4
+

--- a/tests/testthat/test-operators-replace-na.txt
+++ b/tests/testthat/test-operators-replace-na.txt
@@ -10,13 +10,13 @@ Error: Cannot replace missing values in an object of type language
 ==========================
 
 > c(1L, NA) %|% 2
-Error: The replacement values, which have type double, must have the same type as the original values, which have type integer
+Error: Replacement values must have type integer, not type double
 
 > c(1, NA) %|% ""
-Error: The replacement values, which have type character, must have the same type as the original values, which have type double
+Error: Replacement values must have type double, not type character
 
 > c(1, NA) %|% call("fn")
-Error: The replacement values, which have type language, must have the same type as the original values, which have type double
+Error: Replacement values must have type double, not type language
 
 
 %|% fails with wrong length

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -35,19 +35,25 @@ test_that("%|% also works when y is of same length as x", {
 })
 
 test_that("%|% fails on non-atomic original values", {
-  expect_error(call("fn") %|% 1)
+  verify_errors({
+    expect_error(call("fn") %|% 1)
+  })
 })
 
 test_that("%|% fails with wrong types", {
-  expect_error(c(1L, NA) %|% 2)
-  expect_error(c(1, NA) %|% "")
-  expect_error(c(1, NA) %|% call("fn"))
+  verify_errors({
+    expect_error(c(1L, NA) %|% 2)
+    expect_error(c(1, NA) %|% "")
+    expect_error(c(1, NA) %|% call("fn"))
+  })
 })
 
 test_that("%|% fails with wrong length", {
-  expect_error(c(1L, NA) %|% 1:3)
-  expect_error(1:10 %|% 1:4)
-  expect_error(1L %|% 1:4)
+  verify_errors({
+    expect_error(c(1L, NA) %|% 1:3)
+    expect_error(1:10 %|% 1:4)
+    expect_error(1L %|% 1:4)
+  })
 })
 
 test_that("%|% fails with intelligent errors", {

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -34,14 +34,37 @@ test_that("%|% also works when y is of same length as x", {
   expect_equal(cpx, c(1i, 2i, 12i, 4i))
 })
 
+test_that("%|% fails on non-atomic original values", {
+  expect_error(call("fn") %|% 1)
+})
+
 test_that("%|% fails with wrong types", {
   expect_error(c(1L, NA) %|% 2)
   expect_error(c(1, NA) %|% "")
+  expect_error(c(1, NA) %|% call("fn"))
 })
 
 test_that("%|% fails with wrong length", {
   expect_error(c(1L, NA) %|% 1:3)
   expect_error(1:10 %|% 1:4)
+  expect_error(1L %|% 1:4)
+})
+
+test_that("%|% fails with intelligent errors", {
+  verify_output(test_path("test-operators-replace-na.txt"), {
+    "# %|% fails on non-atomic original values"
+    call("fn") %|% 1
+
+    "# %|% fails with wrong types"
+    c(1L, NA) %|% 2
+    c(1, NA) %|% ""
+    c(1, NA) %|% call("fn")
+
+    "# %|% fails with wrong length"
+    c(1L, NA) %|% 1:3
+    1:10 %|% 1:4
+    1L %|% 1:4
+  })
 })
 
 test_that("%@% returns attribute", {


### PR DESCRIPTION
Mainly for speed, but also for better errors

I used `verify_output()`, and have the matching hard error checks as well. You don't have a `verify_errors()` stub yet so I didn't wrap them in that, do you want one?

``` r
library(rlang)
x <- letters
```

```r
bench::mark(1 %|% 1, iterations = 100000)

# master
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 1 %|% 1       5.8µs    7.5µs   128412.    10.9KB     92.5

# this PR
#> # A tibble: 1 x 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 1 %|% 1       321ns    446ns  2096734.    6.48KB     105.
```

```r
bench::mark(letters %|% "", iterations = 100000)

# master
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 letters %|% ""   4.75µs   6.74µs   144082.        0B     25.9

# this PR
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 letters %|% ""    386ns    445ns  1888954.        0B     18.9
```