### PR TITLE
Implement `set_names()` in C

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 
 # rlang (development version)
 
+* `set_names()` is now implemented in C, and should be faster.
+
+* `is_formula()` is now implemented in C, and should be faster.
+
+* `is_function()`, `is_closure()`, `is_primitive()`, `is_primitive_eager()`,
+  and `is_primitive_lazy()` are now implemented in C, and should be faster.
+
 * The `.data` pronoun now accepts symbol subscripts (#836).
 
 * Quosure lists now explicitly inherit from `"list"`. This makes them

--- a/R/attr.R
+++ b/R/attr.R
@@ -167,7 +167,7 @@ has_name <- function(x, name) {
 #' set_names(head(mtcars), paste0, "_foo")
 set_names <- function(x, nm = x, ...) {
   mold <- x
-  .External2(rlang_set_names, x, mold, nm)
+  .Call(rlang_set_names, x, mold, nm, environment())
 }
 
 #' Get names of a vector

--- a/R/attr.R
+++ b/R/attr.R
@@ -195,7 +195,7 @@ set_names <- function(x, nm = x, ...) {
 #' x <- set_names(1:3, c("a", NA, "b"))
 #' names2(x)
 names2 <- function(x) {
-  .Call(rlang_names2, x)
+  .Call(rlang_names2, x, environment())
 }
 
 # Avoids `NA` names on subset-assign with unnamed vectors

--- a/R/attr.R
+++ b/R/attr.R
@@ -166,37 +166,8 @@ has_name <- function(x, name) {
 #' # `...` is passed to the function:
 #' set_names(head(mtcars), paste0, "_foo")
 set_names <- function(x, nm = x, ...) {
-  set_names_impl(x, x, nm, ...)
-}
-
-# FIXME: This can be simplified once the `_along` ctors are defunct
-set_names_impl <- function(x, mold, nm, ...) {
-  if (!is_vector(x)) {
-    abort("`x` must be a vector")
-  }
-
-  if (is_function(nm) || is_formula(nm)) {
-    if (is_null(names(mold))) {
-      mold <- as.character(mold)
-    } else {
-      mold <- names2(mold)
-    }
-    nm <- as_function(nm)
-    nm <- nm(mold, ...)
-  } else if (!is_null(nm)) {
-    if (dots_n(...)) {
-      nm <- as.character(c(nm, ...))
-    } else {
-      nm <- as.character(nm)
-    }
-  }
-
-  if (!is_null(nm) && !is_character(nm, length(x))) {
-    abort("`nm` must be `NULL` or a character vector the same length as `x`")
-  }
-
-  names(x) <- nm
-  x
+  mold <- x
+  .External2(rlang_set_names, x, mold, nm)
 }
 
 #' Get names of a vector
@@ -224,15 +195,7 @@ set_names_impl <- function(x, mold, nm, ...) {
 #' x <- set_names(1:3, c("a", NA, "b"))
 #' names2(x)
 names2 <- function(x) {
-  if (typeof(x) == "environment") {
-    abort("Use `env_names()` for environments.")
-  }
-  nms <- names(x)
-  if (is_null(nms)) {
-    rep("", length(x))
-  } else {
-    nms %|% ""
-  }
+  .Call(rlang_names2, x)
 }
 
 # Avoids `NA` names on subset-assign with unnamed vectors

--- a/R/fn.R
+++ b/R/fn.R
@@ -276,19 +276,19 @@ fn_body_node <- function(fn) {
 #' # While closures do:
 #' identity(identity(ctxt_stack()))
 is_function <- function(x) {
-  is_closure(x) || is_primitive(x)
+  .Call(rlang_is_function, x)
 }
 
 #' @export
 #' @rdname is_function
 is_closure <- function(x) {
-  typeof(x) == "closure"
+  .Call(rlang_is_closure, x)
 }
 
 #' @export
 #' @rdname is_function
 is_primitive <- function(x) {
-  typeof(x) %in% c("builtin", "special")
+  .Call(rlang_is_primitive, x)
 }
 #' @export
 #' @rdname is_function
@@ -299,7 +299,7 @@ is_primitive <- function(x) {
 #' is_primitive_eager(base::list)
 #' is_primitive_eager(base::`+`)
 is_primitive_eager <- function(x) {
-  typeof(x) == "builtin"
+  .Call(rlang_is_primitive_eager, x)
 }
 #' @export
 #' @rdname is_function
@@ -310,7 +310,7 @@ is_primitive_eager <- function(x) {
 #' is_primitive_lazy(base::quote)
 #' is_primitive_lazy(base::substitute)
 is_primitive_lazy <- function(x) {
-  typeof(x) == "special"
+  .Call(rlang_is_primitive_lazy, x)
 }
 
 

--- a/R/formula.R
+++ b/R/formula.R
@@ -53,10 +53,7 @@ new_formula <- function(lhs, rhs, env = caller_env()) {
 #' is_bare_formula(f, scoped = TRUE)
 #' is_bare_formula(eval(f), scoped = TRUE)
 is_formula <- function(x, scoped = NULL, lhs = NULL) {
-  if (!is_formulaish(x, scoped = scoped, lhs = lhs)) {
-    return(FALSE)
-  }
-  identical(node_car(x), tilde_sym)
+  .Call(rlang_is_formula, x, scoped, lhs)
 }
 #' @rdname is_formula
 #' @export

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -1796,7 +1796,7 @@ warn_deprecated_along <- function(type, na) {
 }
 # FIXME: This can be simplified once the `_along` ctors are defunct
 set_names_impl <- function(x, mold, nm, ...) {
-  .External2(rlang_set_names, x, mold, nm)
+  .Call(rlang_set_names, x, mold, nm, environment())
 }
 
 #' Prepend a vector

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -1794,6 +1794,10 @@ warn_deprecated_along <- function(type, na) {
     sprintf("Please use `rep_along(x, %s)` or `rep_named(nms, %s)` instead.", na, na)
   ))
 }
+# FIXME: This can be simplified once the `_along` ctors are defunct
+set_names_impl <- function(x, mold, nm, ...) {
+  .External2(rlang_set_names, x, mold, nm)
+}
 
 #' Prepend a vector
 #'

--- a/src/Makevars
+++ b/src/Makevars
@@ -29,6 +29,7 @@ lib-files = \
 
 internal-files = \
         internal/arg.c \
+        internal/attr.c \
         internal/dots.c \
         internal/call.c \
         internal/env.c \

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -137,6 +137,14 @@ sexp* rlang_is_primitive_eager(sexp* x) {
 
 // formula.c
 
+sexp* rlang_is_formula(sexp* x, sexp* scoped, sexp* lhs) {
+  int scoped_int = r_as_optional_bool(scoped);
+  int lhs_int = r_as_optional_bool(lhs);
+
+  bool out = r_is_formula(x, scoped_int, lhs_int);
+  return r_lgl(out);
+}
+
 sexp* rlang_is_formulaish(sexp* x, sexp* scoped, sexp* lhs) {
   int scoped_int = r_as_optional_bool(scoped);
   int lhs_int = r_as_optional_bool(lhs);

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -114,6 +114,26 @@ sexp* rlang_eval_top(sexp* expr, sexp* env) {
   }
 }
 
+// fn.c
+
+sexp* rlang_is_function(sexp* x) {
+  return r_shared_lgl(r_is_function(x));
+}
+
+sexp* rlang_is_closure(sexp* x) {
+  return r_shared_lgl(r_is_closure(x));
+}
+
+sexp* rlang_is_primitive(sexp* x) {
+  return r_shared_lgl(r_is_primitive(x));
+}
+sexp* rlang_is_primitive_lazy(sexp* x) {
+  return r_shared_lgl(r_is_primitive_lazy(x));
+}
+sexp* rlang_is_primitive_eager(sexp* x) {
+  return r_shared_lgl(r_is_primitive_eager(x));
+}
+
 
 // formula.c
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -131,7 +131,7 @@ extern sexp* rlang_find_var(sexp*, sexp*);
 extern sexp* rlang_env_bind_list(sexp*, sexp*, sexp*);
 extern sexp* rlang_glue_is_there();
 extern sexp* rlang_linked_version();
-extern sexp* rlang_names2();
+extern sexp* rlang_names2(sexp*);
 
 // Library initialisation defined below
 sexp* rlang_library_load(sexp*);

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -132,6 +132,7 @@ extern sexp* rlang_env_bind_list(sexp*, sexp*, sexp*);
 extern sexp* rlang_glue_is_there();
 extern sexp* rlang_linked_version();
 extern sexp* rlang_names2(sexp*);
+extern sexp* rlang_set_names(sexp*, sexp*, sexp*, sexp*);
 
 // Library initialisation defined below
 sexp* rlang_library_load(sexp*);
@@ -303,6 +304,7 @@ static const r_callable r_callables[] = {
   {"rlang_glue_is_there",               (r_fn_ptr) &rlang_glue_is_there, 0},
   {"rlang_linked_version",              (r_fn_ptr) &rlang_linked_version, 0},
   {"rlang_names2",                      (r_fn_ptr) &rlang_names2, 1},
+  {"rlang_set_names",                   (r_fn_ptr) &rlang_set_names, 4},
   {NULL, NULL, 0}
 };
 
@@ -311,7 +313,6 @@ extern sexp* rlang_is_missing(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_call2_external(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_dots_values(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_exec(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_set_names(sexp*, sexp*, sexp*, sexp*);
 
 
 static const r_external externals[] = {
@@ -319,7 +320,6 @@ static const r_external externals[] = {
   {"rlang_call2_external",              (r_fn_ptr) &rlang_call2_external, 2},
   {"rlang_ext2_dots_values",            (r_fn_ptr) &rlang_ext2_dots_values, 6},
   {"rlang_exec",                        (r_fn_ptr) &rlang_exec, 2},
-  {"rlang_set_names",                   (r_fn_ptr) &rlang_set_names, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -39,6 +39,11 @@ extern sexp* rlang_node_tag(sexp*);
 extern sexp* rlang_node_poke_tag(sexp*, sexp*);
 extern sexp* rlang_eval(sexp*, sexp*);
 extern sexp* rlang_interp(sexp*, sexp*);
+extern sexp* rlang_is_function(sexp*);
+extern sexp* rlang_is_closure(sexp*);
+extern sexp* rlang_is_primitive(sexp*);
+extern sexp* rlang_is_primitive_eager(sexp*);
+extern sexp* rlang_is_primitive_lazy(sexp*);
 extern sexp* rlang_is_formulaish(sexp*, sexp*, sexp*);
 extern sexp* rlang_is_reference(sexp*, sexp*);
 extern sexp* rlang_sexp_address(sexp*);
@@ -163,6 +168,11 @@ static const r_callable r_callables[] = {
   {"rlang_node_tree_clone",             (r_fn_ptr) &r_node_tree_clone, 1},
   {"rlang_eval",                        (r_fn_ptr) &rlang_eval, 2},
   {"rlang_interp",                      (r_fn_ptr) &rlang_interp, 2},
+  {"rlang_is_function",                 (r_fn_ptr) &rlang_is_function, 1},
+  {"rlang_is_closure",                  (r_fn_ptr) &rlang_is_closure, 1},
+  {"rlang_is_primitive",                (r_fn_ptr) &rlang_is_primitive, 1},
+  {"rlang_is_primitive_eager",          (r_fn_ptr) &rlang_is_primitive_eager, 1},
+  {"rlang_is_primitive_lazy",           (r_fn_ptr) &rlang_is_primitive_lazy, 1},
   {"rlang_is_formulaish",               (r_fn_ptr) &rlang_is_formulaish, 3},
   {"rlang_is_null",                     (r_fn_ptr) &rlang_is_null, 1},
   {"rlang_is_reference",                (r_fn_ptr) &rlang_is_reference, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -131,7 +131,7 @@ extern sexp* rlang_find_var(sexp*, sexp*);
 extern sexp* rlang_env_bind_list(sexp*, sexp*, sexp*);
 extern sexp* rlang_glue_is_there();
 extern sexp* rlang_linked_version();
-extern sexp* rlang_names2(sexp*);
+extern sexp* rlang_names2(sexp*, sexp*);
 extern sexp* rlang_set_names(sexp*, sexp*, sexp*, sexp*);
 
 // Library initialisation defined below
@@ -303,7 +303,7 @@ static const r_callable r_callables[] = {
   {"rlang_env_bind_list",               (r_fn_ptr) &rlang_env_bind_list, 3},
   {"rlang_glue_is_there",               (r_fn_ptr) &rlang_glue_is_there, 0},
   {"rlang_linked_version",              (r_fn_ptr) &rlang_linked_version, 0},
-  {"rlang_names2",                      (r_fn_ptr) &rlang_names2, 1},
+  {"rlang_names2",                      (r_fn_ptr) &rlang_names2, 2},
   {"rlang_set_names",                   (r_fn_ptr) &rlang_set_names, 4},
   {NULL, NULL, 0}
 };

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -44,6 +44,7 @@ extern sexp* rlang_is_closure(sexp*);
 extern sexp* rlang_is_primitive(sexp*);
 extern sexp* rlang_is_primitive_eager(sexp*);
 extern sexp* rlang_is_primitive_lazy(sexp*);
+extern sexp* rlang_is_formula(sexp*, sexp*, sexp*);
 extern sexp* rlang_is_formulaish(sexp*, sexp*, sexp*);
 extern sexp* rlang_is_reference(sexp*, sexp*);
 extern sexp* rlang_sexp_address(sexp*);
@@ -173,6 +174,7 @@ static const r_callable r_callables[] = {
   {"rlang_is_primitive",                (r_fn_ptr) &rlang_is_primitive, 1},
   {"rlang_is_primitive_eager",          (r_fn_ptr) &rlang_is_primitive_eager, 1},
   {"rlang_is_primitive_lazy",           (r_fn_ptr) &rlang_is_primitive_lazy, 1},
+  {"rlang_is_formula",                  (r_fn_ptr) &rlang_is_formula, 3},
   {"rlang_is_formulaish",               (r_fn_ptr) &rlang_is_formulaish, 3},
   {"rlang_is_null",                     (r_fn_ptr) &rlang_is_null, 1},
   {"rlang_is_reference",                (r_fn_ptr) &rlang_is_reference, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -131,6 +131,7 @@ extern sexp* rlang_find_var(sexp*, sexp*);
 extern sexp* rlang_env_bind_list(sexp*, sexp*, sexp*);
 extern sexp* rlang_glue_is_there();
 extern sexp* rlang_linked_version();
+extern sexp* rlang_names2();
 
 // Library initialisation defined below
 sexp* rlang_library_load(sexp*);
@@ -301,6 +302,7 @@ static const r_callable r_callables[] = {
   {"rlang_env_bind_list",               (r_fn_ptr) &rlang_env_bind_list, 3},
   {"rlang_glue_is_there",               (r_fn_ptr) &rlang_glue_is_there, 0},
   {"rlang_linked_version",              (r_fn_ptr) &rlang_linked_version, 0},
+  {"rlang_names2",                      (r_fn_ptr) &rlang_names2, 1},
   {NULL, NULL, 0}
 };
 
@@ -309,6 +311,7 @@ extern sexp* rlang_is_missing(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_call2_external(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_dots_values(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_exec(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_set_names(sexp*, sexp*, sexp*, sexp*);
 
 
 static const r_external externals[] = {
@@ -316,6 +319,7 @@ static const r_external externals[] = {
   {"rlang_call2_external",              (r_fn_ptr) &rlang_call2_external, 2},
   {"rlang_ext2_dots_values",            (r_fn_ptr) &rlang_ext2_dots_values, 6},
   {"rlang_exec",                        (r_fn_ptr) &rlang_exec, 2},
+  {"rlang_set_names",                   (r_fn_ptr) &rlang_set_names, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/internal.c
+++ b/src/internal.c
@@ -1,4 +1,5 @@
 #include "internal/arg.c"
+#include "internal/attr.c"
 #include "internal/call.c"
 #include "internal/dots.c"
 #include "internal/env.c"

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -66,14 +66,8 @@ static inline sexp* r_as_character(sexp* x);
 static inline sexp* r_as_function(sexp* x);
 static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm);
 
-sexp* rlang_set_names(sexp* call, sexp* op, sexp* args, sexp* env) {
+sexp* rlang_set_names(sexp* x, sexp* mold, sexp* nm, sexp* env) {
   int n_kept = 0;
-
-  args = r_node_cdr(args);
-
-  sexp* x = KEEP_N(r_node_car(args), n_kept); args = r_node_cdr(args);
-  sexp* mold = KEEP_N(r_node_car(args), n_kept); args = r_node_cdr(args);
-  sexp* nm = KEEP_N(r_node_car(args), n_kept); args = r_node_cdr(args);
 
   sexp* dots = KEEP_N(rlang_dots(env), n_kept);
 

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -1,0 +1,189 @@
+#include <rlang.h>
+#include "internal.h"
+
+static inline sexp* r_language_names(sexp* x);
+static inline sexp* r_names_dispatch(sexp* x);
+
+sexp* rlang_names2(sexp* x) {
+  const enum r_type type = r_typeof(x);
+
+  if (type == r_type_environment) {
+    r_abort("Use `env_names()` for environments.");
+  }
+
+  // Handle pairlists and language objects specially like `getAttrib()`
+  // does. `r_names()` will not find these names because it has a guarantee
+  // to never allocate.
+  if (type == r_type_pairlist || type == r_type_call) {
+    return r_language_names(x);
+  }
+
+  sexp* nms;
+  if (r_is_object(x)) {
+    nms = KEEP(r_names_dispatch(x));
+  } else {
+    nms = KEEP(r_names(x));
+  }
+
+  if (r_is_null(nms)) {
+    r_ssize n = r_length(x);
+    nms = KEEP(r_new_vector(r_type_character, n));
+    r_chr_fill(nms, r_empty_str, n);
+  } else {
+    nms = KEEP(rlang_replace_na(nms, r_shared_empty_chr));
+  }
+
+  FREE(2);
+  return nms;
+}
+
+static inline sexp* r_language_names(sexp* x) {
+  r_ssize n = r_length(x);
+
+  sexp* out = KEEP(r_new_vector(r_type_character, n));
+  sexp** p_out = STRING_PTR(out);
+
+  int i = 0;
+
+  for(; x != r_null; x = r_node_cdr(x), ++i) {
+    sexp* tag = r_node_tag(x);
+
+    if (tag == r_null) {
+      p_out[i] = r_empty_str;
+    } else if (r_is_symbolic(tag)) {
+      p_out[i] = PRINTNAME(tag);
+    } else {
+      r_abort("Invalid type %s for tag", r_type_as_c_string(r_typeof(tag)));
+    }
+  }
+
+  FREE(1);
+  r_mark_shared(out);
+  return out;
+}
+
+static inline sexp* r_eval_fn_with_x_dots(sexp* fn, sexp* x, sexp* dots);
+static inline sexp* r_eval_c_with_x_dots(sexp* x, sexp* dots);
+static inline sexp* r_as_character(sexp* x);
+static inline sexp* r_as_function(sexp* x);
+static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm);
+
+sexp* rlang_set_names(sexp* call, sexp* op, sexp* args, sexp* env) {
+  int n_kept = 0;
+
+  args = r_node_cdr(args);
+
+  sexp* x = KEEP_N(r_node_car(args), n_kept); args = r_node_cdr(args);
+  sexp* mold = KEEP_N(r_node_car(args), n_kept); args = r_node_cdr(args);
+  sexp* nm = KEEP_N(r_node_car(args), n_kept); args = r_node_cdr(args);
+
+  sexp* dots = KEEP_N(rlang_dots(env), n_kept);
+
+  if (!r_is_vector(x, -1)) {
+    r_abort("`x` must be a vector");
+  }
+
+  if (nm == r_null) {
+    x = r_set_names_dispatch(x, r_null);
+
+    FREE(n_kept);
+    return x;
+  }
+
+  if (r_is_function(nm) || r_is_formula(nm, -1, -1)) {
+    if (r_is_null(r_names(mold))) {
+      mold = KEEP_N(r_as_character(mold), n_kept);
+    } else {
+      mold = KEEP_N(rlang_names2(mold), n_kept);
+    }
+
+    nm = KEEP_N(r_as_function(nm), n_kept);
+    nm = KEEP_N(r_eval_fn_with_x_dots(nm, mold, dots), n_kept);
+  } else {
+    if (r_length(dots) > 0) {
+      nm = KEEP_N(r_eval_c_with_x_dots(nm, dots), n_kept);
+    }
+
+    nm = KEEP_N(r_as_character(nm), n_kept);
+  }
+
+  if (!r_is_character(nm, r_length(x))) {
+    r_abort("`nm` must be `NULL` or a character vector the same length as `x`");
+  }
+
+  x = r_set_names_dispatch(x, nm);
+
+  FREE(n_kept);
+  return x;
+}
+
+
+static inline sexp* r_eval_fn_with_x(sexp* fn, sexp* x) {
+  sexp* args = KEEP(r_new_node(x, r_null));
+
+  sexp* call = KEEP(r_new_call(fn, args));
+
+  sexp* out = r_eval(call, r_global_env);
+
+  FREE(2);
+  return out;
+}
+
+static inline sexp* r_eval_fn_with_x_y(sexp* fn, sexp* x, sexp* y) {
+  sexp* args = KEEP(r_new_node(y, r_null));
+  args = KEEP(r_new_node(x, args));
+
+  sexp* call = KEEP(r_new_call(fn, args));
+
+  sexp* out = r_eval(call, r_global_env);
+
+  FREE(3);
+  return out;
+}
+
+static inline sexp* r_eval_fn_with_x_dots(sexp* fn, sexp* x, sexp* dots) {
+  sexp* args = KEEP(r_new_node(x, dots));
+  sexp* call = KEEP(r_new_call(fn, args));
+
+  sexp* out = r_eval(call, r_global_env);
+
+  FREE(2);
+  return out;
+}
+
+static sexp* c_fn = NULL;
+static inline sexp* r_eval_c_with_x_dots(sexp* x, sexp* dots) {
+  return r_eval_fn_with_x_dots(c_fn, x, dots);
+}
+
+static sexp* as_character_fn = NULL;
+static inline sexp* r_as_character(sexp* x) {
+  return r_eval_fn_with_x(as_character_fn, x);
+}
+
+static sexp* names_fn = NULL;
+static inline sexp* r_names_dispatch(sexp* x) {
+  return r_eval_fn_with_x(names_fn, x);
+}
+
+// TODO: Replace with C implementation of `as_function()`
+static sexp* as_function_fn = NULL;
+static inline sexp* r_as_function(sexp* x) {
+  return r_eval_fn_with_x(as_function_fn, x);
+}
+
+// Use `names<-()` rather than setting names directly with `r_poke_names()`
+// for genericity and for speed. `names<-()` can shallow duplicate `x`'s
+// attributes using ALTREP wrappers, which is not in R's public API.
+static sexp* set_names_fn = NULL;
+static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm) {
+  return r_eval_fn_with_x_y(set_names_fn, x, nm);
+}
+
+void rlang_init_attr(sexp* ns) {
+  c_fn = r_eval(r_sym("c"), r_base_env);
+  as_character_fn = r_eval(r_sym("as.character"), r_base_env);
+  names_fn = r_eval(r_sym("names"), r_base_env);
+  as_function_fn = r_eval(r_sym("as_function"), ns);
+  set_names_fn = r_eval(r_sym("names<-"), r_base_env);
+}

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -1,7 +1,7 @@
 #include <rlang.h>
 #include "internal.h"
 
-static inline sexp* r_language_names(sexp* x);
+static inline sexp* r_node_names(sexp* x);
 static inline sexp* r_names_dispatch(sexp* x);
 
 sexp* rlang_names2(sexp* x) {
@@ -15,7 +15,7 @@ sexp* rlang_names2(sexp* x) {
   // does. `r_names()` will not find these names because it has a guarantee
   // to never allocate.
   if (type == r_type_pairlist || type == r_type_call) {
-    return r_language_names(x);
+    return r_node_names(x);
   }
 
   sexp* nms;
@@ -37,7 +37,7 @@ sexp* rlang_names2(sexp* x) {
   return nms;
 }
 
-static inline sexp* r_language_names(sexp* x) {
+static inline sexp* r_node_names(sexp* x) {
   r_ssize n = r_length(x);
 
   sexp* out = KEEP(r_new_vector(r_type_character, n));

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -2,9 +2,9 @@
 #include "internal.h"
 
 static inline sexp* r_node_names(sexp* x);
-static inline sexp* r_names_dispatch(sexp* x);
+static inline sexp* r_names_dispatch(sexp* x, sexp* env);
 
-sexp* rlang_names2(sexp* x) {
+sexp* rlang_names2(sexp* x, sexp* env) {
   const enum r_type type = r_typeof(x);
 
   if (type == r_type_environment) {
@@ -20,7 +20,7 @@ sexp* rlang_names2(sexp* x) {
 
   sexp* nms;
   if (r_is_object(x)) {
-    nms = KEEP(r_names_dispatch(x));
+    nms = KEEP(r_names_dispatch(x, env));
   } else {
     nms = KEEP(r_names(x));
   }
@@ -60,11 +60,11 @@ static inline sexp* r_node_names(sexp* x) {
   return out;
 }
 
-static inline sexp* r_eval_fn_with_x_dots(sexp* fn, sexp* x, sexp* dots);
-static inline sexp* r_eval_c_with_x_dots(sexp* x, sexp* dots);
-static inline sexp* r_as_character(sexp* x);
-static inline sexp* r_as_function(sexp* x);
-static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm);
+static inline sexp* r_fn_eval_in_with_x_dots(sexp* fn, sexp* x, sexp* dots, sexp* env);
+static inline sexp* r_c_eval_in_with_x_dots(sexp* x, sexp* dots, sexp* env);
+static inline sexp* r_as_character(sexp* x, sexp* env);
+static inline sexp* r_as_function(sexp* x, sexp* env);
+static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm, sexp* env);
 
 sexp* rlang_set_names(sexp* x, sexp* mold, sexp* nm, sexp* env) {
   int n_kept = 0;
@@ -76,7 +76,7 @@ sexp* rlang_set_names(sexp* x, sexp* mold, sexp* nm, sexp* env) {
   }
 
   if (nm == r_null) {
-    x = r_set_names_dispatch(x, r_null);
+    x = r_set_names_dispatch(x, r_null, env);
 
     FREE(n_kept);
     return x;
@@ -84,95 +84,85 @@ sexp* rlang_set_names(sexp* x, sexp* mold, sexp* nm, sexp* env) {
 
   if (r_is_function(nm) || r_is_formula(nm, -1, -1)) {
     if (r_is_null(r_names(mold))) {
-      mold = KEEP_N(r_as_character(mold), n_kept);
+      mold = KEEP_N(r_as_character(mold, env), n_kept);
     } else {
-      mold = KEEP_N(rlang_names2(mold), n_kept);
+      mold = KEEP_N(rlang_names2(mold, env), n_kept);
     }
 
-    nm = KEEP_N(r_as_function(nm), n_kept);
-    nm = KEEP_N(r_eval_fn_with_x_dots(nm, mold, dots), n_kept);
+    nm = KEEP_N(r_as_function(nm, env), n_kept);
+    nm = KEEP_N(r_fn_eval_in_with_x_dots(nm, mold, dots, env), n_kept);
   } else {
     if (r_length(dots) > 0) {
-      nm = KEEP_N(r_eval_c_with_x_dots(nm, dots), n_kept);
+      nm = KEEP_N(r_c_eval_in_with_x_dots(nm, dots, env), n_kept);
     }
 
-    nm = KEEP_N(r_as_character(nm), n_kept);
+    nm = KEEP_N(r_as_character(nm, env), n_kept);
   }
 
   if (!r_is_character(nm, r_length(x))) {
     r_abort("`nm` must be `NULL` or a character vector the same length as `x`");
   }
 
-  x = r_set_names_dispatch(x, nm);
+  x = r_set_names_dispatch(x, nm, env);
 
   FREE(n_kept);
   return x;
 }
 
+static inline sexp* r_fn_eval_in_with_x_dots(sexp* fn, sexp* x, sexp* dots, sexp* env) {
+  sexp* args = KEEP(r_new_node(r_dot_x_sym, dots));
+  sexp* call = KEEP(r_new_call(r_dot_fn_sym, args));
 
-static inline sexp* r_eval_fn_with_x(sexp* fn, sexp* x) {
-  sexp* args = KEEP(r_new_node(x, r_null));
-
-  sexp* call = KEEP(r_new_call(fn, args));
-
-  sexp* out = r_eval(call, r_global_env);
-  FREE(2);
-  return out;
-}
-
-static inline sexp* r_eval_fn_with_x_y(sexp* fn, sexp* x, sexp* y) {
-  sexp* args = KEEP(r_new_node(y, r_null));
-  args = KEEP(r_new_node(x, args));
-
-  sexp* call = KEEP(r_new_call(fn, args));
-
-  sexp* out = r_eval(call, r_global_env);
-  FREE(3);
-  return out;
-}
-
-static inline sexp* r_eval_fn_with_x_dots(sexp* fn, sexp* x, sexp* dots) {
-  sexp* args = KEEP(r_new_node(x, dots));
-  sexp* call = KEEP(r_new_call(fn, args));
-
-  sexp* out = r_eval(call, r_global_env);
+  // This evaluates `fn(x, ...)`
+  // `.x` is the first input, x
+  // `.fn` is the function, fn
+  // The dots are a pairlist already in the call
+  sexp* out = r_eval_in_with_xy(call, env, x, r_dot_x_sym, fn, r_dot_fn_sym);
   FREE(2);
   return out;
 }
 
 static sexp* c_fn = NULL;
-static inline sexp* r_eval_c_with_x_dots(sexp* x, sexp* dots) {
-  return r_eval_fn_with_x_dots(c_fn, x, dots);
+static inline sexp* r_c_eval_in_with_x_dots(sexp* x, sexp* dots, sexp* env) {
+  return r_fn_eval_in_with_x_dots(c_fn, x, dots, env);
 }
 
-static sexp* as_character_fn = NULL;
-static inline sexp* r_as_character(sexp* x) {
-  return r_eval_fn_with_x(as_character_fn, x);
+static sexp* as_character_call = NULL;
+static inline sexp* r_as_character(sexp* x, sexp* env) {
+  return r_eval_in_with_x(as_character_call, env, x, r_dot_x_sym);
 }
 
-static sexp* names_fn = NULL;
-static inline sexp* r_names_dispatch(sexp* x) {
-  return r_eval_fn_with_x(names_fn, x);
+static sexp* names_call = NULL;
+static inline sexp* r_names_dispatch(sexp* x, sexp* env) {
+  return r_eval_in_with_x(names_call, env, x, r_dot_x_sym);
 }
 
 // TODO: Replace with C implementation of `as_function()`
-static sexp* as_function_fn = NULL;
-static inline sexp* r_as_function(sexp* x) {
-  return r_eval_fn_with_x(as_function_fn, x);
+static sexp* as_function_call = NULL;
+static inline sexp* r_as_function(sexp* x, sexp* env) {
+  return r_eval_in_with_x(as_function_call, env, x, r_dot_x_sym);
 }
 
 // Use `names<-()` rather than setting names directly with `r_poke_names()`
 // for genericity and for speed. `names<-()` can shallow duplicate `x`'s
 // attributes using ALTREP wrappers, which is not in R's public API.
-static sexp* set_names_fn = NULL;
-static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm) {
-  return r_eval_fn_with_x_y(set_names_fn, x, nm);
+static sexp* set_names_call = NULL;
+static inline sexp* r_set_names_dispatch(sexp* x, sexp* nm, sexp* env) {
+  return r_eval_in_with_xy(set_names_call, env, x, r_dot_x_sym, nm, r_dot_y_sym);
 }
 
 void rlang_init_attr(sexp* ns) {
   c_fn = r_eval(r_sym("c"), r_base_env);
-  as_character_fn = r_eval(r_sym("as.character"), r_base_env);
-  names_fn = r_eval(r_sym("names"), r_base_env);
-  as_function_fn = r_eval(r_sym("as_function"), ns);
-  set_names_fn = r_eval(r_sym("names<-"), r_base_env);
+
+  as_character_call = r_parse("as.character(.x)");
+  r_mark_precious(as_character_call);
+
+  names_call = r_parse("names(.x)");
+  r_mark_precious(names_call);
+
+  as_function_call = r_parse("as_function(.x)");
+  r_mark_precious(as_function_call);
+
+  set_names_call = r_parse("`names<-`(.x, .y)");
+  r_mark_precious(set_names_call);
 }

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -50,10 +50,8 @@ static inline sexp* r_node_names(sexp* x) {
 
     if (tag == r_null) {
       p_out[i] = r_empty_str;
-    } else if (r_is_symbolic(tag)) {
-      p_out[i] = PRINTNAME(tag);
     } else {
-      r_abort("Invalid type %s for tag", r_type_as_c_string(r_typeof(tag)));
+      p_out[i] = PRINTNAME(tag);
     }
   }
 

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -56,7 +56,6 @@ static inline sexp* r_node_names(sexp* x) {
   }
 
   FREE(1);
-  r_mark_shared(out);
   return out;
 }
 

--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -122,7 +122,6 @@ static inline sexp* r_eval_fn_with_x(sexp* fn, sexp* x) {
   sexp* call = KEEP(r_new_call(fn, args));
 
   sexp* out = r_eval(call, r_global_env);
-
   FREE(2);
   return out;
 }
@@ -134,7 +133,6 @@ static inline sexp* r_eval_fn_with_x_y(sexp* fn, sexp* x, sexp* y) {
   sexp* call = KEEP(r_new_call(fn, args));
 
   sexp* out = r_eval(call, r_global_env);
-
   FREE(3);
   return out;
 }
@@ -144,7 +142,6 @@ static inline sexp* r_eval_fn_with_x_dots(sexp* fn, sexp* x, sexp* dots) {
   sexp* call = KEEP(r_new_call(fn, args));
 
   sexp* out = r_eval(call, r_global_env);
-
   FREE(2);
   return out;
 }

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -17,12 +17,14 @@ void rlang_init_utils();
 void rlang_init_dots(sexp* ns);
 void rlang_init_expr_interp();
 void rlang_init_eval_tidy();
+void rlang_init_attr(sexp* ns);
 
 void rlang_init_internal(sexp* ns) {
   rlang_init_utils();
   rlang_init_dots(ns);
   rlang_init_expr_interp();
   rlang_init_eval_tidy();
+  rlang_init_attr(ns);
 
   rlang_zap = rlang_ns_get("zap!");
 

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -14,7 +14,7 @@ sexp* fns_function = NULL;
 sexp* fns_quote = NULL;
 
 void rlang_init_utils();
-void rlang_init_dots();
+void rlang_init_dots(sexp* ns);
 void rlang_init_expr_interp();
 void rlang_init_eval_tidy();
 

--- a/src/lib/eval.c
+++ b/src/lib/eval.c
@@ -3,47 +3,75 @@
 
 sexp* r_eval_with_x(sexp* call, sexp* parent, sexp* x) {
   sexp* env = KEEP(r_new_environment(parent, 1));
-  r_env_poke(env, r_x_sym, x);
-
-  sexp* out = r_eval(call, env);
+  sexp* out = r_eval_in_with_x(call, env,
+                               x, r_x_sym);
 
   FREE(1);
   return out;
 }
 sexp* r_eval_with_xy(sexp* call, sexp* parent, sexp* x, sexp* y) {
   sexp* env = KEEP(r_new_environment(parent, 1));
-  r_env_poke(env, r_x_sym, x);
-  r_env_poke(env, r_y_sym, y);
-
-  sexp* out = r_eval(call, env);
+  sexp* out = r_eval_in_with_xy(call, env,
+                                x, r_x_sym,
+                                y, r_y_sym);
 
   FREE(1);
   return out;
 }
 sexp* r_eval_with_xyz(sexp* call, sexp* parent, sexp* x, sexp* y, sexp* z) {
   sexp* env = KEEP(r_new_environment(parent, 1));
-  r_env_poke(env, r_x_sym, x);
-  r_env_poke(env, r_y_sym, y);
-  r_env_poke(env, r_z_sym, z);
-
-  sexp* out = r_eval(call, env);
+  sexp* out = r_eval_in_with_xyz(call, env,
+                                 x, r_x_sym,
+                                 y, r_y_sym,
+                                 z, r_z_sym);
 
   FREE(1);
   return out;
 }
 sexp* r_eval_with_wxyz(sexp* call, sexp* parent, sexp* w, sexp* x, sexp* y, sexp* z) {
   sexp* env = KEEP(r_new_environment(parent, 1));
-  r_env_poke(env, r_w_sym, w);
-  r_env_poke(env, r_x_sym, x);
-  r_env_poke(env, r_y_sym, y);
-  r_env_poke(env, r_z_sym, z);
-
-  sexp* out = r_eval(call, env);
+  sexp* out = r_eval_in_with_wxyz(call, env,
+                                  w, r_w_sym,
+                                  x, r_x_sym,
+                                  y, r_y_sym,
+                                  z, r_z_sym);
 
   FREE(1);
   return out;
 }
 
+sexp* r_eval_in_with_x(sexp* call, sexp* env,
+                       sexp* x, sexp* x_sym) {
+  r_env_poke(env, x_sym, x);
+  return r_eval(call, env);
+}
+sexp* r_eval_in_with_xy(sexp* call, sexp* env,
+                        sexp* x, sexp* x_sym,
+                        sexp* y, sexp* y_sym) {
+  r_env_poke(env, x_sym, x);
+  r_env_poke(env, y_sym, y);
+  return r_eval(call, env);
+}
+sexp* r_eval_in_with_xyz(sexp* call, sexp* env,
+                         sexp* x, sexp* x_sym,
+                         sexp* y, sexp* y_sym,
+                         sexp* z, sexp* z_sym) {
+  r_env_poke(env, x_sym, x);
+  r_env_poke(env, y_sym, y);
+  r_env_poke(env, z_sym, z);
+  return r_eval(call, env);
+}
+sexp* r_eval_in_with_wxyz(sexp* call, sexp* env,
+                          sexp* w, sexp* w_sym,
+                          sexp* x, sexp* x_sym,
+                          sexp* y, sexp* y_sym,
+                          sexp* z, sexp* z_sym) {
+  r_env_poke(env, w_sym, w);
+  r_env_poke(env, x_sym, x);
+  r_env_poke(env, y_sym, y);
+  r_env_poke(env, z_sym, z);
+  return r_eval(call, env);
+}
 
 static sexp* shared_x_env;
 static sexp* shared_xy_env;

--- a/src/lib/eval.h
+++ b/src/lib/eval.h
@@ -11,5 +11,19 @@ sexp* r_eval_with_xy(sexp* call, sexp* parent, sexp* x, sexp* y);
 sexp* r_eval_with_xyz(sexp* call, sexp* parent, sexp* x, sexp* y, sexp* z);
 sexp* r_eval_with_wxyz(sexp* call, sexp* parent, sexp* w, sexp* x, sexp* y, sexp* z);
 
+sexp* r_eval_in_with_x(sexp* call, sexp* env,
+                       sexp* x, sexp* x_sym);
+sexp* r_eval_in_with_xy(sexp* call, sexp* env,
+                        sexp* x, sexp* x_sym,
+                        sexp* y, sexp* y_sym);
+sexp* r_eval_in_with_xyz(sexp* call, sexp* env,
+                         sexp* x, sexp* x_sym,
+                         sexp* y, sexp* y_sym,
+                         sexp* z, sexp* z_sym);
+sexp* r_eval_in_with_wxyz(sexp* call, sexp* env,
+                          sexp* w, sexp* w_sym,
+                          sexp* x, sexp* x_sym,
+                          sexp* y, sexp* y_sym,
+                          sexp* z, sexp* z_sym);
 
 #endif

--- a/src/lib/fn.h
+++ b/src/lib/fn.h
@@ -29,5 +29,24 @@ static inline bool r_is_function(sexp* x) {
   }
 }
 
+static inline bool r_is_closure(sexp* x) {
+  return r_typeof(x) == r_type_closure;
+}
+
+static inline bool r_is_primitive(sexp* x) {
+  switch (r_typeof(x)) {
+  case r_type_builtin:
+  case r_type_special:
+    return true;
+  default:
+    return false;
+  }
+}
+static inline bool r_is_primitive_eager(sexp* x) {
+  return r_typeof(x) == r_type_builtin;
+}
+static inline bool r_is_primitive_lazy(sexp* x) {
+  return r_typeof(x) == r_type_special;
+}
 
 #endif

--- a/src/lib/formula.c
+++ b/src/lib/formula.c
@@ -31,6 +31,14 @@ bool r_f_has_env(sexp* f) {
   return r_is_environment(r_f_env(f));
 }
 
+bool r_is_formula(sexp* x, int scoped, int lhs) {
+  if (r_is_formulaish(x, scoped, lhs)) {
+    return r_node_car(x) == r_tilde_sym;
+  } else {
+    return false;
+  }
+}
+
 bool r_is_formulaish(sexp* x, int scoped, int lhs) {
   static const char* formulaish_names[2] = { "~", ":=" };
 

--- a/src/lib/formula.h
+++ b/src/lib/formula.h
@@ -2,6 +2,7 @@
 #define RLANG_FORMULA_H
 
 
+bool r_is_formula(sexp* x, int scoped, int lhs);
 bool r_is_formulaish(sexp* x, int scoped, int lhs);
 
 sexp* r_f_rhs(sexp* f);

--- a/src/lib/replace-na.h
+++ b/src/lib/replace-na.h
@@ -1,0 +1,8 @@
+#ifndef RLANG_REPLACE_NA_H
+#define RLANG_REPLACE_NA_H
+
+
+sexp* rlang_replace_na(sexp* x, sexp* replacement);
+
+
+#endif

--- a/src/lib/rlang.h
+++ b/src/lib/rlang.h
@@ -80,6 +80,7 @@ extern sexp* r_shared_false;
 #include "node.h"
 #include "parse.h"
 #include "quo.h"
+#include "replace-na.h"
 #include "session.h"
 #include "squash.h"
 #include "stack.h"

--- a/src/lib/sym.c
+++ b/src/lib/sym.c
@@ -74,6 +74,10 @@ sexp* r_x_sym;
 sexp* r_y_sym;
 sexp* r_z_sym;
 
+sexp* r_dot_x_sym;
+sexp* r_dot_y_sym;
+sexp* r_dot_fn_sym;
+
 void r_init_library_sym() {
   r_dot_environment_sym = r_sym(".Environment");
   r_function_sym = r_sym("function");
@@ -84,4 +88,8 @@ void r_init_library_sym() {
   r_x_sym = r_sym("x");
   r_y_sym = r_sym("y");
   r_z_sym = r_sym("z");
+
+  r_dot_x_sym = r_sym(".x");
+  r_dot_y_sym = r_sym(".y");
+  r_dot_fn_sym = r_sym(".fn");
 }

--- a/src/lib/sym.h
+++ b/src/lib/sym.h
@@ -20,6 +20,10 @@ extern sexp* r_x_sym;
 extern sexp* r_y_sym;
 extern sexp* r_z_sym;
 
+extern sexp* r_dot_x_sym;
+extern sexp* r_dot_y_sym;
+extern sexp* r_dot_fn_sym;
+
 
 sexp* r_new_symbol(sexp* x, int* err);
 

--- a/src/lib/vec-chr.c
+++ b/src/lib/vec-chr.c
@@ -59,6 +59,14 @@ bool r_chr_has_any(sexp* chr, const char** c_strings) {
   return false;
 }
 
+void r_chr_fill(sexp* chr, sexp* value, r_ssize n) {
+  sexp** p_chr = STRING_PTR(chr);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    p_chr[i] = value;
+  }
+}
+
 static void validate_chr_setter(sexp* chr, sexp* r_string) {
   if (r_typeof(chr) != r_type_character) {
     r_abort("`chr` must be a character vector");

--- a/src/lib/vec-chr.h
+++ b/src/lib/vec-chr.h
@@ -37,6 +37,7 @@ bool r_chr_has(sexp* chr, const char* c_string);
 bool r_chr_has_any(sexp* chr, const char** c_strings);
 r_ssize r_chr_detect_index(sexp* chr, const char* c_string);
 
+void r_chr_fill(sexp* chr, sexp* value, r_ssize n);
 
 sexp* r_new_character(const char** strings);
 


### PR DESCRIPTION
To do this, I've had to implement a few other things in C:

- `is_function()`

   - While I was there, I went ahead and did `is_closure()`, `is_primitive()`, `is_primitive_eager()` and `is_primitive_lazy()` too

- `is_formula()`

- `names2()`

I've created a new file, `internal/attr.c` to house the C implementations of `set_names()` and `names2()`.

For `names2()`, we fall back to the R level `names()` when `x` is an object to allow it to dispatch. We also handle pairlists and language objects specially, like `getAttrib()` does.

For `set_names()`, we always eventually set the names with `names<-()` rather than with `r_poke_names()`. The reason for this is that `do_namesgets()` has the ability to shallow copy _attributes_ using an ALTREP wrapper with `R_shallow_duplicate_attr()`. This isn't exposed to us yet from C, but calling `names<-` and getting a wrapper object is way faster than calling `r_maybe_duplicate()`, which will duplicate `x`.

I have allowed the new `r_as_function()` to call out to `rlang::as_function()` for simplicity. I have seen that you worked on a partial implementation of a C `as_function()` in vctrs, but the quosure handling here looks tricky to me. Feel free to take over and implement that if you want 😬 

```r
library(rlang)

x <- 1:50000 + 0L
a <- rep("x", 50000L)
```

```r
bench::mark(set_names(x, a), iterations = 100000)

# master
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, a)    6.7µs   9.32µs   105179.     121KB     72.6

# this PR
#> # A tibble: 1 x 6
#>   expression           min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>      <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, a)   1.03µs    1.5µs   649682.    7.81KB     110.
```

```r
bench::mark(is_function(1))

# master
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 is_function(1)   1.81µs   2.14µs   452624.      18KB     90.5

# this PR
#> # A tibble: 1 x 6
#>   expression          min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>     <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 is_function(1)    264ns    354ns  2491092.    3.86KB        0
```