### PR TITLE
Generically check length in `set_names()`

### DIFF
--- a/src/internal/attr.c
+++ b/src/internal/attr.c
@@ -170,9 +170,11 @@ static inline r_ssize r_length_dispatch(sexp* x, sexp* env) {
 
   switch (r_typeof(n)) {
   case r_type_integer:
-    out = (r_ssize) INTEGER(n)[0]; break;
+    out = (r_ssize) INTEGER(n)[0];
+    break;
   case r_type_double:
-    out = REAL(n)[0]; break;
+    out = REAL(n)[0];
+    break;
   default:
     r_abort("Object length has unknown type %s", r_type_as_c_string(r_typeof(n)));
   }

--- a/tests/testthat/test-attr.R
+++ b/tests/testthat/test-attr.R
@@ -36,6 +36,15 @@ test_that("set_names() coerces to character", {
   expect_identical(set_names(1:2, "a", TRUE), c(a = 1L, `TRUE` = 2L))
 })
 
+test_that("set_names() checks length generically", {
+  x <- as.POSIXlt("1970-01-01", tz = "UTC")
+
+  expect <- x
+  names(expect) <- "a"
+
+  expect_identical(set_names(x, "a"), expect)
+})
+
 test_that("has_name() works with pairlists", {
   expect_true(has_name(fn_fmls(`[.data.frame`), "drop"))
 })

--- a/tests/testthat/test-attr.R
+++ b/tests/testthat/test-attr.R
@@ -43,6 +43,7 @@ test_that("set_names() checks length generically", {
   names(expect) <- "a"
 
   expect_identical(set_names(x, "a"), expect)
+  expect_error(set_names(x, c("a", "b")), "the same length")
 })
 
 test_that("has_name() works with pairlists", {


### PR DESCRIPTION
I forgot we can't use `r_length()` unconditionally to check the length of the names vs the length of `x`. We need to fallback to the R level `length()` if `x` is an object

Found while running vctrs tests. With this PR, tests now pass for vctrs and dplyr with no issues