### PR TITLE
Use `[[` to convert S3 and S4 objects to list in `!!!` 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 # rlang (development version)
 
 * `!!!` now uses a combination of `length()`, `names()`, and `[[` to splice
-  S3 and S4 objects (#945).
+  S3 and S4 objects. This produces more consistent behaviour than `as.list()`
+  on a wider variety of vector classes (#945, tidyverse/dplyr#4931).
 
 # rlang 0.4.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # rlang (development version)
 
+* `!!!` now uses a combination of `length()`, `names()`, and `[[` to splice
+  S3 and S4 objects (#945).
 
 # rlang 0.4.5
 

--- a/R/dots.R
+++ b/R/dots.R
@@ -488,10 +488,10 @@ check_dots_empty <- function(...) {
 }
 
 
-# This helper is used when coercing S3 objects found
-# in `!!!` to a list. It is similar to `as.list()`, but
-# the names of `x` always end up on the names of the
-# output list, unlike `as.list.factor()`.
+# This helper is used when splicing S3 or S4 objects found
+# in `!!!`. It is similar to `as.list()`, but the names of
+# `x` always end up on the names of the output list,
+# unlike `as.list.factor()`.
 rlang_as_list <- function(x) {
   n <- length(x)
   names <- names(x)

--- a/R/dots.R
+++ b/R/dots.R
@@ -486,3 +486,23 @@ check_dots_empty <- function(...) {
     abort("These `...` must be empty")
   }
 }
+
+
+# This helper is used when coercing S3 objects found
+# in `!!!` to a list. It is similar to `as.list()`, but
+# the names of `x` always end up on the names of the
+# output list, unlike `as.list.factor()`.
+rlang_as_list <- function(x) {
+  n <- length(x)
+  names <- names(x)
+
+  out <- vector("list", n)
+
+  for (i in seq_len(n)) {
+    out[[i]] <- x[[i]]
+  }
+
+  names(out) <- names
+
+  out
+}

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -199,18 +199,18 @@ static sexp* dots_big_bang_coerce(sexp* x) {
   case r_type_character:
   case r_type_raw:
     if (r_is_object(x)) {
-      return r_eval_with_x(as_list_call, r_global_env, x);
+      return r_eval_with_x(rlang_as_list_call, rlang_ns_env, x);
     } else {
       return r_vec_coerce(x, r_type_list);
     }
   case r_type_list:
     if (r_is_object(x)) {
-      return r_eval_with_x(as_list_call, r_global_env, x);
+      return r_eval_with_x(rlang_as_list_call, rlang_ns_env, x);
     } else {
       return x;
     }
   case r_type_s4:
-    return r_eval_with_x(as_list_s4_call, r_methods_ns_env, x);
+    return r_eval_with_x(rlang_as_list_call, rlang_ns_env, x);
   case r_type_call:
     if (r_is_symbol(r_node_car(x), "{")) {
       return r_vec_coerce(r_node_cdr(x), r_type_list);

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -4,8 +4,7 @@
 
 sexp* rlang_zap = NULL;
 
-sexp* as_list_call = NULL;
-sexp* as_list_s4_call = NULL;
+sexp* rlang_as_list_call = NULL;
 
 sexp* rlang_objs_keep = NULL;
 sexp* rlang_objs_trailing = NULL;
@@ -28,11 +27,8 @@ void rlang_init_internal(sexp* ns) {
 
   rlang_zap = rlang_ns_get("zap!");
 
-  as_list_call = r_parse("as.list(x)");
-  r_mark_precious(as_list_call);
-
-  as_list_s4_call = r_parse("as(x, 'list')");
-  r_mark_precious(as_list_s4_call);
+  rlang_as_list_call = r_parse("rlang_as_list(x)");
+  r_mark_precious(rlang_as_list_call);
 
 
   rlang_objs_keep = r_chr("keep");

--- a/src/internal/internal.h
+++ b/src/internal/internal.h
@@ -6,8 +6,7 @@
 
 extern sexp* rlang_zap;
 
-extern sexp* as_list_call;
-extern sexp* as_list_s4_call;
+extern sexp* rlang_as_list_call;
 
 extern sexp* rlang_objs_keep;
 extern sexp* rlang_objs_trailing;

--- a/tests/testthat/test-node.R
+++ b/tests/testthat/test-node.R
@@ -95,10 +95,10 @@ test_that("pairlist2() converts to pairlist", {
   expect_identical_(pairlist2(1, !!!mtcars[1:2], 4), pairlist(1, mpg = mtcars$mpg, cyl = mtcars$cyl, 4))
 
   local_bindings(.env = global_env(),
-    as.list.rlang_foobar = function(x) list("foo", "bar")
+    `[[.rlang_foobar` = function(x, i) "foo"
   )
   foobar <- structure(NA, class = "rlang_foobar")
-  expect_identical_(pairlist2(1, !!!foobar, 4), pairlist(1, "foo", "bar", 4))
+  expect_identical_(pairlist2(1, !!!foobar, 4), pairlist(1, "foo", 4))
 })
 
 test_that("pairlist2() duplicates spliced pairlists", {

--- a/tests/testthat/test-nse-force.R
+++ b/tests/testthat/test-nse-force.R
@@ -361,22 +361,58 @@ test_that("!!! calls `[[`", {
   expect_identical_(expr(foo(!!!fct)), do.call(call, c(list("foo"), exp)))
   expect_identical_(list2(!!!fct), exp)
 })
+
+test_that("!!! errors on scalar S4 objects without a `[[` method", {
+  .Person <- methods::setClass("Person", slots = c(name = "character", species = "character"))
+  fievel <- .Person(name = "Fievel", species = "mouse")
+  expect_error_(list2(!!!fievel))
 })
 
-test_that("!!! calls methods::as()", {
+test_that("!!! works with scalar S4 objects with a `[[` method defined", {
+  .Person2 <- methods::setClass("Person2", slots = c(name = "character", species = "character"))
+  fievel <- .Person2(name = "Fievel", species = "mouse")
+
+  methods::setMethod("[[", methods::signature(x = "Person2"),
+    function(x, i, ...) .Person2(name = x@name, species = x@species)
+  )
+
+  expect_identical_(list2(!!!fievel), list(fievel))
+})
+
+test_that("!!! works with all vector S4 objects", {
+  .Counts <- methods::setClass("Counts", contains = "numeric", slots = c(name = "character"))
+  fievel <- .Counts(c(1, 2), name = "Fievel")
+  expect_identical_(list2(!!!fievel), list(1, 2))
+})
+
+test_that("!!! calls `[[` with vector S4 objects", {
   as_quos_list <- function(x, env = empty_env()) {
     new_quosures(map(x, new_quosure, env = env))
   }
 
-  .Person <- setClass("Person", slots = c(name = "character", species = "character"))
-  fievel <- .Person(name = "Fievel", species = "mouse")
-  methods::setAs("Person", "list", function(from, to) list(name = from@name, species = from@species))
+  .Belongings <- methods::setClass("Belongings", contains = "list", slots = c(name = "character"))
+  fievel <- .Belongings(list(1, "x"), name = "Fievel")
 
-  exp <- list(name = "Fievel", species = "mouse")
-  expect_identical_(exprs(!!!fievel), exp)
-  expect_identical_(quos(!!!fievel), as_quos_list(exp))
-  expect_identical_(expr(foo(!!!fievel)), quote(foo(name = "Fievel", species = "mouse")))
+  methods::setMethod("[[", methods::signature(x = "Belongings"),
+    function(x, i, ...) .Belongings(x@.Data[[i]], name = x@name)
+  )
+
+  exp <- list(
+    .Belongings(list(1), name = "Fievel"),
+    .Belongings(list("x"), name = "Fievel")
+  )
+
+  exp_named <- set_names(exp, c("", ""))
+
+  exp_foo <- quote(foo(
+    new("Belongings", .Data = list(1), name = "Fievel"),
+    new("Belongings", .Data = list("x"), name = "Fievel")
+  ))
+
   expect_identical_(list2(!!!fievel), exp)
+  expect_identical_(exprs(!!!fievel), exp_named)
+  expect_identical_(quos(!!!fievel), as_quos_list(exp_named))
+  expect_equal_(expr(foo(!!!fievel)), exp_foo)
 })
 
 

--- a/tests/testthat/test-nse-force.R
+++ b/tests/testthat/test-nse-force.R
@@ -341,22 +341,26 @@ test_that("!!! succeeds with vectors, pairlists and language objects", {
   expect_identical_(list2(!!!bytes(0)), list(bytes(0)))
 })
 
-test_that("!!! calls as.list()", {
+test_that("!!! calls `[[`", {
   as_quos_list <- function(x, env = empty_env()) {
     new_quosures(map(x, new_quosure, env = env))
   }
-  exp <- as.list(mtcars)
+
+  exp <- map(seq_along(mtcars), function(i) mtcars[[i]])
+  names(exp) <- names(mtcars)
   expect_identical_(exprs(!!!mtcars), exp)
   expect_identical_(quos(!!!mtcars), as_quos_list(exp))
   expect_identical_(expr(foo(!!!mtcars)), do.call(call, c(list("foo"), exp)))
   expect_identical_(list2(!!!mtcars), as.list(mtcars))
 
   fct <- factor(c("a", "b"))
-  exp <- set_names(as.list(fct), c("", ""))
+  fct <- set_names(fct, c("x", "y"))
+  exp <- set_names(list(fct[[1]], fct[[2]]), names(fct))
   expect_identical_(exprs(!!!fct), exp)
   expect_identical_(quos(!!!fct), as_quos_list(exp))
   expect_identical_(expr(foo(!!!fct)), do.call(call, c(list("foo"), exp)))
-  expect_identical_(list2(!!!fct), as.list(fct))
+  expect_identical_(list2(!!!fct), exp)
+})
 })
 
 test_that("!!! calls methods::as()", {

--- a/tests/testthat/test-nse-force.R
+++ b/tests/testthat/test-nse-force.R
@@ -389,6 +389,9 @@ test_that("!!! calls `[[` with vector S4 objects", {
   as_quos_list <- function(x, env = empty_env()) {
     new_quosures(map(x, new_quosure, env = env))
   }
+  foo <- function(x, y) {
+    list(x, y)
+  }
 
   .Belongings <- methods::setClass("Belongings", contains = "list", slots = c(name = "character"))
   fievel <- .Belongings(list(1, "x"), name = "Fievel")
@@ -404,15 +407,10 @@ test_that("!!! calls `[[` with vector S4 objects", {
 
   exp_named <- set_names(exp, c("", ""))
 
-  exp_foo <- quote(foo(
-    new("Belongings", .Data = list(1), name = "Fievel"),
-    new("Belongings", .Data = list("x"), name = "Fievel")
-  ))
-
   expect_identical_(list2(!!!fievel), exp)
+  expect_identical_(eval_bare(expr(foo(!!!fievel))), exp)
   expect_identical_(exprs(!!!fievel), exp_named)
   expect_identical_(quos(!!!fievel), as_quos_list(exp_named))
-  expect_equal_(expr(foo(!!!fievel)), exp_foo)
 })
 
 


### PR DESCRIPTION
Part of tidyverse/dplyr#4931

@lionel- would you like me to call the helper `rlang_as_list()` or `rlang_chop2()`? I felt like the first seemed more appropriate here, but don't have a strong preference.

Before:

``` r
library(rlang)

f <- set_names(factor(c("a", "b")), c("x", "y"))

qs <- quos(!!!f, .named = TRUE)

qs
#> <list_of<quosure>>
#> 
#> $`<fct>`
#> <quosure>
#> expr: ^<fct>
#> env:  empty
#> 
#> $`<fct>`
#> <quosure>
#> expr: ^<fct>
#> env:  empty

lapply(qs, eval_tidy)
#> $`<fct>`
#> x 
#> a 
#> Levels: a b
#> 
#> $`<fct>`
#> y 
#> b 
#> Levels: a b
```

After:

``` r
library(rlang)

f <- set_names(factor(c("a", "b")), c("x", "y"))

qs <- quos(!!!f, .named = TRUE)

qs
#> <list_of<quosure>>
#> 
#> $x
#> <quosure>
#> expr: ^<fct>
#> env:  empty
#> 
#> $y
#> <quosure>
#> expr: ^<fct>
#> env:  empty

lapply(qs, eval_tidy)
#> $x
#> [1] a
#> Levels: a b
#> 
#> $y
#> [1] b
#> Levels: a b
```