### PR TITLE
Special case lists in `rlang_as_list()`

### DIFF
--- a/R/dots.R
+++ b/R/dots.R
@@ -493,9 +493,17 @@ check_dots_empty <- function(...) {
 # `x` always end up on the names of the output list,
 # unlike `as.list.factor()`.
 rlang_as_list <- function(x) {
-  n <- length(x)
   names <- names(x)
 
+  # Special case if `x` is already a list.
+  # This also avoids accidentally shortening the `out` list with `[[<-`
+  # if any element of `x` happens to be `NULL`.
+  if (is.list(x)) {
+    attributes(x) <- list(names = names)
+    return(x)
+  }
+
+  n <- length(x)
   out <- vector("list", n)
 
   for (i in seq_len(n)) {

--- a/R/dots.R
+++ b/R/dots.R
@@ -493,16 +493,18 @@ check_dots_empty <- function(...) {
 # `x` always end up on the names of the output list,
 # unlike `as.list.factor()`.
 rlang_as_list <- function(x) {
-  names <- names(x)
-
-  # Special case if `x` is already a list.
-  # This also avoids accidentally shortening the `out` list with `[[<-`
-  # if any element of `x` happens to be `NULL`.
   if (is.list(x)) {
-    attributes(x) <- list(names = names)
-    return(x)
+    out <- rlang_as_list_from_list_impl(x)
+  } else {
+    out <- rlang_as_list_impl(x)
   }
 
+  names(out) <- names(x)
+
+  out
+}
+
+rlang_as_list_impl <- function(x) {
   n <- length(x)
   out <- vector("list", n)
 
@@ -510,7 +512,25 @@ rlang_as_list <- function(x) {
     out[[i]] <- x[[i]]
   }
 
-  names(out) <- names
+  out
+}
+
+# Special handling if `x` is already a list.
+# This avoids the potential for `out[[i]] <- NULL`,
+# which shortens the list.
+rlang_as_list_from_list_impl <- function(x) {
+  n <- length(x)
+  out <- vector("list", n)
+
+  for (i in seq_len(n)) {
+    elt <- x[[i]]
+
+    if (is.null(elt)) {
+      next
+    }
+
+    out[[i]] <- elt
+  }
 
   out
 }

--- a/tests/testthat/test-nse-force.R
+++ b/tests/testthat/test-nse-force.R
@@ -413,6 +413,13 @@ test_that("!!! calls `[[` with vector S4 objects", {
   expect_identical_(quos(!!!fievel), as_quos_list(exp_named))
 })
 
+test_that("!!! doesn't shorten S3 lists containing `NULL`", {
+  x <- structure(list(NULL), class = "foobar")
+  y <- structure(list(a = NULL, b = 1), class = "foobar")
+
+  expect_identical_(list2(!!!x), list(NULL))
+  expect_identical_(list2(!!!y), list(a = NULL, b = 1))
+})
 
 # bang ---------------------------------------------------------------
 

--- a/tests/testthat/test-nse-force.R
+++ b/tests/testthat/test-nse-force.R
@@ -421,6 +421,12 @@ test_that("!!! doesn't shorten S3 lists containing `NULL`", {
   expect_identical_(list2(!!!y), list(a = NULL, b = 1))
 })
 
+test_that("!!! goes through `[[` for record S3 types", {
+  x <- as.POSIXlt(as.Date("1970-01-01"))
+  x_named <- set_names(x, "a")
+  expect_identical_(list2(!!!x_named), list(a = x))
+})
+
 # bang ---------------------------------------------------------------
 
 test_that("single ! is not treated as shortcut", {

--- a/tests/testthat/test-nse-force.R
+++ b/tests/testthat/test-nse-force.R
@@ -422,9 +422,33 @@ test_that("!!! doesn't shorten S3 lists containing `NULL`", {
 })
 
 test_that("!!! goes through `[[` for record S3 types", {
-  x <- as.POSIXlt(as.Date("1970-01-01"))
-  x_named <- set_names(x, "a")
-  expect_identical_(list2(!!!x_named), list(a = x))
+  x <- structure(list(x = c(1, 2, 3), y = c(3, 2, 1)), class = "rcrd")
+
+  local_methods(
+    `[[.rcrd` = function(x, i, ...) {
+      structure(lapply(unclass(x), "[[", i), class = "rcrd")
+    },
+    names.rcrd = function(x) {
+      names(x$x)
+    },
+    `names<-.rcrd` = function(x, value) {
+      names(x$x) <- value
+      x
+    },
+    length.rcrd = function(x) {
+      length(x$x)
+    }
+  )
+
+  x_named <- set_names(x, c("a", "b", "c"))
+
+  expect <- list(
+    a = structure(list(x = 1, y = 3), class = "rcrd"),
+    b = structure(list(x = 2, y = 2), class = "rcrd"),
+    c = structure(list(x = 3, y = 1), class = "rcrd")
+  )
+
+  expect_identical_(list2(!!!x_named), expect)
 })
 
 # bang ---------------------------------------------------------------


### PR DESCRIPTION
I forgot that `[[<-` can shorten a list if you assign `NULL` directly to it. I've given lists their own path to avoid repeatedly checking if each element `is.null()` when splicing an S3 type that isn't a list.