### PR TITLE
Issue924: Resolve Normal Tilde's in Quosures

### DIFF
--- a/src/internal/utils.h
+++ b/src/internal/utils.h
@@ -7,6 +7,11 @@ void signal_soft_deprecated(const char* msg);
 sexp* rlang_ns_get(const char* name);
 sexp* rlang_enquo(sexp* sym, sexp* frame);
 
+ __attribute__((noreturn))
+void never_reached(const char* fn) {
+  r_abort("Internal error in `%s()`: Reached the unreachable.", fn);
+}
+
 extern sexp* rlang_ns_env;
 
 

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -508,7 +508,7 @@ test_that("Non-quosure tilde found correctly (#924)", {
       f <- function(`~`) quo(~1)
       f()
     }),
-    "missing, with no default"
+    "not found"
   )
 
   # No tilde
@@ -516,13 +516,22 @@ test_that("Non-quosure tilde found correctly (#924)", {
   env[['quo']] <- quo
   expect_error(
     eval_tidy(local(quo(~1), envir = env)),
-    "Could not find function"
+    "not found"
   )
 
   # But make sure quosure tilde works
   env[['x']] <- 1
   expect_equal(eval_tidy(local(quo(x), envir = env)), 1)
 })
+
+test_that("can evaluate tilde in nested masks", {
+  tilde <- eval_tidy(quo(eval_tidy(~1)))
+  expect_identical(
+    eval_bare(tilde, f_env(tilde)),
+    tilde
+  )
+})
+
 
 # Lifecycle ----------------------------------------------------------
 

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -462,10 +462,10 @@ test_that(".data pronoun handles promises (#908)", {
 })
 
 test_that("Non-quosure tilde found correctly (#924)", {
-  ## Base tilde
+  # Base tilde
   expect_equal(eval_tidy(quo(~1)), ~1)
 
-  ## tilde outside
+  # Tilde outside
   expect_equal(
     with(
       list(`~` = function(...) "outside"),
@@ -473,7 +473,8 @@ test_that("Non-quosure tilde found correctly (#924)", {
     ),
     "outside"
   )
-  ## tilde inside; works trivially
+
+  # Tilde inside; works trivially
   expect_equal(
     eval_tidy(
       quo(
@@ -483,8 +484,8 @@ test_that("Non-quosure tilde found correctly (#924)", {
     ) ) ),
     "inside"
   )
-  ## tilde in promise
 
+  # Tilde in promise
   expect_equal(
     eval_tidy({
       f <- function(`~`) quo(~1)
@@ -509,18 +510,18 @@ test_that("Non-quosure tilde found correctly (#924)", {
     }),
     "missing, with no default"
   )
-  ## no tilde
 
+  # No tilde
   env <- new.env(parent=emptyenv())
   env[['quo']] <- quo
   expect_error(
     eval_tidy(local(quo(~1), envir = env)),
     "Could not find function"
   )
-  ## but make sure quosure tilde works
 
+  # But make sure quosure tilde works
   env[['x']] <- 1
-  expect_equal(eval_tidy(local(quo(x), envir=env)), 1)
+  expect_equal(eval_tidy(local(quo(x), envir = env)), 1)
 })
 
 # Lifecycle ----------------------------------------------------------


### PR DESCRIPTION
Fix #924 

This ended up a bit complicated as in order to work correctly we have to search through all the enclosures while also skipping the mask environment, so we couldn't just rely on `Rf_findFun`.  I'm also not a huge fan of how the KEEP/FREE business ended up in `findTilde`, but I didn't want to resort to more complex PROTECT stack management (that I'm less familiar with).

Note this does not correctly resolve things like `get('~')` which will return the Rlang tilde.  I tested this with valgrind, SAN, and rchk.  For rchk, there are errors, but they appear to be from code I did not touch:

```
   Function mask_find
     [UP] protect stack is too deep, unprotecting all variables, results will be incomplete
     [UP] calling allocating function r_eval with a fresh pointer (obj <arg 1>) /opt/R-svn/packages/build/En6i7e90/rlang/src/./internal/eval-tidy.c:219
     [UP] unsupported form of unprotect, unprotecting all variables, results will be incomplete /opt/R-svn/packages/build/En6i7e90/rlang/src/./internal/eval-tidy.c:222
     [UP] unsupported form of unprotect, unprotecting all variables, results will be incomplete /opt/R-svn/packages/build/En6i7e90/rlang/src/./internal/eval-tidy.c:233
```