### PR TITLE
Mark the value as not mutable, not the expression

### DIFF
--- a/src/capture.c
+++ b/src/capture.c
@@ -41,6 +41,7 @@ SEXP attribute_hidden new_captured_promise(SEXP x, SEXP env) {
         expr = new_captured_literal(value);
         UNPROTECT(1);
     } else {
+        MARK_NOT_MUTABLE(expr);
         expr = new_captured_arg(expr, expr_env);
     }
 

--- a/src/capture.c
+++ b/src/capture.c
@@ -41,7 +41,6 @@ SEXP attribute_hidden new_captured_promise(SEXP x, SEXP env) {
         expr = new_captured_literal(value);
         UNPROTECT(1);
     } else {
-        MARK_NOT_MUTABLE(expr);
         expr = new_captured_arg(expr, expr_env);
     }
 

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -452,6 +452,7 @@ static sexp* dots_unquote(sexp* dots, struct dots_capture_info* capture_info) {
       r_abort("Internal error: `OP_DOTS_MAX`");
     }
 
+    r_mark_shared(expr);
     r_node_poke_car(node, expr);
     FREE(1);
   }


### PR DESCRIPTION
@lionel- this seems to fix the vctrs issues we were seeing around namedness.

It almost seems like you were trying to do this already with the `MARK_NOT_MUTABLE()` that I removed. But maybe it was in the wrong place because this was marking the unevaluated expression as not mutable, not the actual value you get? Maybe I'm wrong.

I'm having trouble coming up with a test. Any ideas?