### PR TITLE
Update docs around `class` (vs `.subclass`)

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -3,10 +3,10 @@
 #' @description
 #'
 #' These functions are equivalent to base functions [base::stop()],
-#' [base::warning()] and [base::message()], but make it easy to supply
+#' [base::warning()], and [base::message()], but make it easy to supply
 #' condition metadata:
 #'
-#' * Supply `.subclass` to create a classed condition. Typed
+#' * Supply `class` to create a classed condition. Typed
 #'   conditions can be captured or handled selectively, allowing for
 #'   finer-grained error handling.
 #'
@@ -53,11 +53,12 @@
 #' @section Lifecycle:
 #'
 #' These functions were changed in rlang 0.3.0 to take condition
-#' metadata with `...`. Consequently:
+#' metadata with `...` and further changes occurred in 0.4.2. Consequently:
 #'
-#' * All arguments were renamed to be prefixed with a dot, except for
-#'   `type` which was renamed to `.subclass`.
-#' * `.call` (previously `call`) can no longer be passed positionally.
+#' * The `type` argument was renamed to `.subclass` (0.3.0) and then renamed
+#'   again to `class` (0.4.2).
+#' * Only `message` and `class` can be passed positionally, i.e. they are the
+#'   only arguments before `...`.
 #'
 #' @inheritParams cnd
 #' @param message The message to display.

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -75,10 +75,10 @@ still filter out the messages easily by redirecting \code{stderr}.}
 }
 \description{
 These functions are equivalent to base functions \code{\link[base:stop]{base::stop()}},
-\code{\link[base:warning]{base::warning()}} and \code{\link[base:message]{base::message()}}, but make it easy to supply
+\code{\link[base:warning]{base::warning()}}, and \code{\link[base:message]{base::message()}}, but make it easy to supply
 condition metadata:
 \itemize{
-\item Supply \code{.subclass} to create a classed condition. Typed
+\item Supply \code{class} to create a classed condition. Typed
 conditions can be captured or handled selectively, allowing for
 finer-grained error handling.
 \item Supply metadata with named \code{...} arguments. This data will be
@@ -129,11 +129,12 @@ guaranteed.
 
 
 These functions were changed in rlang 0.3.0 to take condition
-metadata with \code{...}. Consequently:
+metadata with \code{...} and further changes occurred in 0.4.2. Consequently:
 \itemize{
-\item All arguments were renamed to be prefixed with a dot, except for
-\code{type} which was renamed to \code{.subclass}.
-\item \code{.call} (previously \code{call}) can no longer be passed positionally.
+\item The \code{type} argument was renamed to \code{.subclass} (0.3.0) and then renamed
+again to \code{class} (0.4.2).
+\item Only \code{message} and \code{class} can be passed positionally, i.e. they are the
+only arguments before \code{...}.
 }
 }
 


### PR DESCRIPTION
I think there are places in the docs that suggest `type` --> `.subclass` is the most recent change. But in fact there is also `.subclass` --> `class`. I'm not entirely sure I have the wording right, so feel free to refine this PR or close and make the changes separately. But I am pretty sure this is an improvement.