### PR TITLE
Run exit expressions in LIFO order

### DIFF
--- a/R/events.R
+++ b/R/events.R
@@ -1,6 +1,7 @@
 
 local_exit <- function(expr, frame = caller_env()) {
   expr <- enexpr(expr)
+  out <- expr
 
   # We are at top-level when only one frame refers to the global environment
   if (is_reference(frame, global_env())) {
@@ -10,9 +11,67 @@ local_exit <- function(expr, frame = caller_env()) {
     }
   }
 
-  # Inline everything so the call will succeed in any environment
-  expr <- call2(on.exit, expr, add = TRUE)
-  eval_bare(expr, frame)
+  exit_exprs <- eval_bare(call2(sys.on.exit), frame)
+  rlang_exit <- detect_rlang_exit(exit_exprs)
 
-  invisible(expr)
+  if (is_null(rlang_exit)) {
+    first_expr <- new_node(expr)
+    exit_marker_env <- new_environment(list(
+      exprs = first_expr,
+      frame = frame
+    ))
+
+    expr <- call2(eval_rlang_exit, exit_marker_env)
+
+    # Add marker to exit expressions
+    expr <- call2("{", "_rlang_exit", expr)
+
+    # Inline everything so the call will succeed in any environment
+    expr <- call2(on.exit, expr, add = TRUE)
+
+    eval_bare(expr, frame)
+  } else {
+    # Insert new exit in place in LIFO order
+    exit_marker_env <- node_cadr(rlang_exit)
+    exit_marker_env$exprs <- new_node(expr, exit_marker_env$exprs)
+  }
+
+  invisible(out)
+}
+
+eval_rlang_exit <- function(marker_env) {
+  exits <- new_call(`{`, marker_env$exprs)
+  eval_bare(exits, marker_env$frame)
+}
+
+# This is set up to recurse across `{` calls for robustness
+# because sys.on.exit() rewraps in `{`
+detect_rlang_exit <- function(expr) {
+  if (!is_call(expr, "{")) {
+    return(NULL)
+  }
+
+  expr <- node_cdr(expr)
+
+  while (!is_null(expr)) {
+    exit <- node_car(expr)
+    expr <- node_cdr(expr)
+
+    if (is_call(exit, "{")) {
+      exit <- detect_rlang_exit(exit)
+      if (is_null(exit)) {
+        next
+      } else {
+        return(exit)
+      }
+    }
+
+    if (identical(exit, "_rlang_exit")) {
+      return(node_car(expr))
+    }
+
+    next
+  }
+
+  NULL
 }

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -91,6 +91,20 @@ test_that("local_bindings binds temporarily", {
   expect_false(env_has(env, "baz"))
 })
 
+test_that("local_bindings() restores in correct order", {
+  foo <- "start"
+
+  local({
+    local_bindings(foo = "foo")
+    expect_identical(foo, "foo")
+
+    local_bindings(foo = "bar")
+    expect_identical(foo, "bar")
+  })
+
+  expect_identical(foo, "start")
+})
+
 test_that("with_bindings() evaluates with temporary bindings", {
   foo <- "foo"
   baz <- "baz"

--- a/tests/testthat/test-state.R
+++ b/tests/testthat/test-state.R
@@ -28,3 +28,20 @@ test_that("is_interactive() honors rlang_interactive option, above all else", {
   expect_false(is_interactive())
   expect_true(with_interactive(value = TRUE, is_interactive()))
 })
+
+test_that("local_options() restores options in correct order (#980)", {
+  local_options(foo = -1)
+
+  local({
+    local_options(foo = 0)
+    local_options(foo = 1)
+  })
+  expect_identical(peek_option("foo"), -1)
+
+  local({
+    on.exit("existing")
+    local_options(foo = 0)
+    local_options(foo = 1)
+  })
+  expect_identical(peek_option("foo"), -1)
+})


### PR DESCRIPTION
Closes #980

Implements `after = ` logic with a custom stack of exit expressions so it works on old R versions.