### PR TITLE
Use R_*Value in r_lgl()

### DIFF
--- a/src/lib/vec-lgl.h
+++ b/src/lib/vec-lgl.h
@@ -5,7 +5,8 @@
 int r_as_optional_bool(sexp* lgl);
 
 static inline sexp* r_lgl(bool x) {
-  return Rf_ScalarLogical(x);
+  extern SEXP R_TrueValue, R_FalseValue;
+  return x ? R_TrueValue : R_FalseValue;
 }
 
 bool r_is_true(sexp* x);


### PR DESCRIPTION
to shave off a few cycles perhaps? Impact not measured.

AFAICT R checks consistency of these values in `gc()`, they should be safe? Are we allowed to use them anyway?