### PR TITLE
Add `.named` argument to `dots_list()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # rlang (development version)
 
+* `dots_list()` gains a `.named` argument for auto-naming dots (#957).
+
 * It is now possible to subset the `.data` pronoun with quosured
   symbols or strings (#807).
 

--- a/R/dots.R
+++ b/R/dots.R
@@ -97,6 +97,9 @@ list3 <- function(...) {
 
 
 #' @rdname list2
+#' @param .named Whether to ensure all dots are named. Unnamed
+#'   elements are processed with [as_label()] to build a default
+#'   name.
 #' @param .ignore_empty Whether to ignore empty arguments. Can be one
 #'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
 #'   last argument is ignored if it is empty.
@@ -185,13 +188,14 @@ list3 <- function(...) {
 #' # This requires users to be explicit about their intent:
 #' my_list({ a <- 1 })
 dots_list <- function(...,
+                      .named = FALSE,
                       .ignore_empty = c("trailing", "none", "all"),
                       .preserve_empty = FALSE,
                       .homonyms = c("keep", "first", "last", "error"),
                       .check_assign = FALSE) {
   dots <- .Call(rlang_dots_list,
     frame_env = environment(),
-    named = FALSE,
+    named = .named,
     ignore_empty = .ignore_empty,
     preserve_empty = .preserve_empty,
     unquote_names = TRUE,

--- a/R/nse-defuse.R
+++ b/R/nse-defuse.R
@@ -110,9 +110,6 @@
 #'   arguments to capture without evaluation (including `...`). For
 #'   `exprs()` and `quos()`, the expressions to capture unevaluated
 #'   (including expressions contained in `...`).
-#' @param .named Whether to ensure all dots are named. Unnamed
-#'   elements are processed with [as_label()] to build a default
-#'   name. See also [quos_auto_name()].
 #' @param .ignore_empty Whether to ignore empty arguments. Can be one
 #'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the
 #'   last argument is ignored if it is empty. Note that `"trailing"`

--- a/R/nse-defuse.R
+++ b/R/nse-defuse.R
@@ -111,7 +111,7 @@
 #'   `exprs()` and `quos()`, the expressions to capture unevaluated
 #'   (including expressions contained in `...`).
 #' @param .named Whether to ensure all dots are named. Unnamed
-#'   elements are processed with [quo_name()] to build a default
+#'   elements are processed with [as_label()] to build a default
 #'   name. See also [quos_auto_name()].
 #' @param .ignore_empty Whether to ignore empty arguments. Can be one
 #'   of `"trailing"`, `"none"`, `"all"`. If `"trailing"`, only the

--- a/man/dots_definitions.Rd
+++ b/man/dots_definitions.Rd
@@ -17,7 +17,7 @@ arguments to capture without evaluation (including \code{...}). For
 (including expressions contained in \code{...}).}
 
 \item{.named}{Whether to ensure all dots are named. Unnamed
-elements are processed with \code{\link[=quo_name]{quo_name()}} to build a default
+elements are processed with \code{\link[=as_label]{as_label()}} to build a default
 name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one

--- a/man/dots_definitions.Rd
+++ b/man/dots_definitions.Rd
@@ -18,7 +18,7 @@ arguments to capture without evaluation (including \code{...}). For
 
 \item{.named}{Whether to ensure all dots are named. Unnamed
 elements are processed with \code{\link[=as_label]{as_label()}} to build a default
-name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
+name.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/man/list2.Rd
+++ b/man/list2.Rd
@@ -10,6 +10,7 @@ list2(...)
 
 dots_list(
   ...,
+  .named = FALSE,
   .ignore_empty = c("trailing", "none", "all"),
   .preserve_empty = FALSE,
   .homonyms = c("keep", "first", "last", "error"),
@@ -19,6 +20,10 @@ dots_list(
 \arguments{
 \item{...}{Arguments to collect in a list. These dots are
 \link[=dyn-dots]{dynamic}.}
+
+\item{.named}{Whether to ensure all dots are named. Unnamed
+elements are processed with \code{\link[=as_label]{as_label()}} to build a default
+name.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/man/nse-defuse.Rd
+++ b/man/nse-defuse.Rd
@@ -79,7 +79,7 @@ arguments to capture without evaluation (including \code{...}). For
 (including expressions contained in \code{...}).}
 
 \item{.named}{Whether to ensure all dots are named. Unnamed
-elements are processed with \code{\link[=quo_name]{quo_name()}} to build a default
+elements are processed with \code{\link[=as_label]{as_label()}} to build a default
 name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one

--- a/man/nse-defuse.Rd
+++ b/man/nse-defuse.Rd
@@ -80,7 +80,7 @@ arguments to capture without evaluation (including \code{...}). For
 
 \item{.named}{Whether to ensure all dots are named. Unnamed
 elements are processed with \code{\link[=as_label]{as_label()}} to build a default
-name. See also \code{\link[=quos_auto_name]{quos_auto_name()}}.}
+name.}
 
 \item{.ignore_empty}{Whether to ignore empty arguments. Can be one
 of \code{"trailing"}, \code{"none"}, \code{"all"}. If \code{"trailing"}, only the

--- a/src/lib/vec-chr.h
+++ b/src/lib/vec-chr.h
@@ -74,6 +74,10 @@ static inline sexp* r_str_as_character(sexp* x) {
   return Rf_ScalarString(x);
 }
 
+static inline sexp* r_chr_as_symbol(sexp* str) {
+  return r_sym(Rf_translateChar(r_chr_get(str, 0)));
+}
+
 static inline bool r_str_is_name(sexp* str) {
   if (str == r_missing_str) {
     return false;

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -285,3 +285,26 @@ test_that("!!! does not evaluate multiple times (#981)", {
   quos(!!!list(foo()))
   expect_identical(x, 1)
 })
+
+test_that("dots_list() optionally auto-names arguments (#957)", {
+  expect_identical(
+    dots_list(.named = TRUE),
+    named(list())
+  )
+  expect_identical(
+    dots_list(1, letters, .named = TRUE),
+    list(`1` = 1, letters = letters)
+  )
+  expect_identical(
+    dots_list(1, foo = letters, .named = TRUE),
+    list(`1` = 1, foo = letters)
+  )
+  expect_identical(
+    dots_list(!!!list(a = 1:3, 1:3), .named = TRUE),
+    list(a = 1:3, `<int>` = 1:3)
+  )
+  expect_identical(
+    dots_list(!!!list(1:3, 1:3), .named = TRUE),
+    list(`<int>` = 1:3, `<int>` = 1:3)
+  )
+})


### PR DESCRIPTION
Same functionality as with `enquos()`. Closes #957.

```r
dots_list(1, letters, .named = TRUE)
#> $`1`
#> [1] 1
#>
#> $letters
#>  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u"
#> [22] "v" "w" "x" "y" "z"
```