### PR TITLE
Move `env_has()` and `env_unbind()` to C

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # rlang (development version)
 
+* `env_has()` is now rewritten in C for performance.
+
 * `dots_list()` gains a `.named` argument for auto-naming dots (#957).
 
 * It is now possible to subset the `.data` pronoun with quosured

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # rlang (development version)
 
+* `env_unbind(inherit = TRUE)` now only removes a binding from the
+  first parent environment that has a binding. It used to remove the
+  bindings from the whole ancestry. The new behaviour doesn't
+  guarantee that a scope doesn't have a binding but it is safer.
+
 * `env_has()` is now rewritten in C for performance.
 
 * `dots_list()` gains a `.named` argument for auto-naming dots (#957).

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -332,17 +332,10 @@ with_bindings <- function(.expr, ..., .env = caller_env()) {
 #' env <- env(parent, foo = "b")
 #'
 #' env_unbind(env, "foo", inherit = TRUE)
+#' env_has(env, c("foo", "bar"))
 #' env_has(env, c("foo", "bar"), inherit = TRUE)
 env_unbind <- function(env = caller_env(), nms, inherit = FALSE) {
-  if (inherit) {
-    while (any(exist <- env_has(env, nms, inherit = TRUE))) {
-      rm(list = nms[exist], envir = env, inherits = TRUE)
-    }
-  } else {
-    exist <- env_has(env, nms, inherit = FALSE)
-    rm(list = nms[exist], envir = env)
-  }
-
+  .Call(rlang_env_unbind, env, nms, inherit)
   invisible(env)
 }
 

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -365,8 +365,7 @@ env_unbind <- function(env = caller_env(), nms, inherit = FALSE) {
 #' env_has(env, "foo", inherit = TRUE)
 env_has <- function(env = caller_env(), nms, inherit = FALSE) {
   env <- get_env_retired(env, "env_has()")
-  nms <- set_names(nms)
-  map_lgl(nms, exists, envir = env, inherits = inherit)
+  .Call(rlang_env_has, env, nms, inherit)
 }
 
 #' Get an object in an environment

--- a/man/env_unbind.Rd
+++ b/man/env_unbind.Rd
@@ -38,5 +38,6 @@ parent <- env(empty_env(), foo = 1, bar = 2)
 env <- env(parent, foo = "b")
 
 env_unbind(env, "foo", inherit = TRUE)
+env_has(env, c("foo", "bar"))
 env_has(env, c("foo", "bar"), inherit = TRUE)
 }

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -137,6 +137,7 @@ extern sexp* rlang_linked_version();
 extern sexp* rlang_names2(sexp*, sexp*);
 extern sexp* rlang_set_names(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_chr_get(sexp* x, sexp* i);
+extern sexp* rlang_env_has(sexp*, sexp*, sexp*);
 
 // Library initialisation defined below
 sexp* rlang_library_load(sexp*);
@@ -309,6 +310,7 @@ static const r_callable r_callables[] = {
   {"rlang_names2",                      (r_fn_ptr) &rlang_names2, 2},
   {"rlang_set_names",                   (r_fn_ptr) &rlang_set_names, 4},
   {"rlang_chr_get",                     (r_fn_ptr) &rlang_chr_get, 2},
+  {"rlang_env_has",                     (r_fn_ptr) &rlang_env_has, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/internal/env-binding.c
+++ b/src/internal/env-binding.c
@@ -18,3 +18,30 @@ sexp* rlang_env_get(sexp* env, sexp* nm) {
   FREE(1);
   return out;
 }
+
+sexp* rlang_env_has(sexp* env, sexp* nms, sexp* inherit) {
+  if (r_typeof(nms) != r_type_character) {
+    r_abort("`nms` must be a character vector.");
+  }
+  if (r_typeof(inherit) != r_type_logical) {
+    r_abort("`inherit` must be a logical value.");
+  }
+
+  bool c_inherits = r_lgl_get(inherit, 0);
+  bool (*env_has)(sexp*, sexp*) = c_inherits ? &r_env_has_anywhere : &r_env_has;
+
+  r_ssize n = r_length(nms);
+  sexp* out = KEEP(r_new_vector(r_type_logical, n));
+
+  int* p_out = r_lgl_deref(out);
+  sexp* const * p_nms = r_chr_deref(nms);
+
+  for (r_ssize i = 0; i < n; ++i) {
+    sexp* sym = r_str_as_symbol(p_nms[i]);
+    p_out[i] = env_has(env, sym);
+  }
+
+  r_poke_names(out, nms);
+  FREE(1);
+  return out;
+}

--- a/src/internal/env-binding.c
+++ b/src/internal/env-binding.c
@@ -27,18 +27,22 @@ sexp* rlang_env_has(sexp* env, sexp* nms, sexp* inherit) {
     r_abort("`inherit` must be a logical value.");
   }
 
-  bool c_inherits = r_lgl_get(inherit, 0);
-  bool (*env_has)(sexp*, sexp*) = c_inherits ? &r_env_has_anywhere : &r_env_has;
-
   r_ssize n = r_length(nms);
   sexp* out = KEEP(r_new_vector(r_type_logical, n));
 
   int* p_out = r_lgl_deref(out);
   sexp* const * p_nms = r_chr_deref(nms);
 
-  for (r_ssize i = 0; i < n; ++i) {
-    sexp* sym = r_str_as_symbol(p_nms[i]);
-    p_out[i] = env_has(env, sym);
+  if (r_lgl_get(inherit, 0)) {
+    for (r_ssize i = 0; i < n; ++i) {
+      sexp* sym = r_str_as_symbol(p_nms[i]);
+      p_out[i] = r_env_has_anywhere(env, sym);
+    }
+  } else {
+    for (r_ssize i = 0; i < n; ++i) {
+      sexp* sym = r_str_as_symbol(p_nms[i]);
+      p_out[i] = r_env_has(env, sym);
+    }
   }
 
   r_poke_names(out, nms);

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -445,14 +445,14 @@ sexp* rlang_data_mask_clean(sexp* mask) {
   }
 
   // At this level we only want to remove our own stuff
-  r_env_unbind_all(mask, data_mask_objects_names, false);
+  r_env_unbind_strings(mask, data_mask_objects_names);
 
   // Remove everything in the other levels
   sexp* env = bottom;
   sexp* parent = r_env_parent(top);
   while (env != parent) {
     sexp* nms = KEEP(r_env_names(env));
-    r_env_unbind_names(env, nms, false);
+    r_env_unbind_names(env, nms);
     FREE(1);
     env = r_env_parent(env);
   }

--- a/src/lib/env.c
+++ b/src/lib/env.c
@@ -135,10 +135,12 @@ static sexp* remove_call = NULL;
 
 #if (R_VERSION < R_Version(4, 0, 0))
 void r__env_unbind(sexp* env, sexp* sym) {
-  sexp* nm = KEEP(r_sym_as_character(sym));
-  sexp* out = eval_with_xyz(remove_call, env, nm, r_shared_false);
-  FREE(1);
-  return out;
+  // Check if binding exists to avoid `rm()` warning
+  if (r_env_has(env, sym)) {
+    sexp* nm = KEEP(r_sym_as_character(sym));
+    eval_with_xyz(remove_call, env, nm, r_shared_false);
+    FREE(1);
+  }
 }
 #endif
 
@@ -161,9 +163,6 @@ void r_env_unbind_syms(sexp* env, sexp** syms) {
 
 static
 void env_unbind_names(sexp* env, sexp* names, bool inherit) {
-#if (R_VERSION < R_Version(4, 0, 0))
-  eval_with_xyz(remove_call, env, names, r_lgl(inherit));
-#else
   sexp* const * p_names = r_chr_deref(names);
   r_ssize n = r_length(names);
 
@@ -178,7 +177,6 @@ void env_unbind_names(sexp* env, sexp* names, bool inherit) {
       r_env_unbind(env, sym);
     }
   }
-#endif
 }
 
 void r_env_unbind_names(sexp* env, sexp* names) {

--- a/src/lib/env.c
+++ b/src/lib/env.c
@@ -133,11 +133,11 @@ sexp* r_env_clone(sexp* env, sexp* parent) {
 
 static sexp* remove_call = NULL;
 
-sexp* r_env_unbind_names(sexp* env, sexp* names) {
-  return eval_with_xyz(remove_call, env, names, r_shared_false);
+void r_env_unbind_names(sexp* env, sexp* names) {
+  eval_with_xyz(remove_call, env, names, r_shared_false);
 }
-sexp* r_env_unbind_anywhere_names(sexp* env, sexp* names) {
-  return eval_with_xyz(remove_call, env, names, r_shared_true);
+void r_env_unbind_anywhere_names(sexp* env, sexp* names) {
+  eval_with_xyz(remove_call, env, names, r_shared_true);
 }
 
 sexp* rlang_env_unbind(sexp* env, sexp* names, sexp* inherits) {
@@ -152,34 +152,34 @@ sexp* rlang_env_unbind(sexp* env, sexp* names, sexp* inherits) {
   }
 
   if (*r_lgl_deref(inherits)) {
-    return r_env_unbind_anywhere_names(env, names);
+    r_env_unbind_anywhere_names(env, names);
   } else {
-    return r_env_unbind_names(env, names);
+    r_env_unbind_names(env, names);
   }
+
+  return r_null;
 }
 
-sexp* r_env_unbind_strings(sexp* env, const char** names) {
+void r_env_unbind_strings(sexp* env, const char** names) {
   sexp* nms = KEEP(r_new_character(names));
-  sexp* out = r_env_unbind_names(env, nms);
+  r_env_unbind_names(env, nms);
   FREE(1);
-  return out;
 }
-sexp* r_env_unbind_anywhere_strings(sexp* env, const char** names) {
+void r_env_unbind_anywhere_strings(sexp* env, const char** names) {
   sexp* nms = KEEP(r_new_character(names));
-  sexp* out = r_env_unbind_anywhere_names(env, nms);
+  r_env_unbind_anywhere_names(env, nms);
   FREE(1);
-  return out;
 }
 
-sexp* r_env_unbind_string(sexp* env, const char* name) {
+void r_env_unbind_string(sexp* env, const char* name) {
   static const char* names[2] = { "", NULL };
   names[0] = name;
-  return r_env_unbind_strings(env, names);
+  r_env_unbind_strings(env, names);
 }
-sexp* r_env_unbind_string_anywhere(sexp* env, const char* name) {
+void r_env_unbind_string_anywhere(sexp* env, const char* name) {
   static const char* names[2] = { "", NULL };
   names[0] = name;
-  return r_env_unbind_anywhere_strings(env, names);
+  r_env_unbind_anywhere_strings(env, names);
 }
 
 bool r_env_inherits(sexp* env, sexp* ancestor, sexp* top) {

--- a/src/lib/env.c
+++ b/src/lib/env.c
@@ -171,12 +171,12 @@ sexp* r_env_unbind_anywhere_strings(sexp* env, const char** names) {
   return out;
 }
 
-sexp* r_env_unbind(sexp* env, const char* name) {
+sexp* r_env_unbind_string(sexp* env, const char* name) {
   static const char* names[2] = { "", NULL };
   names[0] = name;
   return r_env_unbind_strings(env, names);
 }
-sexp* r_env_unbind_anywhere(sexp* env, const char* name) {
+sexp* r_env_unbind_string_anywhere(sexp* env, const char* name) {
   static const char* names[2] = { "", NULL };
   names[0] = name;
   return r_env_unbind_anywhere_strings(env, names);

--- a/src/lib/env.h
+++ b/src/lib/env.h
@@ -71,9 +71,21 @@ sexp* r_env_as_list(sexp* x);
 sexp* r_list_as_environment(sexp* x, sexp* parent);
 sexp* r_env_clone(sexp* env, sexp* parent);
 
+
+static inline
+void r_env_unbind(sexp* env, sexp* sym) {
+#if (R_VERSION < R_Version(4, 0, 0))
+  r__env_unbind(env, sym);
+#else
+  R_removeVarFromFrame(sym, env);
+#endif
+}
+void r_env_unbind_anywhere(sexp* env, sexp* sym);
+
+void r_env_unbind_syms(sexp* env, sexp** syms);
 void r_env_unbind_string(sexp* env, const char* name);
-void r_env_unbind_names(sexp* env, sexp* names);
 void r_env_unbind_strings(sexp* env, const char** strings);
+void r_env_unbind_names(sexp* env, sexp* names);
 
 void r_env_unbind_string_anywhere(sexp* env, const char* name);
 void r_env_unbind_anywhere_names(sexp* env, sexp* names);

--- a/src/lib/env.h
+++ b/src/lib/env.h
@@ -75,6 +75,7 @@ sexp* r_env_clone(sexp* env, sexp* parent);
 static inline
 void r_env_unbind(sexp* env, sexp* sym) {
 #if (R_VERSION < R_Version(4, 0, 0))
+  void r__env_unbind(sexp*, sexp*);
   r__env_unbind(env, sym);
 #else
   R_removeVarFromFrame(sym, env);

--- a/src/lib/env.h
+++ b/src/lib/env.h
@@ -71,11 +71,11 @@ sexp* r_env_as_list(sexp* x);
 sexp* r_list_as_environment(sexp* x, sexp* parent);
 sexp* r_env_clone(sexp* env, sexp* parent);
 
-sexp* r_env_unbind(sexp* env, const char* name);
+sexp* r_env_unbind_string(sexp* env, const char* name);
 sexp* r_env_unbind_names(sexp* env, sexp* names);
 sexp* r_env_unbind_strings(sexp* env, const char** strings);
 
-sexp* r_env_unbind_anywhere(sexp* env, const char* name);
+sexp* r_env_unbind_string_anywhere(sexp* env, const char* name);
 sexp* r_env_unbind_anywhere_names(sexp* env, sexp* names);
 sexp* r_env_unbind_anywhere_strings(sexp* env, const char** names);
 

--- a/src/lib/env.h
+++ b/src/lib/env.h
@@ -71,9 +71,13 @@ sexp* r_env_as_list(sexp* x);
 sexp* r_list_as_environment(sexp* x, sexp* parent);
 sexp* r_env_clone(sexp* env, sexp* parent);
 
-sexp* r_env_unbind_names(sexp* env, sexp* names, bool inherits);
-sexp* r_env_unbind_all(sexp* env, const char** names, bool inherits);
-sexp* r_env_unbind(sexp* env, const char* name, bool inherits);
+sexp* r_env_unbind(sexp* env, const char* name);
+sexp* r_env_unbind_names(sexp* env, sexp* names);
+sexp* r_env_unbind_strings(sexp* env, const char** strings);
+
+sexp* r_env_unbind_anywhere(sexp* env, const char* name);
+sexp* r_env_unbind_anywhere_names(sexp* env, sexp* names);
+sexp* r_env_unbind_anywhere_strings(sexp* env, const char** names);
 
 bool r_env_inherits(sexp* env, sexp* ancestor, sexp* top);
 

--- a/src/lib/env.h
+++ b/src/lib/env.h
@@ -71,13 +71,13 @@ sexp* r_env_as_list(sexp* x);
 sexp* r_list_as_environment(sexp* x, sexp* parent);
 sexp* r_env_clone(sexp* env, sexp* parent);
 
-sexp* r_env_unbind_string(sexp* env, const char* name);
-sexp* r_env_unbind_names(sexp* env, sexp* names);
-sexp* r_env_unbind_strings(sexp* env, const char** strings);
+void r_env_unbind_string(sexp* env, const char* name);
+void r_env_unbind_names(sexp* env, sexp* names);
+void r_env_unbind_strings(sexp* env, const char** strings);
 
-sexp* r_env_unbind_string_anywhere(sexp* env, const char* name);
-sexp* r_env_unbind_anywhere_names(sexp* env, sexp* names);
-sexp* r_env_unbind_anywhere_strings(sexp* env, const char** names);
+void r_env_unbind_string_anywhere(sexp* env, const char* name);
+void r_env_unbind_anywhere_names(sexp* env, sexp* names);
+void r_env_unbind_anywhere_strings(sexp* env, const char** names);
 
 bool r_env_inherits(sexp* env, sexp* ancestor, sexp* top);
 

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -1,8 +1,4 @@
 
-r_env_unbind <- function(env, names, inherits = FALSE) {
-  invisible(.Call(rlang_env_unbind, env, names, inherits))
-}
-
 r_parse_eval <- function(x, env = caller_env()) {
   .Call(rlang_test_parse_eval, x, env)
 }

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -1,5 +1,5 @@
 
-r_env_unbind <- function(env, names, inherits = FALSE) {
+r_env_unbind_anywhere <- function(env, names, inherits = FALSE) {
   invisible(.Call(rlang_env_unbind, env, names, inherits))
 }
 

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -1,5 +1,5 @@
 
-r_env_unbind_string_anywhere <- function(env, names, inherits = FALSE) {
+r_env_unbind <- function(env, names, inherits = FALSE) {
   invisible(.Call(rlang_env_unbind, env, names, inherits))
 }
 

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -1,5 +1,5 @@
 
-r_env_unbind_anywhere <- function(env, names, inherits = FALSE) {
+r_env_unbind_string_anywhere <- function(env, names, inherits = FALSE) {
   invisible(.Call(rlang_env_unbind, env, names, inherits))
 }
 

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -236,15 +236,15 @@ test_that("client library passes tests", {
   expect_identical(result, 0L)
 })
 
-test_that("r_env_unbind_anywhere() removes objects", {
+test_that("r_env_unbind_string_anywhere() removes objects", {
   env <- env(a = 1L)
-  r_env_unbind_anywhere(env, "a")
+  r_env_unbind_string_anywhere(env, "a")
   expect_false(env_has(env, "a"))
 
   env <- env(a = 1L)
   child <- child_env(env)
-  expect_warning(r_env_unbind_anywhere(child, "a"), "not found")
-  r_env_unbind_anywhere(child, "a", inherits = TRUE)
+  expect_warning(r_env_unbind_string_anywhere(child, "a"), "not found")
+  r_env_unbind_string_anywhere(child, "a", inherits = TRUE)
   expect_false(env_has(env, "a"))
 })
 

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -236,15 +236,15 @@ test_that("client library passes tests", {
   expect_identical(result, 0L)
 })
 
-test_that("r_env_unbind() removes objects", {
+test_that("r_env_unbind_anywhere() removes objects", {
   env <- env(a = 1L)
-  r_env_unbind(env, "a")
+  r_env_unbind_anywhere(env, "a")
   expect_false(env_has(env, "a"))
 
   env <- env(a = 1L)
   child <- child_env(env)
-  expect_warning(r_env_unbind(child, "a"), "not found")
-  r_env_unbind(child, "a", inherits = TRUE)
+  expect_warning(r_env_unbind_anywhere(child, "a"), "not found")
+  r_env_unbind_anywhere(child, "a", inherits = TRUE)
   expect_false(env_has(env, "a"))
 })
 

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -236,19 +236,6 @@ test_that("client library passes tests", {
   expect_identical(result, 0L)
 })
 
-test_that("r_env_unbind() removes objects", {
-  env <- env(a = 1L)
-  r_env_unbind(env, "a")
-  expect_false(env_has(env, "a"))
-
-  env <- env(a = 1L)
-  child <- child_env(env)
-  r_env_unbind(child, "a")
-  expect_true(env_has(child, "a", inherit = TRUE))
-  r_env_unbind(child, "a", inherits = TRUE)
-  expect_false(env_has(env, "a"))
-})
-
 node_list_clone_until <- function(node, sentinel) {
   .Call(rlang_test_node_list_clone_until, node, sentinel)
 }

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -236,15 +236,16 @@ test_that("client library passes tests", {
   expect_identical(result, 0L)
 })
 
-test_that("r_env_unbind_string_anywhere() removes objects", {
+test_that("r_env_unbind() removes objects", {
   env <- env(a = 1L)
-  r_env_unbind_string_anywhere(env, "a")
+  r_env_unbind(env, "a")
   expect_false(env_has(env, "a"))
 
   env <- env(a = 1L)
   child <- child_env(env)
-  expect_warning(r_env_unbind_string_anywhere(child, "a"), "not found")
-  r_env_unbind_string_anywhere(child, "a", inherits = TRUE)
+  r_env_unbind(child, "a")
+  expect_true(env_has(child, "a", inherit = TRUE))
+  r_env_unbind(child, "a", inherits = TRUE)
   expect_false(env_has(env, "a"))
 })
 

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -112,14 +112,13 @@ test_that("with_bindings() evaluates with temporary bindings", {
   expect_identical(foo, "foo")
 })
 
-test_that("env_unbind() with `inherits = TRUE` wipes out all bindings", {
-  bindings <- list(`_foo` = "foo", `_bar` = "bar")
-  env_bind(global_env(), !!! bindings)
-  env <- child_env(global_env(), !!! bindings)
+test_that("env_unbind() with `inherits = TRUE` only removes first match", {
+  env <- env(foo = "foo")
+  child <- env(env, foo = "foo")
 
-  env_unbind(env, "_foo", inherit = TRUE)
-  expect_false(all(env_has(env, names(bindings))))
-  expect_false(all(env_has(global_env(), names(bindings))))
+  env_unbind(child, "foo", inherit = TRUE)
+  expect_false(env_has(child, "foo"))
+  expect_true(env_has(env, "foo"))
 })
 
 test_that("env_bind() requires named elements", {

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -438,6 +438,21 @@ test_that("env_name() requires an environment", {
   expect_error(env_name("base"), "must be an environment")
 })
 
+test_that("env_unbind() removes objects", {
+  env <- env(a = 1L)
+  env_unbind(env, "a")
+  expect_false(env_has(env, "a"))
+
+  env <- env(a = 1L)
+  child <- child_env(env)
+
+  env_unbind(child, "a")
+  expect_true(env_has(child, "a", inherit = TRUE))
+
+  env_unbind(child, "a", inherit = TRUE)
+  expect_false(env_has(env, "a"))
+})
+
 
 #  Lifecycle ---------------------------------------------------------
 


### PR DESCRIPTION
* Move `env_has()` and `env_unbind()` implementations to C.
* Use `R_removeVarFromFrame()` on R 4.0.
* Clean up C API for environments a bit.