### PR TITLE
Fix encoding warnings on R 4.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang (development version)
 
+* The unicode translation warnings that appeared on Windows with R 4.0
+  are now fixed.
+
 * `env_unbind(inherit = TRUE)` now only removes a binding from the
   first parent environment that has a binding. It used to remove the
   bindings from the whole ancestry. The new behaviour doesn't

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -247,7 +247,7 @@ env_bind_active <- function(.env, ...) {
     if (nm %in% existing) {
       env_unbind(env, nm)
     }
-    makeActiveBinding(nm, value, env)
+    makeActiveBinding(sym(nm), value, env)
   }
 
   env_bind_impl(.env, fns, "env_bind_active()", TRUE, binder)

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -90,7 +90,7 @@ sexp* rlang_env_bind_list(sexp* env, sexp* names, sexp* data) {
   sexp** namesp = r_chr_deref(names);
 
   for (r_ssize i = 0; i < n; ++i) {
-    Rf_defineVar(Rf_installChar(namesp[i]), r_list_get(data, i), env);
+    Rf_defineVar(r_new_symbol_translate(namesp[i]), r_list_get(data, i), env);
   }
 
   return r_null;

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -90,7 +90,7 @@ sexp* rlang_env_bind_list(sexp* env, sexp* names, sexp* data) {
   sexp** namesp = r_chr_deref(names);
 
   for (r_ssize i = 0; i < n; ++i) {
-    Rf_defineVar(r_new_symbol_translate(namesp[i]), r_list_get(data, i), env);
+    Rf_defineVar(r_str_as_symbol(namesp[i]), r_list_get(data, i), env);
   }
 
   return r_null;

--- a/src/internal/env-binding.c
+++ b/src/internal/env-binding.c
@@ -2,7 +2,7 @@
 
 
 sexp* rlang_env_get(sexp* env, sexp* nm) {
-  sexp* sym = r_new_symbol_translate(r_chr_get(nm, 0));
+  sexp* sym = r_str_as_symbol(r_chr_get(nm, 0));
   sexp* out = KEEP(r_env_find(env, sym));
 
   // Trigger `symbol not found` error if needed

--- a/src/internal/env-binding.c
+++ b/src/internal/env-binding.c
@@ -2,7 +2,7 @@
 
 
 sexp* rlang_env_get(sexp* env, sexp* nm) {
-  sexp* sym = Rf_installChar(r_chr_get(nm, 0));
+  sexp* sym = r_new_symbol_translate(r_chr_get(nm, 0));
   sexp* out = KEEP(r_env_find(env, sym));
 
   // Trigger `symbol not found` error if needed

--- a/src/lib/sym-unescape.c
+++ b/src/lib/sym-unescape.c
@@ -9,9 +9,7 @@ void copy_character(sexp* tgt, sexp* src, R_xlen_t len);
 R_xlen_t unescape_character_in_copy(sexp* tgt, sexp* src, R_xlen_t i);
 
 sexp* rlang_symbol(sexp* chr) {
-  // Uses installChar(), no translation. Translating causes issues
-  // when converting back to character.
-  return r_vec_coerce(chr, r_type_symbol);
+  return r_new_symbol_translate(r_chr_get(chr, 0));
 }
 
 sexp* rlang_sym_as_character(sexp* sym) {

--- a/src/lib/sym-unescape.c
+++ b/src/lib/sym-unescape.c
@@ -9,7 +9,7 @@ void copy_character(sexp* tgt, sexp* src, R_xlen_t len);
 R_xlen_t unescape_character_in_copy(sexp* tgt, sexp* src, R_xlen_t i);
 
 sexp* rlang_symbol(sexp* chr) {
-  return r_new_symbol_translate(r_chr_get(chr, 0));
+  return r_str_as_symbol(r_chr_get(chr, 0));
 }
 
 sexp* rlang_sym_as_character(sexp* sym) {

--- a/src/lib/sym.h
+++ b/src/lib/sym.h
@@ -42,6 +42,14 @@ static inline sexp* r_sym_as_character(sexp* x) {
   return Rf_ScalarString(PRINTNAME(x));
 }
 
+static inline sexp* r_new_symbol_translate(sexp* str) {
+  // Translate with translateChar() to silence R 4.0 warnings
+  // introduced in r76981. This unfortunately causes one additional
+  // heap allocation.
+  const char* str_native = Rf_translateChar(str);
+  return Rf_install(str_native);
+}
+
 bool r_is_symbol(sexp* sym, const char* string);
 bool r_is_symbol_any(sexp* x, const char** strings, int n);
 

--- a/src/lib/sym.h
+++ b/src/lib/sym.h
@@ -42,33 +42,6 @@ static inline sexp* r_sym_as_character(sexp* x) {
   return Rf_ScalarString(PRINTNAME(x));
 }
 
-/*
- * A symbol is always in the native encoding. This means that UTF-8
- * data frame names undergo a lossy translation when they are
- * transformed to symbols to create a data mask. To deal with this, we
- * translate all serialised unicode tags back to UTF-8. This way the
- * UTF-8 -> native -> UTF-8 translation that occurs during the
- * character -> symbol -> character conversion fundamental for data
- * masking is transparent and lossless for the end user.
- *
- * Starting from R 4.0, `installChar()` warns when translation to
- * native encoding is lossy. This warning is disruptive for us since
- * we correctly translate strings behind the scene. To work around
- * this, we call `translateChar()` which doesn't warn (at least
- * currently). If the pointers are the same, no translation is
- * needed and we can call `installChar()`, which preserves the
- * current encoding of the string. Otherwise we intern the symbol
- * with `install()` without encoding.
- */
-static inline sexp* r_new_symbol_translate(sexp* str) {
-  const char* str_native = Rf_translateChar(str);
-
-  if (str_native == CHAR(str)) {
-    return Rf_installChar(str);
-  } else {
-    return Rf_install(str_native);
-  }
-}
 
 bool r_is_symbol(sexp* sym, const char* string);
 bool r_is_symbol_any(sexp* x, const char** strings, int n);

--- a/src/lib/sym.h
+++ b/src/lib/sym.h
@@ -42,12 +42,32 @@ static inline sexp* r_sym_as_character(sexp* x) {
   return Rf_ScalarString(PRINTNAME(x));
 }
 
+/*
+ * A symbol is always in the native encoding. This means that UTF-8
+ * data frame names undergo a lossy translation when they are
+ * transformed to symbols to create a data mask. To deal with this, we
+ * translate all serialised unicode tags back to UTF-8. This way the
+ * UTF-8 -> native -> UTF-8 translation that occurs during the
+ * character -> symbol -> character conversion fundamental for data
+ * masking is transparent and lossless for the end user.
+ *
+ * Starting from R 4.0, `installChar()` warns when translation to
+ * native encoding is lossy. This warning is disruptive for us since
+ * we correctly translate strings behind the scene. To work around
+ * this, we call `translateChar()` which doesn't warn (at least
+ * currently). If the pointers are the same, no translation is
+ * needed and we can call `installChar()`, which preserves the
+ * current encoding of the string. Otherwise we intern the symbol
+ * with `install()` without encoding.
+ */
 static inline sexp* r_new_symbol_translate(sexp* str) {
-  // Translate with translateChar() to silence R 4.0 warnings
-  // introduced in r76981. This unfortunately causes one additional
-  // heap allocation.
   const char* str_native = Rf_translateChar(str);
-  return Rf_install(str_native);
+
+  if (str_native == CHAR(str)) {
+    return Rf_installChar(str);
+  } else {
+    return Rf_install(str_native);
+  }
 }
 
 bool r_is_symbol(sexp* sym, const char* string);

--- a/src/lib/vec-chr.h
+++ b/src/lib/vec-chr.h
@@ -67,11 +67,36 @@ static inline bool r_is_string(sexp* x, const char* string) {
   return true;
 }
 
-static inline sexp* r_str_as_symbol(sexp* str) {
-  return r_sym(Rf_translateChar(str));
-}
 static inline sexp* r_str_as_character(sexp* x) {
   return Rf_ScalarString(x);
+}
+
+/*
+ * A symbol is always in the native encoding. This means that UTF-8
+ * data frame names undergo a lossy translation when they are
+ * transformed to symbols to create a data mask. To deal with this, we
+ * translate all serialised unicode tags back to UTF-8. This way the
+ * UTF-8 -> native -> UTF-8 translation that occurs during the
+ * character -> symbol -> character conversion fundamental for data
+ * masking is transparent and lossless for the end user.
+ *
+ * Starting from R 4.0, `installChar()` warns when translation to
+ * native encoding is lossy. This warning is disruptive for us since
+ * we correctly translate strings behind the scene. To work around
+ * this, we call `translateChar()` which doesn't warn (at least
+ * currently). If the pointers are the same, no translation is
+ * needed and we can call `installChar()`, which preserves the
+ * current encoding of the string. Otherwise we intern the symbol
+ * with `install()` without encoding.
+ */
+static inline sexp* r_str_as_symbol(sexp* str) {
+  const char* str_native = Rf_translateChar(str);
+
+  if (str_native == CHAR(str)) {
+    return Rf_installChar(str);
+  } else {
+    return Rf_install(str_native);
+  }
 }
 
 static inline sexp* r_chr_as_symbol(sexp* str) {


### PR DESCRIPTION
Relies on #1005 so we don't use things like `rm()` or `exists()` which will warn.

The workaround implemented in this PR depends on `Rf_translateChar()` not issuing warnings. Hopefully it stays that way.