### PR TITLE
Use rlang_ext2_* prefix consistently

### DIFF
--- a/R/arg.R
+++ b/R/arg.R
@@ -219,7 +219,7 @@ missing_arg <- function() {
 #' @rdname missing_arg
 #' @export
 is_missing <- function(x) {
-  .External2(rlang_is_missing, missing(x))
+  .External2(rlang_ext2_is_missing, missing(x))
 }
 
 #' @rdname missing_arg

--- a/R/call.R
+++ b/R/call.R
@@ -95,7 +95,7 @@
 #' call2("[", quote(x), , drop = )
 #' @export
 call2 <- function(.fn, ..., .ns = NULL) {
-  .External2(rlang_call2_external, .fn, .ns)
+  .External2(rlang_ext2_call2, .fn, .ns)
 }
 #' Create pairlists with splicing support
 #'

--- a/R/eval.R
+++ b/R/eval.R
@@ -321,5 +321,5 @@ eval_top <- function(expr, env = caller_env()) {
 #' data_env <- env(data = mtcars)
 #' eval(expr(lm(!!f, data)), data_env)
 exec <- function(.fn, ..., .env = caller_env()) {
-  .External2(rlang_exec, .fn, .env)
+  .External2(rlang_ext2_exec, .fn, .env)
 }

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -316,14 +316,14 @@ static const r_callable r_callables[] = {
 
 
 extern sexp* rlang_ext2_is_missing(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_call2_external(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_ext2_call2(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_dots_values(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_exec(sexp*, sexp*, sexp*, sexp*);
 
 
 static const r_external externals[] = {
   {"rlang_ext2_is_missing",             (r_fn_ptr) &rlang_ext2_is_missing, 1},
-  {"rlang_call2_external",              (r_fn_ptr) &rlang_call2_external, 2},
+  {"rlang_ext2_call2",                  (r_fn_ptr) &rlang_ext2_call2, 2},
   {"rlang_ext2_dots_values",            (r_fn_ptr) &rlang_ext2_dots_values, 6},
   {"rlang_exec",                        (r_fn_ptr) &rlang_exec, 2},
   {NULL, NULL, 0}

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -318,14 +318,14 @@ static const r_callable r_callables[] = {
 extern sexp* rlang_ext2_is_missing(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_call2(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_dots_values(sexp*, sexp*, sexp*, sexp*);
-extern sexp* rlang_exec(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_ext2_exec(sexp*, sexp*, sexp*, sexp*);
 
 
 static const r_external externals[] = {
   {"rlang_ext2_is_missing",             (r_fn_ptr) &rlang_ext2_is_missing, 1},
   {"rlang_ext2_call2",                  (r_fn_ptr) &rlang_ext2_call2, 2},
   {"rlang_ext2_dots_values",            (r_fn_ptr) &rlang_ext2_dots_values, 6},
-  {"rlang_exec",                        (r_fn_ptr) &rlang_exec, 2},
+  {"rlang_ext2_exec",                   (r_fn_ptr) &rlang_ext2_exec, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -315,14 +315,14 @@ static const r_callable r_callables[] = {
 };
 
 
-extern sexp* rlang_is_missing(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_ext2_is_missing(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_call2_external(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_dots_values(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_exec(sexp*, sexp*, sexp*, sexp*);
 
 
 static const r_external externals[] = {
-  {"rlang_is_missing",                  (r_fn_ptr) &rlang_is_missing, 1},
+  {"rlang_ext2_is_missing",             (r_fn_ptr) &rlang_ext2_is_missing, 1},
   {"rlang_call2_external",              (r_fn_ptr) &rlang_call2_external, 2},
   {"rlang_ext2_dots_values",            (r_fn_ptr) &rlang_ext2_dots_values, 6},
   {"rlang_exec",                        (r_fn_ptr) &rlang_exec, 2},

--- a/src/internal/arg.c
+++ b/src/internal/arg.c
@@ -74,7 +74,7 @@ sexp* rlang_enquo(sexp* sym, sexp* frame) {
   return quo;
 }
 
-sexp* rlang_is_missing(sexp* _call, sexp* _op, sexp* args, sexp* env) {
+sexp* rlang_ext2_is_missing(sexp* _call, sexp* _op, sexp* args, sexp* env) {
   args = r_node_cdr(args);
 
   sexp* missing = r_eval(r_node_car(args), env);

--- a/src/internal/call.c
+++ b/src/internal/call.c
@@ -44,7 +44,7 @@ sexp* rlang_call2(sexp* fn, sexp* args, sexp* ns) {
   return out;
 }
 
-sexp* rlang_call2_external(sexp* call, sexp* op, sexp* args, sexp* env) {
+sexp* rlang_ext2_call2(sexp* call, sexp* op, sexp* args, sexp* env) {
   args = r_node_cdr(args);
 
   sexp* fn = KEEP(r_eval(r_sym(".fn"), env));

--- a/src/internal/eval.c
+++ b/src/internal/eval.c
@@ -5,7 +5,7 @@
 sexp* rlang_call2(sexp* fn, sexp* args, sexp* ns);
 
 
-sexp* rlang_exec(sexp* call, sexp* op, sexp* args, sexp* rho) {
+sexp* rlang_ext2_exec(sexp* call, sexp* op, sexp* args, sexp* rho) {
   args = r_node_cdr(args);
 
   sexp* fn = KEEP(r_eval(r_sym(".fn"), rho));


### PR DESCRIPTION
for functions called via `.External2()` .

(Where is that documented? WRE doesn't mention it.)