### PR TITLE
Review display of chained errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 
 * The backtraces of chained errors are no longer decomposed by error
   context. Instead, the error messages are displayed as a tree to
-  reflect the error ancestry, and the oldest backtrace in the ancestry
+  reflect the error ancestry, and the deepest backtrace in the ancestry
   is displayed.
 
   This change simplifies the display (#851) and makes it possible to

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,16 @@
 
 # rlang (development version)
 
+* The backtraces of chained errors are no longer decomposed by error
+  context. Instead, the error messages are displayed as a tree to
+  reflect the error ancestry, and the oldest backtrace in the ancestry
+  is displayed.
+
+  This change simplifies the display (#851) and makes it possible to
+  rethow errors from a calling handler rather than an exiting handler,
+  which we now think is more appropriate because it allows users to
+  `recover()` into the error.
+
 * `env_bind()`, `env_bind_active()`, `env_bind_lazy()`, `env_get()`,
   and `env_get_list()` have been rewritten in C.
 

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -129,16 +129,17 @@ abort <- function(message = NULL,
 
   if (is_null(trace) && is_null(peek_option("rlang:::disable_trace_capture"))) {
     # Prevents infloops when rlang throws during trace capture
-    local_options("rlang:::disable_trace_capture" = TRUE)
+    with_options("rlang:::disable_trace_capture" = TRUE, {
+      trace <- trace_back()
 
-    trace <- trace_back()
+      if (is_null(parent)) {
+        context <- trace_length(trace)
+      } else {
+        context <- find_capture_context(3L)
+      }
 
-    if (is_null(parent)) {
-      context <- trace_length(trace)
-    } else {
-      context <- find_capture_context(3L)
-    }
-    trace <- trace_trim_context(trace, context)
+      trace <- trace_trim_context(trace, context)
+    })
   }
 
   message <- validate_signal_message(message, class)
@@ -198,17 +199,33 @@ trace_trim_context <- function(trace, frame = caller_env()) {
   trace
 }
 
-# Assumes we're called from an exiting handler. Need to
+# Assumes we're called from a calling or exiting handler
 find_capture_context <- function(n = 3L) {
-  parent <- orig <- sys.parent(n)
-  call <- sys.call(parent)
+  calls <- sys.calls()
 
-  try_catch_n <- detect_index(sys.calls(), is_call, "tryCatch", .right = TRUE)
-  if (try_catch_n == 0L) {
-    sys.frame(sys.parent(n))
-  } else {
-    sys.frame(try_catch_n)
+  exiting_call <- quote(value[[3L]](cond))
+  exiting_n <- detect_index(calls, identical, exiting_call, .right = TRUE)
+
+  # tryCatch()
+  if (exiting_n != 0L) {
+    try_catch_calls <- calls[seq_len(exiting_n - 1L)]
+    try_catch_n <- detect_index(try_catch_calls, is_call, "tryCatch", .right = TRUE)
+    if (try_catch_n != 0L) {
+      return(sys.frame(try_catch_n))
+    } else {
+      return(sys.frame(sys.parent(n)))
+    }
   }
+
+  bottom_loc <- length(calls) - 3
+  bottom <- calls[[bottom_loc]]
+
+  # withCallingHandlers()
+  if (is_function(bottom[[1]])) {
+    return(sys.frame(bottom_loc))
+  }
+
+  sys.frame(sys.parent(n))
 }
 
 #' Display backtrace on error

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -96,17 +96,20 @@
 #'   }
 #' )
 #'
-#' # If you call low-level APIs it is good practice to catch technical
-#' # errors and rethrow them with a more meaningful message. Pass on
-#' # the caught error as `parent` to get a nice decomposition of
-#' # errors and backtraces:
+#' # If you call low-level APIs it is good practice to handle
+#' # technical errors and rethrow them with a more meaningful
+#' # message. Always prefer doing this from `withCallinghandlers()`
+#' # rather than `tryCatch()` because the former preserves the stack
+#' # on error and makes it possible for users to use `recover()`.
 #' file <- "http://foo.bar/baz"
-#' tryCatch(
+#' try(withCallinghandlers(
 #'   download(file),
 #'   error = function(err) {
 #'     msg <- sprintf("Can't download `%s`", file)
 #'     abort(msg, parent = err)
-#' })
+#' }))
+#' # Note how we supplied the parent error to `abort()` as `parent` to
+#' # get a decomposition of error messages across error contexts.
 #'
 #' # Unhandled errors are saved automatically by `abort()` and can be
 #' # retrieved with `last_error()`. The error prints with a simplified

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -31,6 +31,10 @@ print.rlang_error <- function(x,
   invisible(x)
 }
 
+is_rlang_error <- function(x) {
+  inherits(x, "rlang_error")
+}
+
 #' @export
 format.rlang_error <- function(x,
                                ...,
@@ -40,17 +44,54 @@ format.rlang_error <- function(x,
   # Allow overwriting default display via condition field
   simplify <- x$rlang$internal$print_simplify %||% simplify
 
-  header <- rlang_error_header(x, child)
+  parent <- x$parent
+  style <- cli_box_chars()
 
-  message <- strip_trailing_newline(conditionMessage(x))
-  if (!nzchar(message)) {
-    message <- NULL
+  header <- rlang_error_header(x)
+
+  if (is_rlang_error(parent)) {
+    header <- header_add_tree_node(header, style, parent)
+    header <-   paste_line(trace_root(), header)
+
+    message <- with_reduced_width(
+      as_rlang_error_message(conditionMessage(x))
+    )
+    message <- message_add_tree_prefix(message, style, parent)
+  } else {
+    message <- as_rlang_error_message(conditionMessage(x))
   }
 
   out <- paste_line(
     header,
     message
   )
+
+  while (is_rlang_error(parent)) {
+    x <- parent
+    parent <- parent$parent
+
+    header <- rlang_error_header(x)
+    header <- header_add_tree_node(header, style, parent)
+
+    message <- with_reduced_width(
+      as_rlang_error_message(cnd_header(x))
+    )
+    message <- message_add_tree_prefix(message, style, parent)
+
+    if (is_rlang_error(parent)) {
+      header <- paste0
+      message <- with_reduced_width(
+        as_rlang_error_message(conditionMessage(x))
+      )
+      message <- message_add_tree_prefix(message, style)
+    }
+
+    out <- paste_line(
+      out,
+      header,
+      message
+    )
+  }
 
   trace <- x$trace
   simplify <- arg_match(simplify)
@@ -77,13 +118,54 @@ format.rlang_error <- function(x,
     is_true(x$rlang$internal$from_last_error) &&
     identical(x, last_error())
 
-  if (from_last_error && simplify == "branch" && is_null(child) && !is_null(trace)) {
+  if (from_last_error && simplify == "branch" && !is_null(trace)) {
     reminder <- silver("Run `rlang::last_trace()` to see the full context.")
     out <- paste_line(out, reminder)
   }
 
   out
 }
+
+with_reduced_width <- function(expr) {
+  with_options(
+    width = peek_option("width") - 2L,
+    expr
+  )
+}
+
+as_rlang_error_message <- function(message) {
+  message <- strip_trailing_newline(message)
+
+  if (nzchar(message)) {
+    message
+  } else {
+    NULL
+  }
+}
+
+header_add_tree_node <- function(header, style, parent) {
+  if (is_rlang_error(parent)) {
+    s <- style$j
+  } else {
+    s <- style$l
+  }
+  paste0(s, style$h, header)
+}
+message_add_tree_prefix <- function(message, style, parent) {
+  if (is_null(message)) {
+    return(NULL)
+  }
+
+  if (is_rlang_error(parent)) {
+    s <- style$v
+  } else {
+    s <- " "
+  }
+  message <- split_lines(message)
+  message <- paste0(s, " ", message)
+  paste_line(message)
+}
+
 
 #' @export
 summary.rlang_error <- function(object, ...) {

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -44,6 +44,7 @@ format.rlang_error <- function(x,
   # Allow overwriting default display via condition field
   simplify <- x$rlang$internal$print_simplify %||% simplify
 
+  orig <- x
   parent <- x$parent
   style <- cli_box_chars()
 
@@ -112,12 +113,8 @@ format.rlang_error <- function(x,
     out <- paste_line(out, parent_lines)
   }
 
-  # Recommend printing the full backtrace. Only do it after having
-  # printed all parent errors first.
-  from_last_error <-
-    is_true(x$rlang$internal$from_last_error) &&
-    identical(x, last_error())
-
+  # Recommend printing the full backtrace if called from `last_error()`
+  from_last_error <- is_true(orig$rlang$internal$from_last_error)
   if (from_last_error && simplify == "branch" && !is_null(trace)) {
     reminder <- silver("Run `rlang::last_trace()` to see the full context.")
     out <- paste_line(out, reminder)

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -128,7 +128,7 @@ format.rlang_error <- function(x,
 
 with_reduced_width <- function(expr) {
   with_options(
-    width = peek_option("width") - 2L,
+    width = max(peek_option("width") - 2L, 10L),
     expr
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -254,3 +254,15 @@ unstructure <- function(x) {
 
   out
 }
+
+cli_rule <- function() {
+  if (is_installed("cli")) {
+    cli::rule()
+  } else {
+    strrep("-", peek_option("width") %||% 60L)
+  }
+}
+
+split_lines <- function(x) {
+  strsplit(x, "\n")[[1]]
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -264,5 +264,5 @@ cli_rule <- function() {
 }
 
 split_lines <- function(x) {
-  strsplit(x, "\n")[[1]]
+  strsplit(x, "\n", fixed = TRUE)[[1]]
 }

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -138,17 +138,20 @@ tryCatch(
   }
 )
 
-# If you call low-level APIs it is good practice to catch technical
-# errors and rethrow them with a more meaningful message. Pass on
-# the caught error as `parent` to get a nice decomposition of
-# errors and backtraces:
+# If you call low-level APIs it is good practice to handle
+# technical errors and rethrow them with a more meaningful
+# message. Always prefer doing this from `withCallinghandlers()`
+# rather than `tryCatch()` because the former preserves the stack
+# on error and makes it possible for users to use `recover()`.
 file <- "http://foo.bar/baz"
-tryCatch(
+try(withCallinghandlers(
   download(file),
   error = function(err) {
     msg <- sprintf("Can't download `\%s`", file)
     abort(msg, parent = err)
-})
+}))
+# Note how we supplied the parent error to `abort()` as `parent` to
+# get a decomposition of error messages across error contexts.
 
 # Unhandled errors are saved automatically by `abort()` and can be
 # retrieved with `last_error()`. The error prints with a simplified

--- a/tests/testthat/output-cnd-abort-parent-trace.txt
+++ b/tests/testthat/output-cnd-abort-parent-trace.txt
@@ -1,7 +1,14 @@
+> parent <- TRUE
 > wrapper <- FALSE
 > err <- catch_cnd(f())
 > print(err)
-<simpleError in value[[3L]](cond): object 'parent' not found>
+<error/rlang_error>
+no wrapper
+Backtrace:
+  1. rlang::catch_cnd(f())
+  8. rlang:::f()
+  9. rlang:::g()
+ 10. rlang:::h()
 
 > wrapper <- TRUE
 > err <- catch_cnd(f())

--- a/tests/testthat/output-cnd-abort-trace-reminder.txt
+++ b/tests/testthat/output-cnd-abort-trace-reminder.txt
@@ -41,4 +41,5 @@ Backtrace:
   8. rlang:::f()
   9. rlang:::g()
  10. rlang:::h()
+Run `rlang::last_trace()` to see the full context.
 

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -220,6 +220,7 @@ test_that("capture context doesn't leak into low-level backtraces", {
   }
 
   verify_output(test_path("output-cnd-abort-parent-trace.txt"), {
+    parent <- TRUE
     wrapper <- FALSE
     err <- catch_cnd(f())
     print(err)

--- a/tests/testthat/test-cnd-error-parent-default.txt
+++ b/tests/testthat/test-cnd-error-parent-default.txt
@@ -1,14 +1,25 @@
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/foobar>
 Backtrace:
   1. rlang::catch_cnd(a())
   8. rlang:::a()
   9. rlang:::b()
  10. rlang:::c()
-<error/rlang_error>
-High-level message
+ 15. rlang:::f()
+ 16. rlang:::g()
+ 17. rlang:::h()
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/foobar>
+  Low-level message
 Backtrace:
   1. rlang::with_options(catch_cnd(a()), `rlang:::force_unhandled_error` = TRUE)
   9. rlang:::a()
  10. rlang:::b()
  11. rlang:::c()
+ 16. rlang:::f()
+ 17. rlang:::g()
+ 18. rlang:::h()

--- a/tests/testthat/test-cnd-error-parent-full.txt
+++ b/tests/testthat/test-cnd-error-parent-full.txt
@@ -1,5 +1,7 @@
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/foobar>
 Backtrace:
      █
   1. ├─rlang::catch_cnd(a())
@@ -12,10 +14,10 @@ Backtrace:
   8. └─rlang:::a()
   9.   └─rlang:::b()
  10.     └─rlang:::c()
-<parent: error/foobar>
-Low-level message
-Backtrace:
-    █
- 1. └─rlang:::f()
- 2.   └─rlang:::g()
- 3.     └─rlang:::h()
+ 11.       ├─base::tryCatch(...)
+ 12.       │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
+ 13.       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+ 14.       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
+ 15.       └─rlang:::f()
+ 16.         └─rlang:::g()
+ 17.           └─rlang:::h()

--- a/tests/testthat/test-cnd-error-parent-trace.txt
+++ b/tests/testthat/test-cnd-error-parent-trace.txt
@@ -1,6 +1,8 @@
 Full:
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/foobar>
 Backtrace:
      █
   1. ├─rlang::catch_cnd(a())
@@ -13,36 +15,40 @@ Backtrace:
   8. └─rlang:::a()
   9.   └─rlang:::b()
  10.     └─rlang:::c()
-<parent: error/foobar>
-Low-level message
-Backtrace:
-    █
- 1. └─rlang:::f()
- 2.   └─rlang:::g()
- 3.     └─rlang:::h()
+ 11.       ├─base::tryCatch(...)
+ 12.       │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
+ 13.       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+ 14.       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
+ 15.       └─rlang:::f()
+ 16.         └─rlang:::g()
+ 17.           └─rlang:::h()
 
 Collapsed:
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/foobar>
 Backtrace:
      █
   1. ├─[ rlang::catch_cnd(...) ] with 6 more calls
   8. └─rlang:::a()
   9.   └─rlang:::b()
  10.     └─rlang:::c()
-<parent: error/foobar>
-Low-level message
-Backtrace:
-    █
- 1. └─rlang:::f()
- 2.   └─rlang:::g()
- 3.     └─rlang:::h()
+ 11.       ├─[ base::tryCatch(...) ] with 3 more calls
+ 15.       └─rlang:::f()
+ 16.         └─rlang:::g()
+ 17.           └─rlang:::h()
 
 Branch:
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/foobar>
 Backtrace:
   1. rlang::catch_cnd(a())
   8. rlang:::a()
   9. rlang:::b()
  10. rlang:::c()
+ 15. rlang:::f()
+ 16. rlang:::g()
+ 17. rlang:::h()

--- a/tests/testthat/test-cnd-error-str.txt
+++ b/tests/testthat/test-cnd-error-str.txt
@@ -1,5 +1,8 @@
-<error/rlang_error>
-The high-level error message
+█
+├─<error/rlang_error>
+│ The high-level error message
+└─<error/rlang_error>
+  The low-level error message
 Backtrace:
      █
   1. ├─rlang::catch_cnd(a())
@@ -14,12 +17,12 @@ Backtrace:
  10.   │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
  11.   └─rlang:::b()
  12.     └─rlang:::c()
-<parent: error/rlang_error>
-The low-level error message
-Backtrace:
-    █
- 1. └─rlang:::f()
- 2.   ├─base::tryCatch(g())
- 3.   │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
- 4.   └─rlang:::g()
- 5.     └─rlang:::h()
+ 13.       ├─base::tryCatch(f(), error = handler)
+ 14.       │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
+ 15.       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+ 16.       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
+ 17.       └─rlang:::f()
+ 18.         ├─base::tryCatch(g())
+ 19.         │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
+ 20.         └─rlang:::g()
+ 21.           └─rlang:::h()

--- a/tests/testthat/test-with-abort.txt
+++ b/tests/testthat/test-with-abort.txt
@@ -1,18 +1,27 @@
 print():
 
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/rlang_error>
+  Low-level message
 Backtrace:
   1. base::identity(catch_cnd(a()))
   9. rlang:::a()
  10. rlang:::b()
  11. rlang:::c()
+ 18. rlang:::f()
+ 19. rlang:::g()
+ 20. rlang:::h()
 
 
 summary():
 
-<error/rlang_error>
-High-level message
+█
+├─<error/rlang_error>
+│ High-level message
+└─<error/rlang_error>
+  Low-level message
 Backtrace:
      █
   1. ├─base::identity(catch_cnd(a()))
@@ -26,12 +35,12 @@ Backtrace:
   9. └─rlang:::a()
  10.   └─rlang:::b()
  11.     └─rlang:::c()
-<parent: error/rlang_error>
-Low-level message
-Backtrace:
-    █
- 1. ├─rlang::with_abort(f())
- 2. │ └─base::withCallingHandlers(...)
- 3. └─rlang:::f()
- 4.   └─rlang:::g()
- 5.     └─rlang:::h()
+ 12.       ├─base::tryCatch(...)
+ 13.       │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
+ 14.       │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+ 15.       │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
+ 16.       ├─rlang::with_abort(f())
+ 17.       │ └─base::withCallingHandlers(...)
+ 18.       └─rlang:::f()
+ 19.         └─rlang:::g()
+ 20.           └─rlang:::h()


### PR DESCRIPTION
* We now climb the ancestry of chained errors to find the oldest parent errors carrying a backtrace and display this backtrace in full. This is the oldest and thus most complete backtrace.

* We no longer decompose backtraces across error contexts because there is no way for us to do this with calling handlers. Calling handlers are now the preferred methods of rethrowing errors because they preserve the stack and allow users to `recover()` the error.

* The combination of these two changes produces consistent error and backtrace output for errors rethrown from both `tryCatch()` and `withCallingHandlers()`.

* The error ancestry is reflected with a tree display for error messages. The first message for the youngest error (highest level) is generated with `conditionMessage()`. The messages for older errors are generated with `cnd_header()`. This avoids repetition when the younger errors reuse parts of the messages of their parent errors, e.g. in bullets.

Closes #851

```r
dplyr::mutate(mtcars, dplyr::select(mtcars, foo))
#> Error: Problem with `mutate()` input `..1`.
#> ✖ Can't subset columns that don't exist.
#> ✖ Column `foo` doesn't exist.
#> ℹ Input `..1` is `dplyr::select(mtcars, foo)`.
#> Run `rlang::last_error()` to see where the error occurred.

rlang::last_error()
#> █
#> ├─<error/dplyr_error>
#> │ Problem with `mutate()` input `..1`.
#> │ ✖ Can't subset columns that don't exist.
#> │ ✖ Column `foo` doesn't exist.
#> │ ℹ Input `..1` is `dplyr::select(mtcars, foo)`.
#> └─<error/vctrs_error_subscript_oob>
#>   Can't subset columns that don't exist.
#> Backtrace:
#>   1. dplyr::mutate(mtcars, dplyr::select(mtcars, foo))
#>  10. dplyr:::select.data.frame(mtcars, foo)
#>  11. tidyselect::eval_select(expr(c(...)), .data)
#>  12. tidyselect:::eval_select_impl(...)
#>  20. tidyselect:::vars_select_eval(...)
#>  21. tidyselect:::walk_data_tree(expr, data_mask, context_mask)
#>  22. tidyselect:::eval_c(expr, data_mask, context_mask)
#>  23. tidyselect:::reduce_sels(node, data_mask, context_mask, init = init)
#>  24. tidyselect:::walk_data_tree(new, data_mask, context_mask)
#>  25. tidyselect:::as_indices_sel_impl(...)
#>  26. tidyselect:::as_indices_impl(x, vars, strict = strict)
#>  27. tidyselect:::chr_as_locations(x, vars)
#>  28. vctrs::vec_as_location(x, n = length(vars), names = vars)
#>  29. vctrs:::stop_subscript_oob(...)
#>  30. vctrs:::stop_subscript(...)
#> Run `rlang::last_trace()` to see the full context.

rlang::last_trace()
#> █
#> ├─<error/dplyr_error>
#> │ Problem with `mutate()` input `..1`.
#> │ ✖ Can't subset columns that don't exist.
#> │ ✖ Column `foo` doesn't exist.
#> │ ℹ Input `..1` is `dplyr::select(mtcars, foo)`.
#> └─<error/vctrs_error_subscript_oob>
#>   Can't subset columns that don't exist.
#> Backtrace:
#>      █
#>   1. ├─dplyr::mutate(mtcars, dplyr::select(mtcars, foo))
#>   2. ├─dplyr:::mutate.data.frame(mtcars, dplyr::select(mtcars, foo))
#>   3. │ └─dplyr:::mutate_cols(.data, ...)
#>   4. │   ├─base::tryCatch(...)
#>   5. │   │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>   6. │   │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>   7. │   │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>   8. │   └─mask$eval_all_mutate(dots[[i]])
#>   9. ├─dplyr::select(mtcars, foo)
#>  10. └─dplyr:::select.data.frame(mtcars, foo)
#>  11.   └─tidyselect::eval_select(expr(c(...)), .data)
#>  12.     └─tidyselect:::eval_select_impl(...)
#>  13.       ├─tidyselect:::with_subscript_errors(...)
#>  14.       │ ├─base::tryCatch(...)
#>  15.       │ │ └─base:::tryCatchList(expr, classes, parentenv, handlers)
#>  16.       │ │   └─base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
#>  17.       │ │     └─base:::doTryCatch(return(expr), name, parentenv, handler)
#>  18.       │ └─tidyselect:::instrument_base_errors(expr)
#>  19.       │   └─base::withCallingHandlers(...)
#>  20.       └─tidyselect:::vars_select_eval(...)
#>  21.         └─tidyselect:::walk_data_tree(expr, data_mask, context_mask)
#>  22.           └─tidyselect:::eval_c(expr, data_mask, context_mask)
#>  23.             └─tidyselect:::reduce_sels(node, data_mask, context_mask, init = init)
#>  24.               └─tidyselect:::walk_data_tree(new, data_mask, context_mask)
#>  25.                 └─tidyselect:::as_indices_sel_impl(...)
#>  26.                   └─tidyselect:::as_indices_impl(x, vars, strict = strict)
#>  27.                     └─tidyselect:::chr_as_locations(x, vars)
#>  28.                       └─vctrs::vec_as_location(x, n = length(vars), names = vars)
#>  29.                         └─vctrs:::stop_subscript_oob(...)
#>  30.                           └─vctrs:::stop_subscript(...)
```