### PR TITLE
Do not consult "rstudio.notebook.executing" option in `is_interactive()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # rlang (development version)
 
+* `is_interactive()` no longer consults "rstudio.notebook.executing"
+  option (#1031).
 
 # rlang 0.4.7
 

--- a/R/state.R
+++ b/R/state.R
@@ -121,9 +121,6 @@ is_interactive <- function() {
   if (is_true(peek_option("knitr.in.progress"))) {
     return(FALSE)
   }
-  if (is_true(peek_option("rstudio.notebook.executing"))) {
-    return(FALSE)
-  }
   if (identical(Sys.getenv("TESTTHAT"), "true")) {
     return(FALSE)
   }

--- a/R/state.R
+++ b/R/state.R
@@ -101,8 +101,8 @@ peek_option <- function(name) {
 #'   escape hatch is useful in unit tests or to manually turn on
 #'   interactive features in RMarkdown outputs.
 #'
-#' * Whether knitr, an RStudio notebook, or testthat is in progress
-#'   (in which case `is_interactive()` returns `FALSE`).
+#' * Whether knitr or testthat is in progress, in which case
+#'   `is_interactive()` returns `FALSE`.
 #'
 #' `with_interactive()` and `local_interactive()` set the global
 #' option conveniently.

--- a/man/is_interactive.Rd
+++ b/man/is_interactive.Rd
@@ -32,8 +32,8 @@ mode. It also checks, in this order:
 or \code{FALSE}, \code{is_interactive()} returns that value immediately. This
 escape hatch is useful in unit tests or to manually turn on
 interactive features in RMarkdown outputs.
-\item Whether knitr, an RStudio notebook, or testthat is in progress
-(in which case \code{is_interactive()} returns \code{FALSE}).
+\item Whether knitr or testthat is in progress, in which case
+\code{is_interactive()} returns \code{FALSE}.
 }
 
 \code{with_interactive()} and \code{local_interactive()} set the global


### PR DESCRIPTION
Closes #1031

The original inclusion was inspired by code in readxl and readr that controls progress. However, in that case, the motivation is about performance, not about lack of interactivity *per se*.

RStudio sets "rstudio.notebook.executing" in notebooks AND whenever "Chunk output inline" is selected. Therefore this check makes code fail mysteriously in what seems to be an interactive session. First noticed in gargle/googlesheets4, where this prevented user interaction re: auth.