### PR TITLE
Avoid truncating backtraces in non-interactive sessions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 
 # rlang (development version)
 
+* Backtraces of unhandled errors are now displayed without truncation
+  in non-interactive sessions (#856).
+
 * `is_interactive()` no longer consults "rstudio.notebook.executing"
   option (#1031).
+
 
 # rlang 0.4.7
 

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -21,7 +21,10 @@ test_that("errors are saved", {
 
   # Verbose try() triggers conditionMessage() and thus saves the error.
   # This simulates an unhandled error.
-  local_options(`rlang:::force_unhandled_error` = TRUE)
+  local_options(
+    `rlang:::force_unhandled_error` = TRUE,
+    `rlang:::error_pipe` = tempfile()
+  )
 
   try(abort("foo", "bar"), outFile = file)
   expect_true(inherits_all(last_error(), c("bar", "rlang_error")))
@@ -42,6 +45,7 @@ test_that("No backtrace is displayed with top-level active bindings", {
 test_that("Invalid on_error option resets itself", {
   with_options(
     `rlang:::force_unhandled_error` = TRUE,
+    `rlang:::error_pipe` = tempfile(),
     rlang_backtrace_on_error = NA,
     {
       expect_warning(tryCatch(abort("foo"), error = identity), "Invalid")

--- a/tests/testthat/test-cnd-error-empty.txt
+++ b/tests/testthat/test-cnd-error-empty.txt
@@ -1,11 +1,13 @@
 > # Branch (depth 0)
 > cat_line(branch0)
 Error: foo
+
 Execution halted
 
 > # Full
 > cat_line(full0)
 Error: foo
+
 Execution halted
 
 > # Branch (depth 1)

--- a/tests/testthat/test-cnd-error-parent-default.txt
+++ b/tests/testthat/test-cnd-error-parent-default.txt
@@ -16,7 +16,7 @@ Backtrace:
 └─<error/foobar>
   Low-level message
 Backtrace:
-  1. rlang::with_options(catch_cnd(a()), `rlang:::force_unhandled_error` = TRUE)
+  1. rlang::with_options(...)
   9. rlang:::a()
  10. rlang:::b()
  11. rlang:::c()

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -80,7 +80,8 @@ test_that("error is printed with parent backtrace", {
 
   err_force <- with_options(
     catch_cnd(a()),
-    `rlang:::force_unhandled_error` = TRUE
+    `rlang:::force_unhandled_error` = TRUE,
+    `rlang:::error_pipe` = tempfile()
   )
 
   expect_known_output(file = test_path("test-cnd-error-parent-default.txt"), {

--- a/tests/testthat/test-cnd-error.txt
+++ b/tests/testthat/test-cnd-error.txt
@@ -19,6 +19,7 @@ Execution halted
 > # Reminder
 > cat_line(reminder)
 Error: Error message
+
 Execution halted
 
 > # Branch


### PR DESCRIPTION
Closes #856