### PR TITLE
Don't store `ids` field in backtraces

### DIFF
--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -67,9 +67,15 @@ format.rlang_error <- function(x,
     message
   )
 
+  trace <- x$trace
+
   while (is_rlang_error(parent)) {
     x <- parent
     parent <- parent$parent
+
+    if (!is_null(x$trace)) {
+      trace <- x$trace
+    }
 
     header <- rlang_error_header(x)
     header <- header_add_tree_node(header, style, parent)
@@ -94,16 +100,10 @@ format.rlang_error <- function(x,
     )
   }
 
-  trace <- x$trace
   simplify <- arg_match(simplify)
 
   if (!is_null(trace) && trace_length(trace)) {
     out <- paste_line(out, bold("Backtrace:"))
-
-    if (!is_null(child)) {
-      trace <- trace_trim_common(trace, child$trace)
-    }
-
     trace_lines <- format(trace, ..., simplify = simplify)
     out <- paste_line(out, trace_lines)
   }

--- a/tests/testthat/output-cnd-abort-parent-trace.txt
+++ b/tests/testthat/output-cnd-abort-parent-trace.txt
@@ -33,3 +33,19 @@ Backtrace:
   9. rlang:::g()
  10. rlang:::h()
 
+
+withCallingHandlers()
+=====================
+
+> print(err_wch)
+x
++-<error/rlang_error>
+| bar
+\-<error/rlang_error>
+  foo
+Backtrace:
+  1. rlang::catch_cnd(...)
+  9. rlang:::foo()
+ 10. rlang:::bar(cnd)
+ 11. rlang:::baz(cnd)
+

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -57,13 +57,13 @@ test_that("Invalid on_error option resets itself", {
 test_that("format_onerror_backtrace handles empty and size 1 traces", {
   local_options(rlang_backtrace_on_error = "branch")
 
-  trace <- new_trace(list(), int(), chr())
+  trace <- new_trace(list(), int())
   expect_identical(format_onerror_backtrace(trace), NULL)
 
-  trace <- new_trace(list(quote(foo)), int(0), chr(""))
+  trace <- new_trace(list(quote(foo)), int(0))
   expect_identical(format_onerror_backtrace(trace), NULL)
 
-  trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1), chr("", ""))
+  trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1))
   expect_match(format_onerror_backtrace(error_cnd(trace = trace)), "foo.*bar")
 })
 
@@ -223,6 +223,16 @@ test_that("capture context doesn't leak into low-level backtraces", {
     )
   }
 
+  foo <- function(cnd) bar(cnd)
+  bar <- function(cnd) baz(cnd)
+  baz <- function(cnd) abort("foo")
+  err_wch <- catch_cnd(
+    withCallingHandlers(
+      foo(),
+      error = function(cnd) abort("bar", parent = cnd)
+    )
+  )
+
   verify_output(test_path("output-cnd-abort-parent-trace.txt"), {
     parent <- TRUE
     wrapper <- FALSE
@@ -237,6 +247,9 @@ test_that("capture context doesn't leak into low-level backtraces", {
     parent <- FALSE
     err <- catch_cnd(f())
     print(err)
+
+    "# withCallingHandlers()"
+    print(err_wch)
   })
 })
 

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -406,13 +406,13 @@ test_that("collapsing of eval() frames detects when error occurs within eval()",
 test_that("can print degenerate backtraces", {
   skip_unless_utf8()
 
-  trace_sym <- new_trace(list(quote(foo)), int(0), chr(""))
+  trace_sym <- new_trace(list(quote(foo)), int(0))
   expect_known_trace_output(trace_sym, file = "test-trace-degenerate-sym.txt")
 
-  trace_null <- new_trace(list(NULL), int(0), chr(""))
+  trace_null <- new_trace(list(NULL), int(0))
   expect_known_trace_output(trace_null, file = "test-trace-degenerate-null.txt")
 
-  trace_scalar <- new_trace(list(1L), int(0), chr(""))
+  trace_scalar <- new_trace(list(1L), int(0))
   expect_known_trace_output(trace_scalar, file = "test-trace-degenerate-scalar.txt")
 })
 


### PR DESCRIPTION
And don't use them to trim the signalling context.

cc @gaborcsardi