### PR TITLE
Optionally call winch::winch_add_trace_back() when collecting stack trace

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Suggests:
     rmarkdown,
     testthat (>= 2.3.0),
     vctrs (>= 0.2.3),
+    winch,
     withr
 Encoding: UTF-8
 RoxygenNote: 7.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,8 +26,9 @@ Suggests:
     rmarkdown,
     testthat (>= 2.3.0),
     vctrs (>= 0.2.3),
-    winch,
     withr
+Enhances: 
+    winch
 Encoding: UTF-8
 RoxygenNote: 7.1.1
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # rlang (development version)
 
+* Backtraces now include native stacks (e.g. from C code) when the
+  [winch](https://r-prof.github.io/winch/) package is installed and
+  `rlang_trace_use_winch` is set to `1L` (@krlmlr).
+
 * Compatibility with upcoming testthat 3 and magrittr 2 releases.
 
 * `get_env()` now returns the proper environment with primitive

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 
 * Backtraces now include native stacks (e.g. from C code) when the
   [winch](https://r-prof.github.io/winch/) package is installed and
-  `rlang_trace_use_winch` is set to `1L` (@krlmlr).
+  `rlang_trace_use_winch` is set to `TRUE` (@krlmlr).
 
 * Compatibility with upcoming testthat 3 and magrittr 2 releases.
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -254,6 +254,7 @@ new_trace <- function(calls, parents, indices = NULL) {
       indices = indices
     ),
     class = "rlang_trace",
+    # Increment this number when the internal format for the class changes
     version = 1L
   )
 }
@@ -277,8 +278,6 @@ add_winch_trace <- function(trace) {
     return(trace)
   }
 
-  # Increment this number when the internal format for the rlang_trace class
-  # changes
   use_winch <- peek_option("rlang_trace_use_winch") %||% FALSE
   if (!is_true(as.logical(use_winch))) {
     return(trace)

--- a/R/trace.R
+++ b/R/trace.R
@@ -262,7 +262,8 @@ trace_reset_indices <- function(trace) {
   trace
 }
 
-winch_available_env <- new_environment()
+# Can't use new_environment() here
+winch_available_env <- new.env(parent = emptyenv())
 
 add_winch_trace <- function(trace) {
   avail <- winch_available_env$installed

--- a/R/trace.R
+++ b/R/trace.R
@@ -92,6 +92,14 @@ trace_back <- function(top = NULL, bottom = NULL) {
   trace <- new_trace(calls, parents)
   trace <- trace_trim_env(trace, frames, top)
 
+  trace_hook <- peek_option("rlang:::trace_hook")
+  if (is_function(trace_hook)) {
+    new_trace <- trace_hook(trace)
+    if (inherits(new_trace, "rlang_trace")) {
+      trace <- new_trace
+    }
+  }
+
   trace
 }
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -92,9 +92,8 @@ trace_back <- function(top = NULL, bottom = NULL) {
   trace <- new_trace(calls, parents)
   trace <- trace_trim_env(trace, frames, top)
 
-  trace_hook <- peek_option("rlang:::trace_hook")
-  if (is_function(trace_hook)) {
-    new_trace <- trace_hook(trace)
+  if (is_installed("winch")) {
+    new_trace <- winch::winch_add_trace_back(trace)
     if (inherits(new_trace, "rlang_trace")) {
       trace <- new_trace
     }

--- a/R/trace.R
+++ b/R/trace.R
@@ -728,6 +728,10 @@ is_uninformative_call <- function(call) {
 
   fn <- call[[1]]
 
+  if (is_winch_frame(fn)) {
+    return(TRUE)
+  }
+
   # Inlined functions occur with active bindings
   if (is_function(fn)) {
     return(TRUE)
@@ -742,6 +746,22 @@ is_uninformative_call <- function(call) {
   }
 
   FALSE
+}
+
+# To be replaced with a more structured way of disabling frames in
+# various displays
+is_winch_frame <- function(call) {
+  if (!is_call(call, "::")) {
+    return(FALSE)
+  }
+
+  lhs <- call[[2]]
+  if (!is_symbol(lhs)) {
+    return(FALSE)
+  }
+
+  name <- as_string(lhs)
+  grepl("^/.+[.].+", name)
 }
 
 trace_simplify_collapse <- function(trace) {

--- a/R/trace.R
+++ b/R/trace.R
@@ -253,7 +253,8 @@ new_trace <- function(calls, parents, indices = NULL) {
       parents = parents,
       indices = indices
     ),
-    class = "rlang_trace"
+    class = "rlang_trace",
+    version = 1L
   )
 }
 
@@ -278,8 +279,8 @@ add_winch_trace <- function(trace) {
 
   # Increment this number when the internal format for the rlang_trace class
   # changes
-  enabled <- identical(peek_option("rlang_trace_use_winch"), 1L)
-  if (!enabled) {
+  use_winch <- peek_option("rlang_trace_use_winch") %||% FALSE
+  if (!is_true(as.logical(use_winch))) {
     return(trace)
   }
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -762,7 +762,7 @@ is_winch_frame <- function(call) {
   }
 
   name <- as_string(lhs)
-  grepl("^/.+[.].+", name)
+  grepl("^[/\\\\].+[.]", name)
 }
 
 trace_simplify_collapse <- function(trace) {

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -1,5 +1,9 @@
 context("trace.R")
 
+local_options(
+  rlang_trace_use_winch = FALSE
+)
+
 # These tests must come first because print method includes srcrefs
 test_that("tree printing only changes deliberately", {
   skip_unless_utf8()


### PR DESCRIPTION
This is for capturing a native stack trace when the error occurs. See the examples at https://github.com/r-prof/winch/pull/4/checks?check_run_id=961027969#step:10:28 and below. I hope to get better native stack traces with libunwind (https://github.com/r-prof/winch/issues/2), I rather like how this seems to work already in all cases (`stop()`, `Rf_error()` and `abort()`).

Would you support this in rlang? I understand that we want to document and stabilize the structure of the `"rlang_trace"` before exposing it, and that we need tests. I don't mind marking this as "experimental".