### PR TITLE
Preserve exit status when `entrace()` is used as handler

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # rlang (development version)
 
+* The exit status of is now preserved in non-interactive sessions when
+  `entrace()` is used as an `options(error = )` handler (#1052,
+  rstudio/bookdown#920).
+
 * `next` and `break` are now properly deparsed as nullary operators.
 
 * New `env_browse()` and `env_is_browsed()` functions. `env_browse()`

--- a/R/cnd-entrace.R
+++ b/R/cnd-entrace.R
@@ -163,7 +163,7 @@ sys_body <- function(n) {
 entrace_handle_top <- function(trace) {
   # Happens with ctrl-c at top-level
   if (!trace_length(trace)) {
-    return()
+    return(entrace_exit())
   }
 
   stop_call <- sys.call(-2)
@@ -175,7 +175,7 @@ entrace_handle_top <- function(trace) {
 
   # No need to do anything for rlang errors
   if (from_stop && (is_trace(cnd$trace) || is_true(cnd$rlang_entraced))) {
-    return(NULL)
+    return(entrace_exit())
   }
 
   if (from_stop) {
@@ -197,6 +197,16 @@ entrace_handle_top <- function(trace) {
   backtrace_lines <- format_onerror_backtrace(err)
   if (length(backtrace_lines)) {
     cat_line(backtrace_lines)
+  }
+
+  entrace_exit()
+}
+
+entrace_exit <- function() {
+  # Disable error handler in non-interactive sessions to force
+  # non-zero exit (#1052, rstudio/bookdown#920)
+  if (!is_interactive()) {
+    options(error = NULL)
   }
 
   NULL

--- a/tests/testthat/helper-rlang.R
+++ b/tests/testthat/helper-rlang.R
@@ -50,8 +50,7 @@ Rscript <- function(args, ...) {
     args,
     ...,
     stdout = TRUE,
-    stderr = TRUE,
-    timeout = 3
+    stderr = TRUE
   ))
 
   list(

--- a/tests/testthat/helper-rlang.R
+++ b/tests/testthat/helper-rlang.R
@@ -43,3 +43,19 @@ skip_if_stale_backtrace <- local({
     skip_if(has_stale_backtrace)
   }
 })
+
+Rscript <- function(args, ...) {
+  out <- suppressWarnings(system2(
+    file.path(R.home("bin"), "Rscript"),
+    args,
+    ...,
+    stdout = TRUE,
+    stderr = TRUE,
+    timeout = 3
+  ))
+
+  list(
+    out = unstructure(out),
+    status = attr(out, "status")
+  )
+}

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -185,6 +185,9 @@ test_that("rlang and base errors are properly entraced", {
 })
 
 test_that("entrace() preserves exit status in non-interactive sessions (#1052, rstudio/bookdown#920)", {
+  # Probably because of <https://github.com/wch/r-source/commit/3055aa86>
+  skip_if(getRversion() < "3.3")
+
   out <- Rscript(shQuote(c("--vanilla", "-e", 'options(error = rlang::entrace); stop("An error")')))
   expect_false(out$status == 0L)
 

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -186,7 +186,7 @@ test_that("rlang and base errors are properly entraced", {
 
 test_that("entrace() preserves exit status in non-interactive sessions (#1052, rstudio/bookdown#920)", {
   out <- Rscript(shQuote(c("--vanilla", "-e", 'options(error = rlang::entrace); stop("An error")')))
-  expect_equal(out$status, 1L)
+  expect_false(out$status == 0L)
 
   code <- '
   {
@@ -197,5 +197,5 @@ test_that("entrace() preserves exit status in non-interactive sessions (#1052, r
     f()
   }'
   out <- Rscript(shQuote(c("--vanilla", "-e", code)))
-  expect_equal(out$status, 1L)
+  expect_false(out$status == 0L)
 })

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -183,3 +183,19 @@ test_that("rlang and base errors are properly entraced", {
     cat_line(rlang)
   })
 })
+
+test_that("entrace() preserves exit status in non-interactive sessions (#1052, rstudio/bookdown#920)", {
+  out <- Rscript(shQuote(c("--vanilla", "-e", 'options(error = rlang::entrace); stop("An error")')))
+  expect_equal(out$status, 1L)
+
+  code <- '
+  {
+    options(error = rlang::entrace)
+    f <- function() g()
+    g <- function() h()
+    h <- function() stop("An error")
+    f()
+  }'
+  out <- Rscript(shQuote(c("--vanilla", "-e", code)))
+  expect_equal(out$status, 1L)
+})


### PR DESCRIPTION
Fixes rstudio/bookdown#920
Closes #1052