### PR TITLE
Initialise data mask with expected number of elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # rlang (development version)
 
+* `as_data_mask()` now intialises environments of the correct size to
+  improve efficiency (#1048).
+
 * Fixed bug that prevented splicing a named empty vector with the
   `!!!` operator (#1045).
 

--- a/src/lib/c-utils.h
+++ b/src/lib/c-utils.h
@@ -87,8 +87,6 @@ double r_ssize_as_double(r_ssize x) {
 
 static inline
 r_ssize r_double_as_ssize(double x) {
-  x = round(x);
-
   if (x > R_SSIZE_MAX || x < R_SSIZE_MIN) {
     r_stop_internal("r_ssize_as_double", "Result can't be represented as `r_ssize`.");
   }

--- a/src/lib/c-utils.h
+++ b/src/lib/c-utils.h
@@ -101,7 +101,7 @@ double r_double_mult(double x, double y) {
   double out = x * y;
 
   if (!isfinite(out)) {
-    r_stop_internal("r_double_mult", "Can't multiple double values.");
+    r_stop_internal("r_double_mult", "Can't multiply double values.");
   }
 
   return out;

--- a/src/lib/c-utils.h
+++ b/src/lib/c-utils.h
@@ -1,6 +1,7 @@
 #ifndef RLANG_C_UTILS_H
 #define RLANG_C_UTILS_H
 
+#include <float.h>
 #include "cnd.h"
 
 
@@ -69,9 +70,41 @@ static inline
 r_ssize r_ssize_min(r_ssize x, r_ssize y) {
   return (y < x) ? y : x;
 }
+
 static inline
 r_ssize r_ssize_max(r_ssize x, r_ssize y) {
   return (y < x) ? x : y;
+}
+
+static inline
+double r_ssize_as_double(r_ssize x) {
+  if (x > DBL_MAX || x < -DBL_MAX) {
+    r_stop_internal("r_ssize_as_double", "Result can't be represented as `double`.");
+  }
+
+  return (double) x;
+}
+
+static inline
+r_ssize r_double_as_ssize(double x) {
+  x = round(x);
+
+  if (x > R_SSIZE_MAX || x < R_SSIZE_MIN) {
+    r_stop_internal("r_ssize_as_double", "Result can't be represented as `r_ssize`.");
+  }
+
+  return (r_ssize) x;
+}
+
+static inline
+double r_double_mult(double x, double y) {
+  double out = x * y;
+
+  if (!isfinite(out)) {
+    r_stop_internal("r_double_mult", "Can't multiple double values.");
+  }
+
+  return out;
 }
 
 #endif


### PR DESCRIPTION
Closes #1048. Performance is improved but not dramatically.

```r
data <- as.list(set_names(1:1e5))
bench::mark(before = as_data_mask(data))[1:8]
```

Before

```r
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 before        220ms    223ms      4.47    5.44MB        0     3     0
```

After

```r
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
#> 1 after         169ms    170ms      5.88    2.76MB        0     3     0
```

For 1e6 elements this goes from 2.35s to 1.85s.