### PR TITLE
Propagate visibility in `eval_tidy()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 # rlang (development version)
 
-* `eval_bare()` now propagates visibility.
+* `eval_bare()` and `eval_tidy()` (#961) now propagate visibility.
 
 * `inject()` evaluates its argument with `!!`, `!!!`, and `{{`
   support.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,8 @@
 
 # rlang (development version)
 
-* `eval_bare()` and `eval_tidy()` (#961) now propagate visibility.
+* `eval_bare()`, `eval_tidy()` (#961), and `with_handlers()` (#518)
+  now propagate visibility.
 
 * `inject()` evaluates its argument with `!!`, `!!!`, and `{{`
   support.

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -165,7 +165,7 @@
 #' }
 #' @export
 eval_tidy <- function(expr, data = NULL, env = caller_env()) {
-  .Call(rlang_eval_tidy, expr, data, env)
+  .External2(rlang_ext2_eval_tidy, expr, data, env)
 }
 
 # Helps work around roxygen loading issues

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -1168,7 +1168,7 @@ overscope_eval_next <- function(overscope, quo, env = base_env()) {
     "`overscope_eval_next()` is deprecated as of rlang 0.2.0.",
     "Please use `eval_tidy()` with a data mask instead."
   ))
-  .Call(rlang_eval_tidy, quo, overscope, env)
+  .External2(rlang_ext2_eval_tidy, quo, overscope, env)
 }
 
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -225,6 +225,8 @@ static const r_callable r_callables[] = {
   {"rlang_sexp_address",                (r_fn_ptr) &rlang_sexp_address, 1},
   {"rlang_symbol",                      (r_fn_ptr) &rlang_symbol, 1},
   {"rlang_sym_as_character",            (r_fn_ptr) &rlang_sym_as_character, 1},
+  // No longer necessary but keep this around for a while in case
+  // quosures ended up saved as RDS.
   {"rlang_tilde_eval",                  (r_fn_ptr) &rlang_tilde_eval, 3},
   {"rlang_unescape_character",          (r_fn_ptr) &rlang_unescape_character, 1},
   {"rlang_new_call",                    (r_fn_ptr) &rlang_new_call_node, 2},
@@ -334,6 +336,8 @@ extern sexp* rlang_ext2_call2(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_exec(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_eval(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_eval_tidy(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_ext2_tilde_eval(sexp*, sexp*, sexp*, sexp*);
+
 
 static const r_external externals[] = {
   {"rlang_ext_arg_match0",              (r_fn_ptr) &rlang_ext_arg_match0, 3},
@@ -345,6 +349,7 @@ static const r_external externals[] = {
   {"rlang_ext2_exec",                   (r_fn_ptr) &rlang_ext2_exec, 2},
   {"rlang_ext2_eval",                   (r_fn_ptr) &rlang_ext2_eval, 2},
   {"rlang_ext2_eval_tidy",              (r_fn_ptr) &rlang_ext2_eval_tidy, 3},
+  {"rlang_ext2_tilde_eval",             (r_fn_ptr) &rlang_ext2_tilde_eval, 3},
   {NULL, NULL, 0}
 };
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -97,7 +97,6 @@ extern sexp* rlang_new_data_mask_compat(sexp*, sexp*, sexp*);
 extern sexp* rlang_as_data_mask(sexp*);
 extern sexp* rlang_as_data_mask_compat(sexp*, sexp*);
 extern sexp* rlang_data_mask_clean(sexp*);
-extern sexp* rlang_eval_tidy(sexp*, sexp*, sexp*);
 extern sexp* rlang_as_data_pronoun(sexp*);
 extern sexp* rlang_env_get(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_env_get_list(sexp*, sexp*, sexp*, sexp*);
@@ -279,7 +278,6 @@ static const r_callable r_callables[] = {
   {"rlang_is_data_mask",                (r_fn_ptr) &rlang_is_data_mask, 1},
   {"rlang_data_pronoun_get",            (r_fn_ptr) &rlang_data_pronoun_get, 2},
   {"rlang_data_mask_clean",             (r_fn_ptr) &rlang_data_mask_clean, 1},
-  {"rlang_eval_tidy",                   (r_fn_ptr) &rlang_eval_tidy, 3},
   {"rlang_as_data_pronoun",             (r_fn_ptr) &rlang_as_data_pronoun, 1},
   {"rlang_env_binding_types",           (r_fn_ptr) &r_env_binding_types, 2},
   {"rlang_env_get",                     (r_fn_ptr) &rlang_env_get, 4},
@@ -335,6 +333,7 @@ extern sexp* rlang_ext_dots_values(sexp*);
 extern sexp* rlang_ext2_call2(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_exec(sexp*, sexp*, sexp*, sexp*);
 extern sexp* rlang_ext2_eval(sexp*, sexp*, sexp*, sexp*);
+extern sexp* rlang_ext2_eval_tidy(sexp*, sexp*, sexp*, sexp*);
 
 static const r_external externals[] = {
   {"rlang_ext_arg_match0",              (r_fn_ptr) &rlang_ext_arg_match0, 3},
@@ -345,6 +344,7 @@ static const r_external externals[] = {
   {"rlang_ext2_call2",                  (r_fn_ptr) &rlang_ext2_call2, 2},
   {"rlang_ext2_exec",                   (r_fn_ptr) &rlang_ext2_exec, 2},
   {"rlang_ext2_eval",                   (r_fn_ptr) &rlang_ext2_eval, 2},
+  {"rlang_ext2_eval_tidy",              (r_fn_ptr) &rlang_ext2_eval_tidy, 3},
   {NULL, NULL, 0}
 };
 
@@ -352,6 +352,7 @@ static const r_external externals[] = {
 extern bool is_splice_box(sexp*);
 extern sexp* rlang_env_dots_values(sexp*);
 extern sexp* rlang_env_dots_list(sexp*);
+extern sexp* rlang_eval_tidy(sexp*, sexp*, sexp*);
 
 export void R_init_rlang(r_dll_info* dll) {
   // The quosure functions are stable

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -530,6 +530,14 @@ sexp* rlang_eval_tidy(sexp* expr, sexp* data, sexp* env) {
   return out;
 }
 
+sexp* rlang_ext2_eval_tidy(sexp* call, sexp* op, sexp* args, sexp* rho) {
+  args = r_node_cdr(args);
+  sexp* expr = r_node_car(args); args = r_node_cdr(args);
+  sexp* data = r_node_car(args); args = r_node_cdr(args);
+  sexp* env = r_node_car(args);
+  return rlang_eval_tidy(expr, data, env);
+}
+
 
 void rlang_init_eval_tidy() {
   sexp* rlang_ns_env = KEEP(r_ns_env("rlang"));

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -443,6 +443,14 @@ sexp* rlang_tilde_eval(sexp* tilde, sexp* current_frame, sexp* caller_frame) {
   return r_eval(expr, info.mask);
 }
 
+sexp* rlang_ext2_tilde_eval(sexp* call, sexp* op, sexp* args, sexp* rho) {
+  args = r_node_cdr(args);
+  sexp* tilde = r_node_car(args); args = r_node_cdr(args);
+  sexp* current_frame = r_node_car(args); args = r_node_cdr(args);
+  sexp* caller_frame = r_node_car(args);
+  return rlang_tilde_eval(tilde, current_frame, caller_frame);
+}
+
 static const char* data_mask_objects_names[5] = {
   ".__tidyeval_data_mask__.", "~", ".top_env", ".env", NULL
 };
@@ -544,7 +552,7 @@ void rlang_init_eval_tidy() {
 
   tilde_fn = r_parse_eval(
     "function(...) {                          \n"
-    "  .Call(rlang_tilde_eval,                \n"
+    "  .External2(rlang_ext2_tilde_eval,      \n"
     "    sys.call(),     # Quosure env        \n"
     "    environment(),  # Unwind-protect env \n"
     "    parent.frame()  # Lexical env        \n"

--- a/tests/testthat/test-cnd-handlers.R
+++ b/tests/testthat/test-cnd-handlers.R
@@ -81,3 +81,8 @@ test_that("cnd_muffle() returns FALSE if the condition is not mufflable", {
   ))
   expect_false(value)
 })
+
+test_that("with_handlers() propagates visibility", {
+  expect_visible(with_handlers(list(invisible(1))))
+  expect_invisible(with_handlers(invisible(1)))
+})

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -472,8 +472,6 @@ test_that("can evaluate tilde in nested masks", {
 test_that("eval_tidy() propagates visibility", {
   expect_visible(eval_tidy(quo(list(invisible(list())))))
   expect_invisible(eval_tidy(quo(invisible(list()))))
-
-  skip("FIXME")
   expect_invisible(eval_tidy(quo(identity(!!local(quo(invisible(list())))))))
 })
 

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -469,6 +469,14 @@ test_that("can evaluate tilde in nested masks", {
   )
 })
 
+test_that("eval_tidy() propagates visibility", {
+  expect_visible(eval_tidy(quo(list(invisible(list())))))
+  expect_invisible(eval_tidy(quo(invisible(list()))))
+
+  skip("FIXME")
+  expect_invisible(eval_tidy(quo(identity(!!local(quo(invisible(list())))))))
+})
+
 
 # Lifecycle ----------------------------------------------------------
 


### PR DESCRIPTION
Closes #961.