### PR TITLE
advocate use of 'rlang::entrace' directly in docs

### DIFF
--- a/R/cnd-entrace.R
+++ b/R/cnd-entrace.R
@@ -8,7 +8,7 @@
 #' condition object, without any other effect. Both functions should
 #' be called directly from an error handler.
 #'
-#' Set the `error` global option to `quote(rlang::entrace())` to
+#' Set the `error` global option to `rlang::entrace` to
 #' transform base errors to rlang errors. These enriched errors
 #' include a backtrace. The RProfile is a good place to set the
 #' handler. See [`rlang_backtrace_on_error`] for details.

--- a/man/entrace.Rd
+++ b/man/entrace.Rd
@@ -39,7 +39,7 @@ immediately resumed. \code{cnd_entrace()} adds a backtrace to a
 condition object, without any other effect. Both functions should
 be called directly from an error handler.
 
-Set the \code{error} global option to \code{quote(rlang::entrace())} to
+Set the \code{error} global option to \code{rlang::entrace} to
 transform base errors to rlang errors. These enriched errors
 include a backtrace. The RProfile is a good place to set the
 handler. See \code{\link{rlang_backtrace_on_error}} for details.


### PR DESCRIPTION
IIUC it's safe to just set

```
options(error = rlang::entrace)
```

and other parts of the codebase recommend + use this, so advocate using that directly here as well.