### PR TITLE
Fix warning regarding partial matching

### DIFF
--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -21,8 +21,8 @@ test_that("fails with non-callable objects", {
 })
 
 test_that("succeeds with literal functions", {
-  expect_error(regex = NA, call2(base::mean, 1:10))
-  expect_error(regex = NA, call2(base::list, 1:10))
+  expect_error(regexp = NA, call2(base::mean, 1:10))
+  expect_error(regexp = NA, call2(base::list, 1:10))
 })
 
 test_that("call2() preserves empty arguments", {

--- a/tests/testthat/test-quo.R
+++ b/tests/testthat/test-quo.R
@@ -147,7 +147,7 @@ test_that("as_quosure() coerces formulas", {
 })
 
 test_that("quo_squash() warns", {
-  expect_warning(regex = NA, quo_squash(quo(foo), warn = TRUE))
+  expect_warning(regexp = NA, quo_squash(quo(foo), warn = TRUE))
   expect_warning(quo_squash(quo(list(!! quo(foo))), warn = TRUE), "inner quosure")
 })
 

--- a/tests/testthat/test-vec-squash.R
+++ b/tests/testthat/test-vec-squash.R
@@ -10,7 +10,7 @@ test_that("vectors and names are squashed", {
 })
 
 test_that("bad outer names warn even at depth", {
-  expect_warning(regex = "Outer names",
+  expect_warning(regexp = "Outer names",
     expect_identical(squash_dbl(list(list(list(A = c(a = 1))))), c(a = 1))
   )
 })


### PR DESCRIPTION
`regex` -> `regexp`