### PR TITLE
Deparse double and triple colon on the same line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # rlang (development version)
 
+* `expr_deparse()` now correctly wraps code using `::` and `:::` (#1072, @krlmlr).
+
 
 # rlang 0.4.9
 

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -358,6 +358,13 @@ spaced_op_deparse <- function(x, lines = new_lines()) {
 unspaced_op_deparse <- function(x, lines = new_lines()) {
   binary_op_deparse(x, lines, space = "")
 }
+tight_op_deparse <- function(x, lines = new_lines()) {
+  sub_lines <- new_lines(width = Inf)
+  out <- binary_op_deparse(x, sub_lines, space = "")
+
+  lines$push(out)
+  lines$get_lines()
+}
 
 unary_op_deparse <- function(x, lines = new_lines()) {
   op <- as_string(node_car(x))
@@ -566,9 +573,9 @@ op_deparse <- function(op, x, lines) {
     `:` = ,
     `^` = ,
     `$` = ,
-    `@` = ,
+    `@` = unspaced_op_deparse,
     `::` = ,
-    `:::` = unspaced_op_deparse,
+    `:::` = tight_op_deparse,
     `?unary` = ,
     `~unary` = ,
     `!` = ,

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -330,7 +330,7 @@ operand_deparse <- function(x, parent, side, lines) {
   }
 }
 
-binary_op_deparse <- function(x, lines = new_lines(), space = " ") {
+binary_op_deparse <- function(x, lines = new_lines(), space = " ", sticky_rhs = FALSE) {
   # Constructed call without second argument
   if (is_null(node_cddr(x))) {
     return(call_deparse(x, lines))
@@ -343,6 +343,10 @@ binary_op_deparse <- function(x, lines = new_lines(), space = " ") {
   operand_deparse(node_car(x), outer, "lhs", lines)
 
   lines$push_sticky(paste0(space, op, space))
+
+  if (sticky_rhs) {
+    lines$make_next_sticky()
+  }
 
   x <- node_cdr(x)
 
@@ -359,11 +363,7 @@ unspaced_op_deparse <- function(x, lines = new_lines()) {
   binary_op_deparse(x, lines, space = "")
 }
 tight_op_deparse <- function(x, lines = new_lines()) {
-  sub_lines <- new_lines(width = Inf)
-  out <- binary_op_deparse(x, sub_lines, space = "")
-
-  lines$push(out)
-  lines$get_lines()
+  binary_op_deparse(x, lines, space = "", sticky_rhs = TRUE)
 }
 
 unary_op_deparse <- function(x, lines = new_lines()) {

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -489,11 +489,15 @@ test_that("double colon is never wrapped (#1072)", {
     "some.very.long::construct"
   )
   expect_identical(
-    expr_deparse(quote(id_fun <- base::identity), width = 20),
+    expr_deparse(quote(id_function <- base::identity), width = 15),
     c(
-      "id_fun <-",
+      "id_function <-",
       "  base::identity"
     )
+  )
+  expect_identical(
+    expr_deparse(quote(id_fun <- base::identity), width = 20),
+    "id_fun <- base::identity"
   )
 })
 
@@ -503,10 +507,14 @@ test_that("triple colon is never wrapped (#1072)", {
     "some.very.long:::construct"
   )
   expect_identical(
-    expr_deparse(quote(id_fun <- base:::identity), width = 20),
+    expr_deparse(quote(id_function <- base:::identity), width = 15),
     c(
-      "id_fun <-",
+      "id_function <-",
       "  base:::identity"
     )
+  )
+  expect_identical(
+    expr_deparse(quote(id_fun <- base:::identity), width = 20),
+    "id_fun <- base:::identity"
   )
 })

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -482,3 +482,31 @@ test_that("`next` and `break` are deparsed", {
   expect_equal(expr_deparse(quote({ next; (break) })), c("{", "  next",  "  (break)", "}"))
   expect_equal(expr_deparse(quote(a <- next <- break)), c("a <- next <- break"))
 })
+
+test_that("double colon is never wrapped (#1072)", {
+  expect_identical(
+    expr_deparse(quote(some.very.long::construct), width = 20),
+    "some.very.long::construct"
+  )
+  expect_identical(
+    expr_deparse(quote(identity_fun <- base::identity), width = 20),
+    c(
+      "identity_fun <-",
+      "  base::identity"
+    )
+  )
+})
+
+test_that("triple colon is never wrapped (#1072)", {
+  expect_identical(
+    expr_deparse(quote(some.very.long:::construct), width = 20),
+    "some.very.long:::construct"
+  )
+  expect_identical(
+    expr_deparse(quote(identity_fun <- base:::identity), width = 20),
+    c(
+      "identity_fun <-",
+      "  base:::identity"
+    )
+  )
+})

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -489,9 +489,9 @@ test_that("double colon is never wrapped (#1072)", {
     "some.very.long::construct"
   )
   expect_identical(
-    expr_deparse(quote(identity_fun <- base::identity), width = 20),
+    expr_deparse(quote(id_fun <- base::identity), width = 20),
     c(
-      "identity_fun <-",
+      "id_fun <-",
       "  base::identity"
     )
   )
@@ -503,9 +503,9 @@ test_that("triple colon is never wrapped (#1072)", {
     "some.very.long:::construct"
   )
   expect_identical(
-    expr_deparse(quote(identity_fun <- base:::identity), width = 20),
+    expr_deparse(quote(id_fun <- base:::identity), width = 20),
     c(
-      "identity_fun <-",
+      "id_fun <-",
       "  base:::identity"
     )
   )


### PR DESCRIPTION
to avoid parser error when reparsing.

It's using a hammer, let me know if we can do better here.

Closes #1072.