### PR TITLE
Add a new line after the info message

### DIFF
--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -254,5 +254,5 @@ add_message_freq <- function(message, frequency, type) {
   }
   info <- sprintf(info, type)
 
-  paste_line(message, info)
+  paste_line(message, info, "")
 }

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -143,7 +143,6 @@ inform <- function(message = NULL,
 
   message <- message %||% ""
   message <- collapse_cnd_message(message)
-  message <- paste0(message, "\n")
 
   .frequency <- arg_match(.frequency, c("always", "regularly", "once"))
 
@@ -157,7 +156,7 @@ inform <- function(message = NULL,
 
   withRestarts(muffleMessage = function() NULL, {
     signalCondition(cnd)
-    cat(message, file = .file %||% default_message_file())
+    cat(paste0(message, "\n"), file = .file %||% default_message_file())
   })
 
   invisible()
@@ -254,5 +253,5 @@ add_message_freq <- function(message, frequency, type) {
   }
   info <- sprintf(info, type)
 
-  paste_line(message, info, "")
+  paste_line(message, info)
 }


### PR DESCRIPTION
reprex:

```r
# Print two inform() statements successively
rlang::inform(
  "asdf1", .frequency = "regularly", .frequency_id = as.character(runif(1))
); rlang::inform(
  "asdf2", .frequency = "regularly", .frequency_id = as.character(runif(1))
)
```

------------------

before PR:

```
asdf1

This message is displayed once every 8 hours.asdf2

This message is displayed once every 8 hours.
```

with PR:

```
asdf1

This message is displayed once every 8 hours.
asdf2

This message is displayed once every 8 hours.
```

-----------------

I would argue that the format should be like the output below, but this PR fixes [my use case](https://github.com/rstudio/shiny/pull/3174#discussion_r542541630).

```
asdf1
This message is displayed once every 8 hours.

asdf2
This message is displayed once every 8 hours.

``` 

or

```
asdf1
This message is displayed once every 8 hours.
asdf2
This message is displayed once every 8 hours.
``` 



cc @wch 