### PR TITLE
Ensure hashes are independent of endianness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* `hash()` results are now independent of endianness (#1086).
+
 * Fixed a gcc11 warning related to `hash()` (#1088).
 
 * `XXH3_64bits()` from the XXHash library is now exposed as C callable

--- a/src/internal/hash.c
+++ b/src/internal/hash.c
@@ -202,35 +202,6 @@ void hash_char(R_outpstream_t stream, int input) {
 
 #if USE_VERSION_3
 
-// ntohl() byte swapper brought in from:
-// https://github.com/wch/r-source/blob/d22ee2fc0dc8142b23eed9f46edf76ea9d3ca69a/src/extra/xdr/xdr_mem.c#L11-L35
-
-/* Local mod: the assembly assumes i386 and little-endian generic is 32-bit */
-#if defined(_WIN32) && !defined(_WIN64)
-static uint32_t r__ntohl(uint32_t x)
-{ /* could write VC++ inline assembler, but not worth it for now */
-#ifdef _MSC_VER
-  return((x << 24) | ((x & 0xff00) << 8) | ((x & 0xff0000) >> 8) | (x >> 24));
-#else
-  __asm__("xchgb %b0,%h0\n\t"	/* swap lower bytes	*/
-	  "rorl $16,%0\n\t"	/* swap words		*/
-	  "xchgb %b0,%h0"       /* swap higher bytes	*/
-	  :"=q" (x)
-	  : "0" (x));
-  return x;
-#endif
-}
-#else /* net is big-endian: little-endian hosts need byte-swap code */
-#ifndef WORDS_BIGENDIAN
-static uint32_t r__ntohl(uint32_t x)
-{
-  return((x << 24) | ((x & 0xff00) << 8) | ((x & 0xff0000) >> 8) | (x >> 24));
-}
-#else
-#define r__ntohl(x) (x)
-#endif
-#endif
-
 static inline
 void hash_skip(struct hash_state_t* p_state, void* p_input, int n) {
   if (p_state->n_skipped < N_BYTES_SERIALIZATION_INFO) {
@@ -241,14 +212,11 @@ void hash_skip(struct hash_state_t* p_state, void* p_input, int n) {
 
   if (p_state->n_skipped == N_BYTES_SERIALIZATION_INFO) {
     // We've skipped all serialization info bytes.
-    // Incoming bytes tell the size of the native encoding string, but
-    // they've been byte swapped on little-endian systems,
-    // so we need to undo that with `r__ntohl()`.
+    // Incoming data stream is big-endian, so we extract the int representing
+    // native encoding size in 3210 order.
     char buf[128];
     memcpy(buf, p_input, n);
-    const int32_t* p_buf = (const int32_t*) buf;
-    int32_t val = *p_buf;
-    p_state->n_native_enc = (int32_t) r__ntohl((uint32_t) val);
+    p_state->n_native_enc = (buf[3] << 0) | (buf[2] << 8) | (buf[1] << 16) | (buf[0] << 24);
     p_state->n_skipped += n;
     return;
   }

--- a/src/internal/hash.c
+++ b/src/internal/hash.c
@@ -132,14 +132,18 @@ sexp* hash_impl(void* p_data) {
 
   XXH128_hash_t hash = XXH3_128bits_digest(p_xx_state);
 
-  // R assumes C99, so these are always defined as `uint64_t` in xxhash.h
-  XXH64_hash_t high = hash.high64;
-  XXH64_hash_t low = hash.low64;
+  // Make the hash independent of endianness.
+  // `XXH128_canonical_t` is a struct holding an array of 16 unsigned chars.
+  XXH128_canonical_t canonical;
+  XXH128_canonicalFromHash(&canonical, hash);
+  const unsigned char* p_digest = canonical.digest;
 
   // 32 for hash, 1 for terminating null added by `sprintf()`
   char out[32 + 1];
 
-  sprintf(out, "%016" PRIx64 "%016" PRIx64, high, low);
+  for (int i = 0; i < 16; ++i) {
+    sprintf(out + i * 2, "%02x", p_digest[i]);
+  }
 
   return r_chr(out);
 }

--- a/src/internal/hash.c
+++ b/src/internal/hash.c
@@ -110,6 +110,8 @@ sexp* hash_impl(void* p_data) {
   sexp* (*hook)(sexp*, sexp*) = NULL;
   sexp* hook_data = r_null;
 
+  // XDR format is slower than binary format, but results in a big-endian
+  // encoded data stream on any platform
   R_pstream_format_t format = R_pstream_xdr_format;
 
   struct R_outpstream_st stream;

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -1,5 +1,5 @@
 test_that("simple hashes with no ALTREP and no attributes are reproducible", {
-  expect_identical(hash(1), "a3f7d4a39b65b170005aafbbeed05106")
-  expect_identical(hash("a"), "4d52a7da68952b85f039e85a90f9bbd2")
-  expect_identical(hash(1:5 + 0L), "0d26bf75943b8e13c080c6bab12a7440")
+  expect_identical(hash(1), "e102171758b6df27bab06e4b99ad7d61")
+  expect_identical(hash("a"), "49a20bac2e944a3b87d0f5f70b8b5553")
+  expect_identical(hash(1:5 + 0L), "f24b071216a7d95ccbfcf28616107d64")
 })


### PR DESCRIPTION
Closes #1084 

@QuLogic do the tests pass without modification on big-endian systems now?

@easyaspi314 if you get a moment, could you please comment on whether this looks appropriate as a way to ensure that the resulting hash is independent of endianness? Thanks!