### PR TITLE
Use `memcpy()` to copy over the native encoding size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* Fixed a gcc11 warning related to `hash()` (#1088).
+
 * `XXH3_64bits()` from the XXHash library is now exposed as C callable
   under the name `rlang_xxh3_64bits()`.
 

--- a/src/internal/hash.c
+++ b/src/internal/hash.c
@@ -213,11 +213,8 @@ void hash_skip(struct hash_state_t* p_state, void* p_input, int n) {
   if (p_state->n_skipped == N_BYTES_SERIALIZATION_INFO) {
     // We've skipped all serialization info bytes.
     // Incoming bytes tell the size of the native encoding string.
-    int* p_x = (int*) p_input;
-    p_state->n_native_enc = *p_x;
-
+    memcpy(&p_state->n_native_enc, p_input, sizeof(int));
     p_state->n_skipped += n;
-
     return;
   }
 


### PR DESCRIPTION
Hopefully fixes this gcc11 warning:
https://www.stats.ox.ac.uk/pub/bdr/gcc11/rlang.out

I think the problem comes with casting the `void*` to a `int*` to extract out the `int` representing the native encoding size that we know is there. The `void*` is probably really a `unsigned char*` under the hood, and gcc11 is probably picking up that it looks like we are trying to extract an `int` from an `unsigned char*`?

The fix here copies what R does in `R_Unserialize()` to get at that native encoding size. They use a `memcpy()` in `InBytes()` to just copy over the bytes directly into an `int`.
https://github.com/wch/r-source/blob/d22ee2fc0dc8142b23eed9f46edf76ea9d3ca69a/src/main/serialize.c#L421
https://github.com/wch/r-source/blob/d22ee2fc0dc8142b23eed9f46edf76ea9d3ca69a/src/main/serialize.c#L2767