### PR TITLE
Make `hash_char()` error, since it should never be called

### DIFF
--- a/src/internal/hash.c
+++ b/src/internal/hash.c
@@ -193,11 +193,10 @@ void hash_bytes(R_outpstream_t stream, void* p_input, int n) {
 
 static inline
 void hash_char(R_outpstream_t stream, int input) {
-  // Despite the confusing signature, which is required by `R_Serialize()`,
-  // `input` is always a `char` so this conversion is safe
-  unsigned char byte = (unsigned char) input;
-  unsigned char* p_byte = &byte;
-  hash_bytes(stream, p_byte, 1);
+  // `R_Serialize()` only ever calls `stream->OutChar()` for ASCII and
+  // ASCIIHEX formats, neither of which we are using.
+  // https://github.com/wch/r-source/blob/161e21346c024b79db2654d3331298f96cdf6968/src/main/serialize.c#L376
+  r_stop_internal("hash_char", "Should never be called with binary format.");
 }
 
 #if USE_VERSION_3


### PR DESCRIPTION
Should fix this gcc warning that @lionel- is seeing:

```c
   In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/string.h:190,
                    from ./rlang/vec.h:4,
                    from ./rlang/rlang.h:38,
                    from internal/internal.c:1,
                    from internal.c:1:
   In function 'hash_skip',
       inlined from 'hash_bytes' at internal/hash.c:182:5,
       inlined from 'hash_char' at internal/hash.c:200:3:
   internal/hash.c:216:5: warning: '__builtin_memcpy' forming offset [1, 3] is out of the bounds [0, 1] of object 'byte' with type 'unsigned char' [-Warray-bounds]
     216 |     memcpy(&p_state->n_native_enc, p_input, sizeof(int));
         |     ^~~~~~
   In file included from internal/internal.c:16,
                    from internal.c:1:
   internal/hash.c: In function 'hash_char':
   internal/hash.c:198:17: note: 'byte' declared here
     198 |   unsigned char byte = (unsigned char) input;
         |                 ^~~~
```