### PR TITLE
Preserve objects in a namespace-bound dictionary

### DIFF
--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -151,23 +151,21 @@ detect_rlang_lib_usage <- function(src_path) {
 new_dict <- function(size, prevent_resize = FALSE) {
   .Call(rlang_new_dict, size, prevent_resize)
 }
-
 dict_size <- function(dict) {
   length(dict[[2]][[1]])
 }
-
 dict_resize <- function(dict, size) {
   .Call(rlang_dict_resize, dict, size)
 }
-
 dict_put <- function(dict, key, value) {
   .Call(rlang_dict_put, dict, key, value)
 }
-
+dict_del <- function(dict, key) {
+  .Call(rlang_dict_del, dict, key)
+}
 dict_has <- function(dict, key) {
   .Call(rlang_dict_has, dict, key)
 }
-
 dict_get <- function(dict, key) {
   .Call(rlang_dict_get, dict, key)
 }

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -25,8 +25,9 @@ base_pkg_env <- NULL
 
   on_package_load("glue", .Call(rlang_glue_is_there))
 
-  .Call(r_init_library)
-  .Call(rlang_library_load, ns_env("rlang"))
+  rlang_ns <- topenv(environment())
+  .Call(r_init_library, rlang_ns)
+  .Call(rlang_library_load, rlang_ns)
 
   run_on_load()
 

--- a/src/Makevars
+++ b/src/Makevars
@@ -18,6 +18,7 @@ lib-files = \
         rlang/parse.c \
         rlang/quo.c \
         rlang/rlang.c \
+        rlang/sexp.c \
         rlang/stack.c \
         rlang/sym.c \
         rlang/vec.c \

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -88,6 +88,11 @@ sexp* rlang_dict_put(sexp* dict, sexp* key, sexp* value) {
   return r_lgl(r_dict_put(p_dict, key, value));
 }
 
+sexp* rlang_dict_del(sexp* dict, sexp* key) {
+  struct r_dict* p_dict = dict_deref(dict);
+  return r_lgl(r_dict_del(p_dict, key));
+}
+
 sexp* rlang_dict_has(sexp* dict, sexp* key) {
   struct r_dict* p_dict = dict_deref(dict);
   return r_lgl(r_dict_has(p_dict, key));

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -163,6 +163,7 @@ extern sexp* rlang_test_lgl_sum(sexp*, sexp*);
 extern sexp* rlang_test_lgl_which(sexp*, sexp*);
 extern sexp* rlang_new_dict(sexp*, sexp*);
 extern sexp* rlang_dict_put(sexp*, sexp*, sexp*);
+extern sexp* rlang_dict_del(sexp*, sexp*);
 extern sexp* rlang_dict_has(sexp*, sexp*);
 extern sexp* rlang_dict_get(sexp*, sexp*);
 extern sexp* rlang_dict_resize(sexp*, sexp*);
@@ -324,6 +325,7 @@ static const R_CallMethodDef r_callables[] = {
   {"rlang_hash",                        (DL_FUNC) &rlang_hash, 1},
   {"rlang_new_dict",                    (DL_FUNC) &rlang_new_dict, 2},
   {"rlang_dict_put",                    (DL_FUNC) &rlang_dict_put, 3},
+  {"rlang_dict_del",                    (DL_FUNC) &rlang_dict_del, 2},
   {"rlang_dict_has",                    (DL_FUNC) &rlang_dict_has, 2},
   {"rlang_dict_get",                    (DL_FUNC) &rlang_dict_get, 2},
   {"rlang_dict_resize",                 (DL_FUNC) &rlang_dict_resize, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -169,7 +169,7 @@ extern sexp* rlang_dict_get(sexp*, sexp*);
 extern sexp* rlang_dict_resize(sexp*, sexp*);
 
 static const R_CallMethodDef r_callables[] = {
-  {"r_init_library",                    (DL_FUNC) &r_init_library, 0},
+  {"r_init_library",                    (DL_FUNC) &r_init_library, 1},
   {"rlang_library_load",                (DL_FUNC) &rlang_library_load, 1},
   {"rlang_library_unload",              (DL_FUNC) &rlang_library_unload, 0},
   {"r_f_lhs",                           (DL_FUNC) &r_f_lhs, 1},

--- a/src/rlang/decl/dict-decl.h
+++ b/src/rlang/decl/dict-decl.h
@@ -1,0 +1,8 @@
+static
+sexp* dict_find_node_info(struct r_dict* dict,
+                          sexp* key,
+                          r_ssize* hash,
+                          sexp** parent);
+
+static
+sexp* dict_find_node(struct r_dict* dict, sexp* key);

--- a/src/rlang/dict.c
+++ b/src/rlang/dict.c
@@ -109,6 +109,26 @@ bool r_dict_put(struct r_dict* dict, sexp* key, sexp* value) {
   return true;
 }
 
+// Returns `true` if key existed and was deleted. Returns `false` if
+// the key could not be deleted because it did not exist in the dict.
+bool r_dict_del(struct r_dict* dict, sexp* key) {
+  r_ssize hash;
+  sexp* parent;
+  sexp* node = dict_find_node_info(dict, key, &hash, &parent);
+
+  if (node == r_null) {
+    return false;
+  }
+
+  if (parent == r_null) {
+    r_list_poke(dict->buckets, hash, r_null);
+  }  else {
+    r_node_poke_cdr(parent, r_node_cdr(node));
+  }
+
+  return true;
+}
+
 bool r_dict_has(struct r_dict* dict, sexp* key) {
   return dict_find_node(dict, key) != r_null;
 }

--- a/src/rlang/dict.h
+++ b/src/rlang/dict.h
@@ -23,6 +23,7 @@ struct r_dict {
 
 struct r_dict r_new_dict(r_ssize size);
 bool r_dict_put(struct r_dict* dict, sexp* key, sexp* value);
+bool r_dict_del(struct r_dict* dict, sexp* key);
 bool r_dict_has(struct r_dict* dict, sexp* key);
 sexp* r_dict_get(struct r_dict* dict, sexp* key);
 

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -15,6 +15,7 @@
 #include "parse.c"
 #include "quo.c"
 #include "session.c"
+#include "sexp.c"
 #include "stack.c"
 #include "sym.c"
 #include "vec.c"
@@ -57,6 +58,7 @@ void r_init_library_cnd();
 void r_init_library_env();
 void r_init_library_fn();
 void r_init_library_session();
+void r_init_library_sexp(sexp*);
 void r_init_library_stack();
 void r_init_library_sym();
 void r_init_library_vec();
@@ -69,8 +71,17 @@ static sexp* shared_xyz_env;
 // This *must* be called before making any calls to the functions
 // provided in the library. Register this function in your init file
 // and `.Call()` it from your `.onLoad()` hook.
-SEXP r_init_library() {
-  r_init_library_sym();  // Needs to be first
+sexp* r_init_library(sexp* ns) {
+  if (!R_IsNamespaceEnv(ns)) {
+    Rf_errorcall(r_null,
+                 "Can't initialise rlang library.\n"
+                 "x `ns` must be a namespace environment.");
+  }
+
+  // Need to be first
+  r_init_library_vendor(); // Needed for xxh used in `r_preserve()`
+  r_init_library_sexp(ns);
+  r_init_library_sym();
 
   r_init_rlang_ns_env();
   r_init_library_call();
@@ -80,7 +91,6 @@ SEXP r_init_library() {
   r_init_library_session();
   r_init_library_stack();
   r_init_library_vec();
-  r_init_library_vendor();
 
   shared_x_env = r_parse_eval("new.env(hash = FALSE, parent = baseenv(), size = 1L)", r_base_env);
   r_preserve(shared_x_env);

--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -9,7 +9,7 @@
 #include "rlang-types.h"
 
 
-sexp* r_init_library();
+sexp* r_init_library(sexp* ns);
 
 r_ssize r_as_ssize(sexp* n);
 

--- a/src/rlang/sexp.c
+++ b/src/rlang/sexp.c
@@ -1,0 +1,24 @@
+#include "rlang.h"
+
+#define PRECIOUS_DICT_INIT_SIZE 256
+
+static
+struct r_dict precious_dict = { 0 };
+
+
+void r_preserve(sexp* x) {
+  r_dict_put(&precious_dict, x, r_null);
+}
+void r_unpreserve(sexp* x) {
+  if (!r_dict_del(&precious_dict, x)) {
+    r_abort("Can't unpreserve `x` because it was not being preserved.");
+  }
+}
+
+
+void r_init_library_sexp(sexp* ns) {
+  precious_dict = r_new_dict(PRECIOUS_DICT_INIT_SIZE);
+  KEEP(precious_dict.shelter);
+  r_env_poke(ns, r_sym(".__rlang_lib_precious_dict__."), precious_dict.shelter);
+  FREE(1);
+}

--- a/src/rlang/sexp.h
+++ b/src/rlang/sexp.h
@@ -14,8 +14,8 @@ enum r_type r_typeof(sexp* x) {
   return TYPEOF(x);
 }
 
-#define r_preserve R_PreserveObject
-#define r_unpreserve R_ReleaseObject
+void r_preserve(sexp* x);
+void r_unpreserve(sexp* x);
 
 static inline
 void r_mark_shared(sexp* x) {

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -529,3 +529,18 @@ test_that("dictionary grows", {
   dict_put(dict, quote(quux), 4)
   expect_equal(dict_size(dict), 8L)
 })
+
+test_that("can delete elements from dict", {
+  dict <- new_dict(3L)
+
+  dict_put(dict, quote(foo), 1)
+  dict_put(dict, quote(bar), 2)
+
+  expect_true(dict_del(dict, quote(bar)))
+  expect_false(dict_has(dict, quote(bar)))
+  expect_false(dict_del(dict, quote(bar)))
+
+  expect_true(dict_del(dict, quote(foo)))
+  expect_false(dict_has(dict, quote(foo)))
+  expect_false(dict_del(dict, quote(foo)))
+})


### PR DESCRIPTION
* `r_preserve()` now uses a dictionary to preserve objects. This should guarantee constant time insertion and deletion.

* The dictionary is protected from the embedding namespace. This way, unloading the namespace automatically unprotects all preserved objects.

* `r_init_library()` now takes a namespace as argument. This should be the embedding namespace not the rlang namespace. The namespace must be unsealed at the time of calling because a new binding is added to store the dictionary of precious objects.

* Add `dict_del()` method to remove objects from the dictionary. This is used in `r_unpreserve()`.