### PR TITLE
Use dictionary of stacks for preserving objects

### DIFF
--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -169,3 +169,16 @@ dict_has <- function(dict, key) {
 dict_get <- function(dict, key) {
   .Call(rlang_dict_get, dict, key)
 }
+
+
+# sexp.c
+
+rlang_precious_dict <- function() {
+  .Call(c_ptr_precious_dict)
+}
+rlang_preserve <- function(x) {
+  .Call(c_ptr_preserve, x)
+}
+rlang_unpreserve <- function(x) {
+  .Call(c_ptr_unpreserve, x)
+}

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -44,6 +44,17 @@ sexp* rlang_interrupt() {
 
 // dict.c
 
+static
+sexp* wrap_dict(struct r_dict* p_dict) {
+  sexp* out = KEEP(r_new_vector(r_type_list, 2));
+
+  r_list_poke(out, 0, r_copy_in_raw(p_dict, sizeof(*p_dict)));
+  r_list_poke(out, 1, p_dict->shelter);
+
+  FREE(1);
+  return out;
+}
+
 sexp* rlang_new_dict(sexp* size, sexp* prevent_resize) {
   if (!r_is_int(size)) {
     r_abort("`size` must be an integer.");
@@ -52,17 +63,14 @@ sexp* rlang_new_dict(sexp* size, sexp* prevent_resize) {
     r_abort("`prevent_resize` must be a logical value.");
   }
 
-  sexp* out = KEEP(r_new_vector(r_type_list, 2));
-
   struct r_dict dict = r_new_dict(r_int_get(size, 0));
   KEEP(dict.shelter);
 
   dict.prevent_resize = r_lgl_get(prevent_resize, 0);
 
-  r_list_poke(out, 0, r_copy_in_raw(&dict, sizeof(dict)));
-  r_list_poke(out, 1, dict.shelter);
+  sexp* out = wrap_dict(&dict);
 
-  FREE(2);
+  FREE(1);
   return out;
 }
 
@@ -518,6 +526,23 @@ sexp* rlang_chr_get(sexp* x, sexp* i) {
   }
 
   return r_chr_get(x, c_i);
+}
+
+// Returns a copy
+sexp* rlang_precious_dict() {
+  // From rlang/sexp.c
+  struct r_dict* rlang__precious_dict();
+
+  struct r_dict* p_dict = rlang__precious_dict();
+  return wrap_dict(p_dict);
+}
+sexp* rlang_preserve(sexp* x) {
+  r_preserve(x);
+  return r_null;
+}
+sexp* rlang_unpreserve(sexp* x) {
+  r_unpreserve(x);
+  return r_null;
 }
 
 

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -167,6 +167,9 @@ extern sexp* rlang_dict_del(sexp*, sexp*);
 extern sexp* rlang_dict_has(sexp*, sexp*);
 extern sexp* rlang_dict_get(sexp*, sexp*);
 extern sexp* rlang_dict_resize(sexp*, sexp*);
+extern sexp* rlang_precious_dict();
+extern sexp* rlang_preserve(sexp*);
+extern sexp* rlang_unpreserve(sexp*);
 
 static const R_CallMethodDef r_callables[] = {
   {"r_init_library",                    (DL_FUNC) &r_init_library, 1},
@@ -329,9 +332,11 @@ static const R_CallMethodDef r_callables[] = {
   {"rlang_dict_has",                    (DL_FUNC) &rlang_dict_has, 2},
   {"rlang_dict_get",                    (DL_FUNC) &rlang_dict_get, 2},
   {"rlang_dict_resize",                 (DL_FUNC) &rlang_dict_resize, 2},
+  {"c_ptr_precious_dict",               (DL_FUNC) &rlang_precious_dict, 0},
+  {"c_ptr_preserve",                    (DL_FUNC) &rlang_preserve, 1},
+  {"c_ptr_unpreserve",                  (DL_FUNC) &rlang_unpreserve, 1},
   {NULL, NULL, 0}
 };
-
 
 extern sexp* rlang_ext_arg_match0(sexp*);
 extern sexp* rlang_ext_capturearginfo(sexp*);

--- a/src/rlang/decl/sexp-decl.h
+++ b/src/rlang/decl/sexp-decl.h
@@ -1,0 +1,8 @@
+static
+sexp* new_precious_stack(sexp* x);
+
+static
+int push_precious(sexp* stack);
+
+static
+int pop_precious(sexp* stack);

--- a/src/rlang/dict.c
+++ b/src/rlang/dict.c
@@ -134,13 +134,25 @@ bool r_dict_has(struct r_dict* dict, sexp* key) {
 }
 
 sexp* r_dict_get(struct r_dict* dict, sexp* key) {
-  sexp* node = dict_find_node(dict, key);
+  sexp* out = r_dict_get0(dict, key);
 
-  if (node == r_null) {
+  if (!out) {
     r_abort("Can't find key in dictionary.");
   }
 
-  return r_node_car(node);
+  return out;
+}
+
+/* The 0-suffixed variant returns a C `NULL` if the object doesn't
+   exist. The regular variant throws an error in that case. */
+sexp* r_dict_get0(struct r_dict* dict, sexp* key) {
+  sexp* node = dict_find_node(dict, key);
+
+  if (node == r_null) {
+    return NULL;
+  } else {
+    return r_node_car(node);
+  }
 }
 
 static

--- a/src/rlang/dict.h
+++ b/src/rlang/dict.h
@@ -26,6 +26,7 @@ bool r_dict_put(struct r_dict* dict, sexp* key, sexp* value);
 bool r_dict_del(struct r_dict* dict, sexp* key);
 bool r_dict_has(struct r_dict* dict, sexp* key);
 sexp* r_dict_get(struct r_dict* dict, sexp* key);
+sexp* r_dict_get0(struct r_dict* dict, sexp* key);
 
 // Pass a negative size to resize by the default growth factor
 void r_dict_resize(struct r_dict* dict, r_ssize size);

--- a/src/rlang/sexp.c
+++ b/src/rlang/sexp.c
@@ -62,6 +62,11 @@ int pop_precious(sexp* stack) {
   return --(*p_n);
 }
 
+// For unit tests
+struct r_dict* rlang__precious_dict() {
+  return &precious_dict;
+}
+
 
 void r_init_library_sexp(sexp* ns) {
   precious_dict = r_new_dict(PRECIOUS_DICT_INIT_SIZE);

--- a/src/rlang/sexp.c
+++ b/src/rlang/sexp.c
@@ -5,14 +5,61 @@
 static
 struct r_dict precious_dict = { 0 };
 
+#include "decl/sexp-decl.h"
+
 
 void r_preserve(sexp* x) {
-  r_dict_put(&precious_dict, x, r_null);
+  sexp* stack = r_dict_get0(&precious_dict, x);
+  if (!stack) {
+    stack = KEEP(new_precious_stack(x));
+    r_dict_put(&precious_dict, x, stack);
+    FREE(1);
+  }
+
+  push_precious(stack);
 }
+
 void r_unpreserve(sexp* x) {
-  if (!r_dict_del(&precious_dict, x)) {
+  sexp* stack = r_dict_get0(&precious_dict, x);
+  if (!stack) {
     r_abort("Can't unpreserve `x` because it was not being preserved.");
   }
+
+  int n = pop_precious(stack);
+
+  if (n < 0) {
+    r_stop_internal("r_unpreserve", "`n` unexpectedly < 0.");
+  }
+  if (n == 0) {
+    r_dict_del(&precious_dict, x);
+  }
+}
+
+
+static
+sexp* new_precious_stack(sexp* x) {
+  sexp* stack = KEEP(r_new_list(2));
+
+  // Store (0) protection count and (1) element to protect
+  r_list_poke(stack, 0, r_int(0));
+  r_list_poke(stack, 1, x);
+
+  FREE(1);
+  return stack;
+}
+
+static
+int push_precious(sexp* stack) {
+  sexp* n = r_list_get(stack, 0);
+  int* p_n = r_int_deref(n);
+  return ++(*p_n);
+}
+
+static
+int pop_precious(sexp* stack) {
+  sexp* n = r_list_get(stack, 0);
+  int* p_n = r_int_deref(n);
+  return --(*p_n);
 }
 
 


### PR DESCRIPTION
Follow up to #1096. We need a stack of protection so that `r_preserve()` and `r_unpreserve()` may be called independently in unrelated contexts.

Also adds `r_dict_get0()` which is a variant of `r_dict_get()` that returns a C `NULL` instead of throwing an error when the key does not exist in the dictionary. This avoids an extra lookup in the case the key exists because we no longer need to call `r_dict_has()` before `r_dict_get()`.