### PR TITLE
Adjust `hash()` tests to skip on big endian platforms

### DIFF
--- a/R/hash.R
+++ b/R/hash.R
@@ -3,8 +3,8 @@
 #' @description
 #' `hash()` hashes an arbitrary R object.
 #'
-#' The generated hash is guaranteed to be reproducible across platforms, but
-#' not across R versions.
+#' The generated hash is guaranteed to be reproducible across platforms that
+#' have the same endianness and are using the same R version.
 #'
 #' @details
 #' `hash()` uses the XXH128 hash algorithm of the xxHash library, which

--- a/man/hash.Rd
+++ b/man/hash.Rd
@@ -12,8 +12,8 @@ hash(x)
 \description{
 \code{hash()} hashes an arbitrary R object.
 
-The generated hash is guaranteed to be reproducible across platforms, but
-not across R versions.
+The generated hash is guaranteed to be reproducible across platforms that
+have the same endianness and are using the same R version.
 }
 \details{
 \code{hash()} uses the XXH128 hash algorithm of the xxHash library, which

--- a/tests/testthat/helper-rlang.R
+++ b/tests/testthat/helper-rlang.R
@@ -44,6 +44,13 @@ skip_if_stale_backtrace <- local({
   }
 })
 
+skip_if_big_endian <- function() {
+  skip_if(
+    identical(.Platform$endian, "big"),
+    "Skipping on big-endian platform."
+  )
+}
+
 Rscript <- function(args, ...) {
   out <- suppressWarnings(system2(
     file.path(R.home("bin"), "Rscript"),

--- a/tests/testthat/test-hash.R
+++ b/tests/testthat/test-hash.R
@@ -1,4 +1,5 @@
 test_that("simple hashes with no ALTREP and no attributes are reproducible", {
+  skip_if_big_endian()
   expect_identical(hash(1), "a3f7d4a39b65b170005aafbbeed05106")
   expect_identical(hash("a"), "4d52a7da68952b85f039e85a90f9bbd2")
   expect_identical(hash(1:5 + 0L), "0d26bf75943b8e13c080c6bab12a7440")


### PR DESCRIPTION
Closes #1084 
Closes #1086 

Ultimately, we have decided that the work in #1086 to switch to using XDR format to generate hashes that are independent of endianness is not worth it, due to the large performance impact that comes from switching from binary -> XDR.

This PR skips the `hash()` tests on big-endian platforms, and updates the documentation to note that both the R version and endianness must be the same to generate identical hashes.