### PR TITLE
Support atomic and barrier vectors in dynamic arrays API

### DIFF
--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -189,6 +189,9 @@ print.rlang_dict <- function(x, ...) {
 new_dyn_array <- function(elt_size, capacity) {
   .Call(c_ptr_new_dyn_array, elt_size, capacity)
 }
+arr_unwrap <- function(arr) {
+  .Call(c_ptr_arr_unwrap, arr)
+}
 
 arr_info <- function(arr) {
   .Call(c_ptr_arr_info, arr)

--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -186,9 +186,6 @@ print.rlang_dict <- function(x, ...) {
 
 # dyn-array.c
 
-new_dyn_vector <- function(type, capacity) {
-  .Call(c_ptr_new_dyn_vector, type, capacity)
-}
 new_dyn_array <- function(elt_size, capacity) {
   .Call(c_ptr_new_dyn_array, elt_size, capacity)
 }

--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -186,14 +186,20 @@ print.rlang_dict <- function(x, ...) {
 
 # dyn-array.c
 
-new_dyn_array <- function(capacity, elt_size) {
-  .Call(c_ptr_new_dyn_array, capacity, elt_size)
+new_dyn_vector <- function(type, capacity) {
+  .Call(c_ptr_new_dyn_vector, type, capacity)
+}
+new_dyn_array <- function(elt_size, capacity) {
+  .Call(c_ptr_new_dyn_array, elt_size, capacity)
 }
 
 arr_info <- function(arr) {
   .Call(c_ptr_arr_info, arr)
 }
 
+arr_push_back <- function(arr, x) {
+  .Call(c_ptr_arr_push_back, arr, x)
+}
 arr_push_back_bool <- function(arr, x) {
   .Call(c_ptr_arr_push_back_bool, arr, x)
 }
@@ -212,6 +218,7 @@ print.rlang_dyn_array <- function(x, ...) {
   writeLines(paste0("count: ", info$count))
   writeLines(paste0("capacity: ", info$capacity))
   writeLines(paste0("growth_factor: ", info$growth_factor))
+  writeLines(paste0("type: ", info$type))
   writeLines(paste0("elt_byte_size: ", info$elt_byte_size))
 }
 

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -200,7 +200,7 @@ sexp* rlang_arr_info(sexp* arr_sexp) {
 sexp* rlang_arr_push_back(sexp* arr_sexp, sexp* x) {
   struct r_dyn_array* p_arr = rlang_arr_deref(arr_sexp);
 
-  if (r_vec_elt_sizeof(x) != p_arr->elt_byte_size) {
+  if (!p_arr->barrier_set && r_vec_elt_sizeof(x) != p_arr->elt_byte_size) {
     r_stop_internal("rlang_arr_push_back",
                     "Incompatible byte sizes %d/%d.",
                     r_vec_elt_sizeof(x),

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -201,7 +201,10 @@ sexp* rlang_arr_push_back(sexp* arr_sexp, sexp* x) {
   struct r_dyn_array* p_arr = rlang_arr_deref(arr_sexp);
 
   if (r_vec_elt_sizeof(x) != p_arr->elt_byte_size) {
-    r_stop_internal("rlang_arr_push_back", "Incompatible byte sizes.");
+    r_stop_internal("rlang_arr_push_back",
+                    "Incompatible byte sizes %d/%d.",
+                    r_vec_elt_sizeof(x),
+                    p_arr->elt_byte_size);
   }
 
   switch (p_arr->type) {

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -164,6 +164,11 @@ struct r_dyn_array* rlang_arr_deref(sexp* arr) {
 };
 
 // [[ register() ]]
+sexp* rlang_arr_unwrap(sexp* arr) {
+  return r_arr_unwrap(rlang_arr_deref(arr));
+}
+
+// [[ register() ]]
 sexp* rlang_arr_info(sexp* arr_sexp) {
   struct r_dyn_array* arr = rlang_arr_deref(arr_sexp);
 

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -139,17 +139,9 @@ sexp* rlang_dict_resize(sexp* dict, sexp* size) {
 // dyn-array.c
 
 // [[ register() ]]
-sexp* rlang_new_dyn_vector(sexp* type,
-                           sexp* capacity) {
-  struct r_dyn_array* arr = r_new_dyn_vector(r_chr_as_r_type(type),
-                                             r_as_ssize(capacity));
-  return arr->shelter;
-}
-
-// [[ register() ]]
-sexp* rlang_new_dyn_array(sexp* elt_byte_size,
+sexp* rlang_new_dyn_array(sexp* type,
                           sexp* capacity) {
-  struct r_dyn_array* arr = r_new_dyn_array(r_as_ssize(elt_byte_size),
+  struct r_dyn_array* arr = r_new_dyn_array(r_chr_as_r_type(type),
                                             r_as_ssize(capacity));
   return arr->shelter;
 }

--- a/src/export/exported.c
+++ b/src/export/exported.c
@@ -207,8 +207,15 @@ sexp* rlang_arr_push_back(sexp* arr_sexp, sexp* x) {
     r_stop_internal("rlang_arr_push_back", "Incompatible byte sizes.");
   }
 
-  r_arr_push_back(p_arr, r_vec_deref(x));
-  return r_null;
+  switch (p_arr->type) {
+  case r_type_character:
+  case r_type_list:
+    r_arr_push_back(p_arr, x);
+    return r_null;
+  default:
+    r_arr_push_back(p_arr, r_vec_deref(x));
+    return r_null;
+  }
 }
 // [[ register() ]]
 sexp* rlang_arr_push_back_bool(sexp* arr_sexp, sexp* x_sexp) {

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -347,6 +347,7 @@ static const R_CallMethodDef r_callables[] = {
   {"c_ptr_list_compact",                (DL_FUNC) &r_list_compact, 1},
   {"c_ptr_vec_resize",                  (DL_FUNC) &rlang_vec_resize, 2},
   {"c_ptr_new_dyn_array",               (DL_FUNC) &rlang_new_dyn_array, 2},
+  {"c_ptr_arr_unwrap",                  (DL_FUNC) &rlang_arr_unwrap, 1},
   {"c_ptr_arr_info",                    (DL_FUNC) &rlang_arr_info, 1},
   {"c_ptr_arr_push_back",               (DL_FUNC) &rlang_arr_push_back, 2},
   {"c_ptr_arr_push_back_bool",          (DL_FUNC) &rlang_arr_push_back_bool, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -172,8 +172,10 @@ extern sexp* rlang_preserve(sexp*);
 extern sexp* rlang_unpreserve(sexp*);
 extern sexp* rlang_alloc_data_frame(sexp*, sexp*, sexp*);
 extern sexp* rlang_vec_resize(sexp*, sexp*);
+extern sexp* rlang_new_dyn_vector(sexp*, sexp*);
 extern sexp* rlang_new_dyn_array(sexp*, sexp*);
 extern sexp* rlang_arr_info(sexp*);
+extern sexp* rlang_arr_push_back(sexp*, sexp*);
 extern sexp* rlang_arr_push_back_bool(sexp*, sexp*);
 extern sexp* rlang_arr_pop_back(sexp*);
 extern sexp* rlang_arr_resize(sexp*, sexp*);
@@ -345,8 +347,10 @@ static const R_CallMethodDef r_callables[] = {
   {"c_ptr_alloc_data_frame",            (DL_FUNC) &rlang_alloc_data_frame, 3},
   {"c_ptr_list_compact",                (DL_FUNC) &r_list_compact, 1},
   {"c_ptr_vec_resize",                  (DL_FUNC) &rlang_vec_resize, 2},
+  {"c_ptr_new_dyn_vector",              (DL_FUNC) &rlang_new_dyn_vector, 2},
   {"c_ptr_new_dyn_array",               (DL_FUNC) &rlang_new_dyn_array, 2},
   {"c_ptr_arr_info",                    (DL_FUNC) &rlang_arr_info, 1},
+  {"c_ptr_arr_push_back",               (DL_FUNC) &rlang_arr_push_back, 2},
   {"c_ptr_arr_push_back_bool",          (DL_FUNC) &rlang_arr_push_back_bool, 2},
   {"c_ptr_arr_pop_back",                (DL_FUNC) &rlang_arr_pop_back, 1},
   {"c_ptr_arr_resize",                  (DL_FUNC) &rlang_arr_resize, 2},

--- a/src/export/init.c
+++ b/src/export/init.c
@@ -172,7 +172,6 @@ extern sexp* rlang_preserve(sexp*);
 extern sexp* rlang_unpreserve(sexp*);
 extern sexp* rlang_alloc_data_frame(sexp*, sexp*, sexp*);
 extern sexp* rlang_vec_resize(sexp*, sexp*);
-extern sexp* rlang_new_dyn_vector(sexp*, sexp*);
 extern sexp* rlang_new_dyn_array(sexp*, sexp*);
 extern sexp* rlang_arr_info(sexp*);
 extern sexp* rlang_arr_push_back(sexp*, sexp*);
@@ -347,7 +346,6 @@ static const R_CallMethodDef r_callables[] = {
   {"c_ptr_alloc_data_frame",            (DL_FUNC) &rlang_alloc_data_frame, 3},
   {"c_ptr_list_compact",                (DL_FUNC) &r_list_compact, 1},
   {"c_ptr_vec_resize",                  (DL_FUNC) &rlang_vec_resize, 2},
-  {"c_ptr_new_dyn_vector",              (DL_FUNC) &rlang_new_dyn_vector, 2},
   {"c_ptr_new_dyn_array",               (DL_FUNC) &rlang_new_dyn_array, 2},
   {"c_ptr_arr_info",                    (DL_FUNC) &rlang_arr_info, 1},
   {"c_ptr_arr_push_back",               (DL_FUNC) &rlang_arr_push_back, 2},

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -16,17 +16,33 @@ struct r_dyn_array* r_new_dyn_vector(enum r_type type,
   sexp* vec_raw = r_new_raw(sizeof(struct r_dyn_array));
   r_list_poke(shelter, 0, vec_raw);
 
-  sexp* vec_sexp = r_new_vector(type, capacity);
-  r_list_poke(shelter, 1, vec_sexp);
+  sexp* vec_data = r_new_vector(type, capacity);
+  r_list_poke(shelter, 1, vec_data);
 
   struct r_dyn_array* p_vec = r_raw_deref(vec_raw);
   p_vec->shelter = shelter;
   p_vec->count = 0;
   p_vec->capacity = capacity;
   p_vec->growth_factor = R_DYN_ARRAY_GROWTH_FACTOR;
-  p_vec->v_data = r_vec_deref0(type, vec_sexp);
   p_vec->type = type;
   p_vec->elt_byte_size = r_vec_elt_sizeof0(type);
+  p_vec->data = vec_data;
+
+  switch (type) {
+  case r_type_character:
+    p_vec->v_data = NULL;
+    p_vec->barrier_set = &r_chr_poke;
+    break;
+  case r_type_list:
+    p_vec->v_data = NULL;
+    p_vec->barrier_set = &r_list_poke;
+    break;
+  default:
+    p_vec->barrier_set = NULL;
+    p_vec->v_data = r_vec_deref0(type, vec_data);
+    break;
+  }
+  p_vec->v_data_const = r_vec_deref_const0(type, vec_data);
 
   FREE(1);
   return p_vec;
@@ -47,6 +63,11 @@ void r_arr_push_back(struct r_dyn_array* p_arr, void* p_elt) {
     r_arr_resize(p_arr, new_capacity);
   }
 
+  if (p_arr->barrier_set) {
+    p_arr->barrier_set(p_arr->data, count - 1, (sexp*) p_elt);
+    return;
+  }
+
   if (p_elt) {
     memcpy(r_arr_ptr_back(p_arr), p_elt, p_arr->elt_byte_size);
   } else {
@@ -58,14 +79,24 @@ void r_arr_resize(struct r_dyn_array* p_arr,
                   r_ssize capacity) {
   enum r_type type = p_arr->type;
 
-  sexp* arr_raw = r_vec_resize0(type,
-                                r_list_get(p_arr->shelter, 1),
-                                p_arr->elt_byte_size * capacity);
-  r_list_poke(p_arr->shelter, 1, arr_raw);
+  sexp* data = r_vec_resize0(type,
+                             r_list_get(p_arr->shelter, 1),
+                             p_arr->elt_byte_size * capacity);
+  r_list_poke(p_arr->shelter, 1, data);
 
   p_arr->count = r_ssize_min(p_arr->count, capacity);
   p_arr->capacity = capacity;
-  p_arr->v_data = r_vec_deref0(type, arr_raw);
+  p_arr->data = data;
+
+  switch (type) {
+  case r_type_character:
+  case r_type_list:
+    break;
+  default:
+    p_arr->v_data = r_vec_deref0(type, data);
+    break;
+  }
+  p_arr->v_data_const = r_vec_deref_const0(type, data);
 }
 
 

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -7,8 +7,8 @@ static
 sexp* attribs_dyn_array = NULL;
 
 
-struct r_dyn_array* r_new_dyn_array(r_ssize capacity,
-                                    r_ssize elt_byte_size) {
+struct r_dyn_array* r_new_dyn_vector(enum r_type type,
+                                     r_ssize capacity) {
   sexp* shelter = KEEP(r_new_list(2));
   r_poke_attrib(shelter, attribs_dyn_array);
   r_mark_object(shelter);
@@ -16,20 +16,28 @@ struct r_dyn_array* r_new_dyn_array(r_ssize capacity,
   sexp* vec_raw = r_new_raw(sizeof(struct r_dyn_array));
   r_list_poke(shelter, 0, vec_raw);
 
-  sexp* arr_raw = r_new_raw(r_ssize_mult(capacity, elt_byte_size));
-  r_list_poke(shelter, 1, arr_raw);
+  sexp* vec_sexp = r_new_vector(type, capacity);
+  r_list_poke(shelter, 1, vec_sexp);
 
-  struct r_dyn_array* p_arr = r_raw_deref(vec_raw);
-  p_arr->shelter = shelter;
-  p_arr->count = 0;
-  p_arr->capacity = capacity;
-  p_arr->growth_factor = R_DYN_ARRAY_GROWTH_FACTOR;
-  p_arr->v_data = r_raw_deref(arr_raw);
-  p_arr->elt_byte_size = elt_byte_size;
+  struct r_dyn_array* p_vec = r_raw_deref(vec_raw);
+  p_vec->shelter = shelter;
+  p_vec->count = 0;
+  p_vec->capacity = capacity;
+  p_vec->growth_factor = R_DYN_ARRAY_GROWTH_FACTOR;
+  p_vec->v_data = r_vec_deref0(type, vec_sexp);
+  p_vec->type = type;
+  p_vec->elt_byte_size = r_vec_elt_sizeof0(type);
 
   FREE(1);
-  return p_arr;
+  return p_vec;
 }
+
+struct r_dyn_array* r_new_dyn_array(r_ssize elt_byte_size,
+                                    r_ssize capacity) {
+  r_ssize arr_byte_size = r_ssize_mult(capacity, elt_byte_size);
+  return r_new_dyn_vector(r_type_raw, arr_byte_size);
+}
+
 
 void r_arr_push_back(struct r_dyn_array* p_arr, void* p_elt) {
   r_ssize count = ++p_arr->count;
@@ -48,13 +56,16 @@ void r_arr_push_back(struct r_dyn_array* p_arr, void* p_elt) {
 
 void r_arr_resize(struct r_dyn_array* p_arr,
                   r_ssize capacity) {
-  sexp* arr_raw = r_raw_resize(r_list_get(p_arr->shelter, 1),
-                               p_arr->elt_byte_size * capacity);
+  enum r_type type = p_arr->type;
+
+  sexp* arr_raw = r_vec_resize0(type,
+                                r_list_get(p_arr->shelter, 1),
+                                p_arr->elt_byte_size * capacity);
   r_list_poke(p_arr->shelter, 1, arr_raw);
 
   p_arr->count = r_ssize_min(p_arr->count, capacity);
   p_arr->capacity = capacity;
-  p_arr->v_data = r_raw_deref(arr_raw);
+  p_arr->v_data = r_vec_deref0(type, arr_raw);
 }
 
 

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -7,8 +7,8 @@ static
 sexp* attribs_dyn_array = NULL;
 
 
-struct r_dyn_array* r_new_dyn_vector(enum r_type type,
-                                     r_ssize capacity) {
+struct r_dyn_array* r_new_dyn_array(enum r_type type,
+                                    r_ssize capacity) {
   sexp* shelter = KEEP(r_new_list(2));
   r_poke_attrib(shelter, attribs_dyn_array);
   r_mark_object(shelter);
@@ -47,13 +47,6 @@ struct r_dyn_array* r_new_dyn_vector(enum r_type type,
   FREE(1);
   return p_vec;
 }
-
-struct r_dyn_array* r_new_dyn_array(r_ssize elt_byte_size,
-                                    r_ssize capacity) {
-  r_ssize arr_byte_size = r_ssize_mult(capacity, elt_byte_size);
-  return r_new_dyn_vector(r_type_raw, arr_byte_size);
-}
-
 
 void r_arr_push_back(struct r_dyn_array* p_arr, void* p_elt) {
   r_ssize count = ++p_arr->count;

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -48,6 +48,14 @@ struct r_dyn_array* r_new_dyn_array(enum r_type type,
   return p_vec;
 }
 
+sexp* r_arr_unwrap(struct r_dyn_array* p_arr) {
+  if (p_arr->type == r_type_raw) {
+    return r_raw_resize(p_arr->data, p_arr->count * p_arr->elt_byte_size);
+  } else {
+    return r_vec_resize0(p_arr->type, p_arr->data, p_arr->count);
+  }
+}
+
 void r_arr_push_back(struct r_dyn_array* p_arr, void* p_elt) {
   r_ssize count = ++p_arr->count;
   if (count > p_arr->capacity) {

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -18,11 +18,8 @@ struct r_dyn_array {
   void (*barrier_set)(sexp* x, r_ssize i, sexp* value);
 };
 
-struct r_dyn_array* r_new_dyn_vector(enum r_type type,
-                                     r_ssize capacity);
-
-struct r_dyn_array* r_new_dyn_array(r_ssize capacity,
-                                    r_ssize elt_byte_size);
+struct r_dyn_array* r_new_dyn_array(enum r_type type,
+                                    r_ssize capacity);
 
 void r_arr_resize(struct r_dyn_array* p_arr,
                   r_ssize capacity);

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -31,6 +31,8 @@ void r_arr_pop_back(struct r_dyn_array* p_arr) {
   --p_arr->count;
 }
 
+sexp* r_arr_unwrap(struct r_dyn_array* p_arr);
+
 static inline
 void* r_arr_ptr(struct r_dyn_array* p_arr, r_ssize i) {
   if (p_arr->barrier_set) {

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -10,8 +10,12 @@ struct r_dyn_array {
   void* v_data;
 
   // private:
+  enum r_type type;
   r_ssize elt_byte_size;
 };
+
+struct r_dyn_array* r_new_dyn_vector(enum r_type type,
+                                     r_ssize capacity);
 
 struct r_dyn_array* r_new_dyn_array(r_ssize capacity,
                                     r_ssize elt_byte_size);
@@ -44,6 +48,23 @@ void* r_arr_ptr_end(struct r_dyn_array* p_arr) {
   return r_arr_ptr(p_arr, p_arr->count);
 }
 
+
+static inline
+void r_lgl_push_back(struct r_dyn_array* p_vec, int elt) {
+  r_arr_push_back(p_vec, &elt);
+}
+static inline
+void r_int_push_back(struct r_dyn_array* p_vec, int elt) {
+  r_arr_push_back(p_vec, &elt);
+}
+static inline
+void r_dbl_push_back(struct r_dyn_array* p_vec, double elt) {
+  r_arr_push_back(p_vec, &elt);
+}
+static inline
+void r_cpl_push_back(struct r_dyn_array* p_vec, r_complex_t elt) {
+  r_arr_push_back(p_vec, &elt);
+}
 
 
 #endif

--- a/src/rlang/sexp.c
+++ b/src/rlang/sexp.c
@@ -71,6 +71,14 @@ struct r_dict* rlang__precious_dict() {
 }
 
 
+enum r_type r_chr_as_r_type(sexp* type) {
+  if (!r_is_string(type)) {
+    r_abort("`type` must be a character string.");
+  }
+  return r_c_str_as_r_type(r_chr_get_c_string(type, 0));
+}
+
+
 void r_init_library_sexp(sexp* ns) {
   precious_dict = r_new_dict(PRECIOUS_DICT_INIT_SIZE);
   KEEP(precious_dict->shelter);

--- a/src/rlang/sexp.h
+++ b/src/rlang/sexp.h
@@ -82,6 +82,12 @@ const char* r_type_as_c_string(enum r_type type) {
 }
 
 static inline
+enum r_type r_c_str_as_r_type(const char* type) {
+  return Rf_str2type(type);
+}
+enum r_type r_chr_as_r_type(sexp* type);
+
+static inline
 bool r_is_symbolic(sexp* x) {
   return
     r_typeof(x) == LANGSXP ||

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -78,6 +78,58 @@ sexp* const * r_list_deref_const(sexp* x) {
 }
 
 static inline
+void* r_vec_deref0(enum r_type type, sexp* x) {
+  switch (type) {
+  case r_type_logical: return r_lgl_deref(x);
+  case r_type_integer: return r_int_deref(x);
+  case r_type_double: return r_dbl_deref(x);
+  case r_type_complex: return r_cpl_deref(x);
+  case r_type_raw: return r_raw_deref(x);
+  default: r_stop_unimplemented_type("r_vec_deref", type);
+  }
+}
+static inline
+void* r_vec_deref(sexp* x) {
+  return r_vec_deref0(r_typeof(x), x);
+}
+
+static inline
+const void* r_vec_deref_const0(enum r_type type, sexp* x) {
+  switch (type) {
+  case r_type_logical: return r_lgl_deref_const(x);
+  case r_type_integer: return r_int_deref_const(x);
+  case r_type_double: return r_dbl_deref_const(x);
+  case r_type_complex: return r_cpl_deref_const(x);
+  case r_type_raw: return r_raw_deref_const(x);
+  case r_type_character: return r_chr_deref_const(x);
+  case r_type_list: return r_list_deref_const(x);
+  default: r_stop_unimplemented_type("r_vec_deref_const", type);
+  }
+}
+static inline
+const void* r_vec_deref_const(sexp* x) {
+  return r_vec_deref_const0(r_typeof(x), x);
+}
+
+static inline
+int r_vec_elt_sizeof0(enum r_type type) {
+  switch (type) {
+  case r_type_logical: return sizeof(int);
+  case r_type_integer: return sizeof(int);
+  case r_type_double: return sizeof(double);
+  case r_type_complex: return sizeof(r_complex_t);
+  case r_type_raw: return sizeof(char);
+  case r_type_character: return sizeof(sexp*);
+  case r_type_list: return sizeof(sexp*);
+  default: r_stop_unimplemented_type("r_vec_elt_sizeof", type);
+  }
+}
+static inline
+int r_vec_elt_sizeof(sexp* x) {
+  return r_vec_elt_sizeof0(r_typeof(x));
+}
+
+static inline
 int r_lgl_get(sexp* x, r_ssize i) {
   return LOGICAL(x)[i];
 }
@@ -283,6 +335,24 @@ sexp* r_cpl_resize(sexp* x, r_ssize size);
 sexp* r_raw_resize(sexp* x, r_ssize size);
 sexp* r_chr_resize(sexp* x, r_ssize size);
 sexp* r_list_resize(sexp* x, r_ssize size);
+
+static inline
+sexp* r_vec_resize0(enum r_type type, sexp* x, r_ssize size) {
+  switch (type) {
+  case r_type_logical: return r_lgl_resize(x, size);
+  case r_type_integer: return r_int_resize(x, size);
+  case r_type_double: return r_dbl_resize(x, size);
+  case r_type_complex: return r_cpl_resize(x, size);
+  case r_type_raw: return r_raw_resize(x, size);
+  case r_type_character: return r_chr_resize(x, size);
+  case r_type_list: return r_list_resize(x, size);
+  default: r_stop_unimplemented_type("r_vec_resize", type);
+  }
+}
+static inline
+sexp* r_vec_resize(sexp* x, r_ssize size) {
+  return r_vec_resize0(r_typeof(x), x, size);
+}
 
 static inline
 sexp* r_copy_in_raw(const void* src, size_t size) {

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -636,7 +636,7 @@ test_that("can shrink vectors", {
 })
 
 test_that("can grow and shrink dynamic arrays", {
-  arr <- new_dyn_array(3, 1)
+  arr <- new_dyn_array(1, 3)
 
   expect_equal(
     arr_info(arr),
@@ -644,6 +644,7 @@ test_that("can grow and shrink dynamic arrays", {
       count = 0,
       capacity = 3,
       growth_factor = 2,
+      type = "raw",
       elt_byte_size = 1
     )
   )
@@ -657,6 +658,7 @@ test_that("can grow and shrink dynamic arrays", {
       count = 3,
       capacity = 3,
       growth_factor = 2,
+      type = "raw",
       elt_byte_size = 1
     )
   )
@@ -695,7 +697,7 @@ test_that("can grow and shrink dynamic arrays", {
 })
 
 test_that("can resize dynamic arrays", {
-  arr <- new_dyn_array(4, 1)
+  arr <- new_dyn_array(1, 4)
   arr_push_back_bool(arr, TRUE)
   arr_push_back_bool(arr, FALSE)
   arr_push_back_bool(arr, TRUE)
@@ -707,6 +709,7 @@ test_that("can resize dynamic arrays", {
       count = 2,
       capacity = 2,
       growth_factor = 2,
+      type = "raw",
       elt_byte_size = 1
     )
   )
@@ -721,4 +724,43 @@ test_that("can resize dynamic arrays", {
     )
   )
   expect_equal(arr[[2]][1:2], bytes(1, 0))
+})
+
+test_that("can shrink and grow dynamic atomic vectors", {
+  arr <- new_dyn_vector("double", 3)
+  expect_equal(
+    arr_info(arr),
+    list(
+      count = 0,
+      capacity = 3,
+      growth_factor = 2,
+      type = "double",
+      elt_byte_size = 8
+    )
+  )
+
+  arr_push_back(arr, 1)
+  arr_push_back(arr, 2)
+  arr_push_back(arr, 3)
+  expect_equal(
+    arr_info(arr)[1:2],
+    list(
+      count = 3,
+      capacity = 3
+    )
+  )
+  expect_identical(arr[[2]], dbl(1:3))
+
+  arr_push_back(arr, 4)
+  expect_equal(
+    arr_info(arr),
+    list(
+      count = 4,
+      capacity = 6,
+      growth_factor = 2,
+      type = "double",
+      elt_byte_size = 8
+    )
+  )
+  expect_identical(arr[[2]][1:4], dbl(1:4))
 })

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -724,6 +724,7 @@ test_that("can resize dynamic arrays", {
     )
   )
   expect_equal(arr[[2]][1:2], bytes(1, 0))
+  expect_equal(arr_unwrap(arr), bytes(1, 0))
 })
 
 test_that("can shrink and grow dynamic atomic vectors", {
@@ -763,6 +764,7 @@ test_that("can shrink and grow dynamic atomic vectors", {
     )
   )
   expect_identical(arr[[2]][1:4], dbl(1:4))
+  expect_identical(arr_unwrap(arr), dbl(1:4))
 })
 
 test_that("can shrink and grow dynamic barrier vectors", {
@@ -800,4 +802,5 @@ test_that("can shrink and grow dynamic barrier vectors", {
     )
   )
   expect_identical(arr[[2]][1:4], as.list(dbl(1:4)))
+  expect_identical(arr_unwrap(arr), as.list(dbl(1:4)))
 })

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -764,3 +764,40 @@ test_that("can shrink and grow dynamic atomic vectors", {
   )
   expect_identical(arr[[2]][1:4], dbl(1:4))
 })
+
+test_that("can shrink and grow dynamic barrier vectors", {
+  arr <- new_dyn_vector("list", 3)
+  expect_equal(
+    arr_info(arr)[1:4],
+    list(
+      count = 0,
+      capacity = 3,
+      growth_factor = 2,
+      type = "list"
+    )
+  )
+
+  arr_push_back(arr, 1)
+  arr_push_back(arr, 2)
+  arr_push_back(arr, 3)
+  expect_equal(
+    arr_info(arr)[1:2],
+    list(
+      count = 3,
+      capacity = 3
+    )
+  )
+  expect_identical(arr[[2]], as.list(dbl(1:3)))
+
+  arr_push_back(arr, 4)
+  expect_equal(
+    arr_info(arr)[1:4],
+    list(
+      count = 4,
+      capacity = 6,
+      growth_factor = 2,
+      type = "list"
+    )
+  )
+  expect_identical(arr[[2]][1:4], as.list(dbl(1:4)))
+})

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -636,7 +636,7 @@ test_that("can shrink vectors", {
 })
 
 test_that("can grow and shrink dynamic arrays", {
-  arr <- new_dyn_array(1, 3)
+  arr <- new_dyn_array("raw", 3 * 1)
 
   expect_equal(
     arr_info(arr),
@@ -697,7 +697,7 @@ test_that("can grow and shrink dynamic arrays", {
 })
 
 test_that("can resize dynamic arrays", {
-  arr <- new_dyn_array(1, 4)
+  arr <- new_dyn_array("raw", 4 * 1)
   arr_push_back_bool(arr, TRUE)
   arr_push_back_bool(arr, FALSE)
   arr_push_back_bool(arr, TRUE)
@@ -727,7 +727,7 @@ test_that("can resize dynamic arrays", {
 })
 
 test_that("can shrink and grow dynamic atomic vectors", {
-  arr <- new_dyn_vector("double", 3)
+  arr <- new_dyn_array("double", 3)
   expect_equal(
     arr_info(arr),
     list(
@@ -766,7 +766,7 @@ test_that("can shrink and grow dynamic atomic vectors", {
 })
 
 test_that("can shrink and grow dynamic barrier vectors", {
-  arr <- new_dyn_vector("list", 3)
+  arr <- new_dyn_array("list", 3)
   expect_equal(
     arr_info(arr)[1:4],
     list(


### PR DESCRIPTION
Turns out it was easy to adapt the dynamic arrays implemented in #1107 to support all sorts of vectors.