### PR TITLE
Add tick as a bullet type in format_error_bullets()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `format_error_bullets()` now adds green tick bullets for elements
+  named `"v"` (@rossellhayes).
+
 * `.data` now fails early when it is subsetted outside of a data mask
   context. This provides a more informative error message (#804, #1133).
 

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -112,6 +112,7 @@ cnd_footer.default <- function(cnd, ...) {
 #'
 #' - Elements named `"i"` are bulleted with a blue "info" symbol.
 #' - Elements named `"x"` are bulleted with a red "cross" symbol.
+#' - Elements named `"v"` are bulleted with a green "tick" symbol.
 #' - Unnamed elements are bulleted with a "*" symbol.
 #'
 #' This experimental infrastructure is based on the idea that
@@ -124,7 +125,7 @@ cnd_footer.default <- function(cnd, ...) {
 #' [cnd_header()].
 #'
 #' @param x A named character vector of messages. Elements named as
-#'   `x` or `i` are prefixed with the corresponding bullet.
+#'   `x`, `i` or `v` are prefixed with the corresponding bullet.
 #' @export
 format_error_bullets <- function(x) {
   if (!length(x)) {
@@ -132,9 +133,18 @@ format_error_bullets <- function(x) {
   }
 
   nms <- names2(x)
-  stopifnot(nms %in% c("i", "x", ""))
+  stopifnot(nms %in% c("i", "x", "v", ""))
 
-  bullets <- ifelse(nms == "i", info(), ifelse(nms == "x", cross(), "*"))
+  bullets <- ifelse(
+    nms == "i", info(),
+    ifelse(
+      nms == "x", cross(),
+      ifelse(
+        nms == "v", tick(),
+        "*"
+      )
+    )
+  )
   bullets <- paste(bullets, x, collapse = "\n")
   bullets
 }

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -110,10 +110,10 @@ cnd_footer.default <- function(cnd, ...) {
 #' the input vector are assembled as a list of bullets, depending on
 #' their names:
 #'
+#' - Unnamed elements are bulleted with a "*" symbol.
 #' - Elements named `"i"` are bulleted with a blue "info" symbol.
 #' - Elements named `"x"` are bulleted with a red "cross" symbol.
 #' - Elements named `"v"` are bulleted with a green "tick" symbol.
-#' - Unnamed elements are bulleted with a "*" symbol.
 #'
 #' This experimental infrastructure is based on the idea that
 #' sentences in error messages are best kept short and simple. From
@@ -135,18 +135,12 @@ format_error_bullets <- function(x) {
   nms <- names2(x)
   stopifnot(nms %in% c("i", "x", "v", ""))
 
-  bullets <- ifelse(
-    nms == "i", info(),
-    ifelse(
-      nms == "x", cross(),
-      ifelse(
-        nms == "v", tick(),
-        "*"
-      )
-    )
-  )
-  bullets <- paste(bullets, x, collapse = "\n")
-  bullets
+  bullets <-
+    ifelse(nms == "i", info(),
+    ifelse(nms == "x", cross(),
+    ifelse(nms == "v", tick(), "*")))
+
+  paste(bullets, x, sep = " ", collapse = "\n")
 }
 
 collapse_cnd_message <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -226,6 +226,10 @@ cross <- function() {
   x <- if (is_installed("cli")) cli::symbol$cross else "x"
   red(x)
 }
+tick <- function() {
+  x <- if (is_installed("cli")) cli::symbol$tick else "v"
+  green(x)
+}
 
 strip_trailing_newline <- function(x) {
   n <- nchar(x)

--- a/man/format_error_bullets.Rd
+++ b/man/format_error_bullets.Rd
@@ -16,10 +16,10 @@ string (or an empty vector if the input is empty). The elements of
 the input vector are assembled as a list of bullets, depending on
 their names:
 \itemize{
+\item Unnamed elements are bulleted with a "*" symbol.
 \item Elements named \code{"i"} are bulleted with a blue "info" symbol.
 \item Elements named \code{"x"} are bulleted with a red "cross" symbol.
 \item Elements named \code{"v"} are bulleted with a green "tick" symbol.
-\item Unnamed elements are bulleted with a "*" symbol.
 }
 
 This experimental infrastructure is based on the idea that

--- a/man/format_error_bullets.Rd
+++ b/man/format_error_bullets.Rd
@@ -8,7 +8,7 @@ format_error_bullets(x)
 }
 \arguments{
 \item{x}{A named character vector of messages. Elements named as
-\code{x} or \code{i} are prefixed with the corresponding bullet.}
+\code{x}, \code{i} or \code{v} are prefixed with the corresponding bullet.}
 }
 \description{
 \code{format_error_bullets()} takes a character vector and returns a single
@@ -18,6 +18,7 @@ their names:
 \itemize{
 \item Elements named \code{"i"} are bulleted with a blue "info" symbol.
 \item Elements named \code{"x"} are bulleted with a red "cross" symbol.
+\item Elements named \code{"v"} are bulleted with a green "tick" symbol.
 \item Unnamed elements are bulleted with a "*" symbol.
 }
 

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -4,7 +4,7 @@ test_that("format_error_bullets() formats bullets depending on names", {
     cli.unicode = FALSE
   )
   expect_identical(format_error_bullets(c("foo", "bar")), "* foo\n* bar")
-  expect_identical(format_error_bullets(c(i = "foo", "baz", x = "bar")), "i foo\n* baz\nx bar")
+  expect_identical(format_error_bullets(c(i = "foo", "baz", x = "bar", v = "bam")), "i foo\n* baz\nx bar\nv bam")
   expect_error(format_error_bullets(c(i = "foo", u = "bar")))
   expect_identical(format_error_bullets(chr()), chr())
 })


### PR DESCRIPTION
Packages generally prefix messages with one of four bullets: a star, an info "i", a cross, and a tick.
For example, `usethis` offers `ui_todo()`, `ui_info()`, `ui_oops()` and `ui_done()`.
Currently, `format_error_bullets()` only offers a star, info symbol and cross.

This PR adds a green tick bullet when the element name is `"v"`, matching current usage where a cross is used for elements named `"x"` and an info symbol for elements named `"i"`.