### PR TITLE
Defuse numbered dots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `enquo()`, `enquos()` and variants now support numbered dots like
+  `..1` (#1137).
+
 * `sexp_address()` is now exported.
 
 * `%<~%` now actually works.

--- a/src/capture.c
+++ b/src/capture.c
@@ -1,6 +1,6 @@
 #include <Rinternals.h>
 #include <stdlib.h>
-#include <rlang.h>
+#include <string.h>
 
 #define attribute_hidden
 #define _(string) (string)

--- a/src/capture.c
+++ b/src/capture.c
@@ -1,7 +1,12 @@
 #include <Rinternals.h>
+#include <stdlib.h>
+#include <rlang.h>
 
 #define attribute_hidden
 #define _(string) (string)
+
+static Rboolean dotDotVal(SEXP);
+static SEXP capturedot(SEXP, int);
 
 
 SEXP attribute_hidden new_captured_arg(SEXP x, SEXP env) {
@@ -33,6 +38,12 @@ SEXP attribute_hidden new_captured_promise(SEXP x, SEXP env) {
     while (TYPEOF(expr) == PROMSXP) {
         expr_env = PRENV(expr);
         expr = PREXPR(expr);
+
+	if (TYPEOF(expr) == SYMSXP) {
+	    int dd = dotDotVal(expr);
+	    if (dd)
+		expr = capturedot(expr_env, dd);
+	}
     }
 
     // Evaluated arguments are returned as literals
@@ -71,13 +82,17 @@ SEXP attribute_hidden rlang_capturearginfo(SEXP call, SEXP op, SEXP args, SEXP r
     }
 
     SEXP frame = CAR(args);
-    SEXP arg = findVar(sym, frame);
-    PROTECT(arg); ++nProt;
+    SEXP arg;
 
-    if (arg == R_UnboundValue) {
-        UNPROTECT(nProt);
-        error(_("object '%s' not found"), CHAR(PRINTNAME(sym)));
+    int dd = dotDotVal(sym);
+    if (dd) {
+	arg = capturedot(frame, dd);
+    } else {
+	arg = findVar(sym, frame);
+	if (arg == R_UnboundValue)
+	    error(_("object '%s' not found"), CHAR(PRINTNAME(sym)));
     }
+    PROTECT(arg); ++nProt;
 
     SEXP value;
     if (arg == R_MissingArg)
@@ -94,9 +109,9 @@ SEXP attribute_hidden rlang_capturearginfo(SEXP call, SEXP op, SEXP args, SEXP r
 SEXP capturedots(SEXP frame) {
     SEXP dots = PROTECT(findVar(R_DotsSymbol, frame));
 
-    if (dots == R_UnboundValue) {
-        error(_("Must capture dots in a function where dots exist"));
-    }
+    if (dots == R_UnboundValue)
+	error(_("'...' used in an incorrect context"));
+
     if (dots == R_MissingArg) {
         UNPROTECT(1);
         return R_NilValue;
@@ -130,6 +145,52 @@ SEXP attribute_hidden rlang_capturedots(SEXP call, SEXP op, SEXP args, SEXP rho)
     SEXP caller_env = CAR(args);
     return capturedots(caller_env);
 }
+
+
+static Rboolean dotDotVal(SEXP sym)
+{
+    const char* str = CHAR(PRINTNAME(sym));
+
+    if (strlen(str) < 3)
+	return 0;
+    if (*str++ != '.')
+	return 0;
+    if (*str++ != '.')
+	return 0;
+
+    char* p_end;
+    int val = (int) strtol(str, &p_end, 10);
+
+    if (*p_end == '\0')
+	return val;
+    else
+	return 0;
+}
+
+static SEXP capturedot(SEXP frame, int i) {
+    if (i < 1)
+	error("'i' must be a positive non-zero integer");
+
+    SEXP dots = PROTECT(findVar(R_DotsSymbol, frame));
+    if (dots == R_UnboundValue)
+	error(_("'...' used in an incorrect context"));
+
+    if (dots == R_MissingArg)
+	goto fewer;
+
+    for (int j = 1; j != i; ++j)
+	dots = CDR(dots);
+
+    if (dots == R_NilValue)
+	goto fewer;
+
+    UNPROTECT(1);
+    return CAR(dots);
+
+ fewer:
+    error(_("the ... list contains fewer than %d elements"), i);
+}
+
 
 // Local Variables:
 // tab-width: 8

--- a/tests/testthat/test-nse-defuse.R
+++ b/tests/testthat/test-nse-defuse.R
@@ -539,3 +539,52 @@ test_that("enquo0() and enquos0() don't rewrap quosures", {
   quo <- local(quo(x))
   expect_equal(fn(!!quo), list(quo))
 })
+
+test_that("enquo() defuses numbered dots (#1137)", {
+  f <- function(arg) enquo(..1)
+  expect_error(
+    f(foo),
+    "'...' used in an incorrect context"
+  )
+
+  f <- function(...) enquo(..1)
+  expect_error(
+    f(),
+    "fewer than 1"
+  )
+
+  f <- function(...) enquo(..2)
+  expect_error(
+    f(1),
+    "fewer than 2"
+  )
+})
+
+test_that("enquos() defuses numbered dots (#1137)", {
+  f <- function(...) enquos(...)
+  g <- function(...) f(..1)
+  expect_equal(
+    g(foo),
+    quos(foo)
+  )
+
+  f <- function(...) enquos(...)
+  g <- function(...) f(..1, ..2)
+  h <- function(...) g(..1, ...)
+  expect_equal(
+    h(foo, bar),
+    quos(foo, foo)
+  )
+
+  g <- function(...) f(..1, ..3)
+  expect_equal(
+    h(foo, bar),
+    quos(foo, bar)
+  )
+
+  g <- function(...) f(..1, ..4)
+  expect_error(
+    h(foo, bar),
+    "fewer than 4 elements"
+  )
+})


### PR DESCRIPTION
Closes #1137
Step towards tidyverse/dplyr#5815

`enquo(..1)` and `enquos(...)` with numbered dots supplied within `...` now properly capture the underlying expressions and environments. This allows new metaprogramming patterns based on `match.call()`. For an example see https://github.com/tidyverse/dplyr/pull/5815/commits/d4fd1e0f.