### PR TITLE
Define `_ISOC99_SOURCE` to avoid warnings on CRAN's UCRT machine

### DIFF
--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -1,6 +1,23 @@
 #ifndef RLANG_RLANG_H
 #define RLANG_RLANG_H
 
+/*
+ * `_ISOC99_SOURCE` is defined to avoid warnings on Windows UCRT builds where
+ * usage of `PRIx64` in Microsoft's `printf()` can generate the warnings shown
+ * below. Defining this before including `<stdio.h>` forces usage of MinGW's
+ * custom `printf()`, which is C99 compliant.
+ * warning: unknown conversion type character 'l' in format [-Wformat]
+ * warning: too many arguments for format [-Wformat-extra-args]
+ *
+ * The conventional define for this is `__USE_MINGW_ANSI_STDIO`, but according
+ * to the thread below it is recommended to instead use a feature test macro
+ * (such as `_ISOC99_SOURCE`) which will indirectly define the internal
+ * `__USE_MINGW_ANSI_STDIO` macro for us.
+ * https://osdn.net/projects/mingw/lists/archive/users/2019-January/000199.html
+ */
+#define _ISOC99_SOURCE
+#include <stdio.h>
+
 #define R_NO_REMAP
 #include <Rinternals.h>
 #include <Rversion.h>


### PR DESCRIPTION
Specifically, to avoid:

```c
In file included from internal.c:12:
internal/hash.c: In function 'hash_impl':
internal/hash.c:142:16: warning: unknown conversion type character 'l' in format [-Wformat=]
  142 |   sprintf(out, "%016" PRIx64 "%016" PRIx64, high, low);
      |                ^~~~~~
In file included from ./lib/rlang.h:5,
                 from internal/arg.c:1,
                 from internal.c:1:
c:\msys64\home\tomas\ucrt3\svn\ucrt3\r_packages\x86_64-w64-mingw32.static.posix\include\inttypes.h:37:18: note: format string is defined here
   37 | #define PRIx64 "llx"
      |                  ^
In file included from internal.c:12:
internal/hash.c:142:16: warning: unknown conversion type character 'l' in format [-Wformat=]
  142 |   sprintf(out, "%016" PRIx64 "%016" PRIx64, high, low);
      |                ^~~~~~
In file included from ./lib/rlang.h:5,
                 from internal/arg.c:1,
                 from internal.c:1:
c:\msys64\home\tomas\ucrt3\svn\ucrt3\r_packages\x86_64-w64-mingw32.static.posix\include\inttypes.h:37:18: note: format string is defined here
   37 | #define PRIx64 "llx"
      |                  ^
In file included from internal.c:12:
internal/hash.c:142:16: warning: too many arguments for format [-Wformat-extra-args]
  142 |   sprintf(out, "%016" PRIx64 "%016" PRIx64, high, low);
      |                ^~~~~~
In file included from ./lib/rlang.h:83,
                 from internal/arg.c:1,
                 from internal.c:1:
```