### PR TITLE
compat-purrr.R tweaks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rlang (development version)
 
 * `compat-purrr.R` now longer includes `pluck*` helpers; these used a defintion
-  of pluck that predated purrr (#1159).
+  of pluck that predated purrr (#1159). `*_cpl()` has also been removed.
 
 * New `call_match()` function. It is like `match.call()` but also
   supports matching missing arguments to their defaults in the function

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `compat-purrr.R` now longer includes `pluck*` helpers; these used a defintion
+  of pluck that predated purrr (#1159).
+
 * New `call_match()` function. It is like `match.call()` but also
   supports matching missing arguments to their defaults in the function
   definition (#875).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * `compat-purrr.R` now longer includes `pluck*` helpers; these used a defintion
   of pluck that predated purrr (#1159). `*_cpl()` has also been removed.
+  The `map*` wrappers now call `as_function()` so that you can pass short
+  anonymous functions that use `~` (#1157).
 
 * New `call_match()` function. It is like `match.call()` but also
   supports matching missing arguments to their defaults in the function

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -1,10 +1,16 @@
-# nocov start - compat-purrr (last updated: rlang 0.3.2.9000)
+# nocov start - compat-purrr.R
+# Latest version: https://github.com/r-lib/rlang/blob/master/R/compat-purrr.R
 
-# This file serves as a reference for compatibility functions for
-# purrr. They are not drop-in replacements but allow a similar style
-# of programming. This is useful in cases where purrr is too heavy a
-# package to depend on. Please find the most recent version in rlang's
-# repository.
+# This file provides a minimal shim to provide a purrr-like API on top of
+# base R functions. They are not drop-in replacements but allow a similar style
+# of programming.
+#
+# Changelog:
+# 2020-04-14:
+# * removed pluck*() functions
+# * removed *_cpl() functions
+# * used as_function() to allow use of ~
+# * used . prefix for helpers
 
 map <- function(.x, .f, ...) {
   .f <- as_function(.f)

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -61,6 +61,9 @@ map2_dbl <- function(.x, .y, .f, ...) {
 map2_chr <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "character")
 }
+imap <- function(.x, .f, ...) {
+  map2(.x, names(x) %||% seq_along(x), .f, ...)
+}
 
 pmap <- function(.l, .f, ...) {
   .f <- as.function(.f)
@@ -188,13 +191,5 @@ detect_index <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
   }
   idx
 }
-
-imap <- function(.x, .f, ...) {
-  map2(.x, .vec_index(.x), .f, ...)
-}
-.vec_index <- function(x) {
-  names(x) %||% seq_along(x)
-}
-
 
 # nocov end

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -21,12 +21,6 @@ walk <- function(.x, .f, ...) {
   invisible(.x)
 }
 
-.map_mold <- function(.x, .f, .mold, ...) {
-  .f <- as_function(.f)
-  out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
-  names(out) <- names(.x)
-  out
-}
 map_lgl <- function(.x, .f, ...) {
   .map_mold(.x, .f, logical(1), ...)
 }
@@ -38,6 +32,12 @@ map_dbl <- function(.x, .f, ...) {
 }
 map_chr <- function(.x, .f, ...) {
   .map_mold(.x, .f, character(1), ...)
+}
+.map_mold <- function(.x, .f, .mold, ...) {
+  .f <- as_function(.f)
+  out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
+  names(out) <- names(.x)
+  out
 }
 
 map2 <- function(.x, .y, .f, ...) {
@@ -62,16 +62,6 @@ map2_chr <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "character")
 }
 
-.args_recycle <- function(args) {
-  lengths <- map_int(args, length)
-  n <- max(lengths)
-
-  stopifnot(all(lengths == 1L | lengths == n))
-  to_recycle <- lengths == 1L
-  args[to_recycle] <- map(args[to_recycle], function(x) rep.int(x, n))
-
-  args
-}
 pmap <- function(.l, .f, ...) {
   .f <- as.function(.f)
   args <- .args_recycle(.l)
@@ -81,15 +71,15 @@ pmap <- function(.l, .f, ...) {
     SIMPLIFY = FALSE, USE.NAMES = FALSE
   ))
 }
+.args_recycle <- function(args) {
+  lengths <- map_int(args, length)
+  n <- max(lengths)
 
-.probe <- function(.x, .p, ...) {
-  if (is_logical(.p)) {
-    stopifnot(length(.p) == length(.x))
-    .p
-  } else {
-    .p <- as_function(.p)
-    map_lgl(.x, .p, ...)
-  }
+  stopifnot(all(lengths == 1L | lengths == n))
+  to_recycle <- lengths == 1L
+  args[to_recycle] <- map(args[to_recycle], function(x) rep.int(x, n))
+
+  args
 }
 
 keep <- function(.x, .f, ...) {
@@ -103,6 +93,15 @@ map_if <- function(.x, .p, .f, ...) {
   matches <- .probe(.x, .p)
   .x[matches] <- map(.x[matches], .f, ...)
   .x
+}
+.probe <- function(.x, .p, ...) {
+  if (is_logical(.p)) {
+    stopifnot(length(.p) == length(.x))
+    .p
+  } else {
+    .p <- as_function(.p)
+    map_lgl(.x, .p, ...)
+  }
 }
 
 compact <- function(.x) {
@@ -191,9 +190,9 @@ detect_index <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
 }
 
 imap <- function(.x, .f, ...) {
-  map2(.x, vec_index(.x), .f, ...)
+  map2(.x, .vec_index(.x), .f, ...)
 }
-vec_index <- function(x) {
+.vec_index <- function(x) {
   names(x) %||% seq_along(x)
 }
 

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -26,9 +26,6 @@ map_dbl <- function(.x, .f, ...) {
 map_chr <- function(.x, .f, ...) {
   map_mold(.x, .f, character(1), ...)
 }
-map_cpl <- function(.x, .f, ...) {
-  map_mold(.x, .f, complex(1), ...)
-}
 
 walk <- function(.x, .f, ...) {
   map(.x, .f, ...)
@@ -54,9 +51,6 @@ map2_dbl <- function(.x, .y, .f, ...) {
 }
 map2_chr <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "character")
-}
-map2_cpl <- function(.x, .y, .f, ...) {
-  as.vector(map2(.x, .y, .f, ...), "complex")
 }
 
 args_recycle <- function(args) {

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -35,25 +35,6 @@ walk <- function(.x, .f, ...) {
   invisible(.x)
 }
 
-pluck <- function(.x, .f) {
-  map(.x, `[[`, .f)
-}
-pluck_lgl <- function(.x, .f) {
-  map_lgl(.x, `[[`, .f)
-}
-pluck_int <- function(.x, .f) {
-  map_int(.x, `[[`, .f)
-}
-pluck_dbl <- function(.x, .f) {
-  map_dbl(.x, `[[`, .f)
-}
-pluck_chr <- function(.x, .f) {
-  map_chr(.x, `[[`, .f)
-}
-pluck_cpl <- function(.x, .f) {
-  map_cpl(.x, `[[`, .f)
-}
-
 map2 <- function(.x, .y, .f, ...) {
   out <- mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
   if (length(out) == length(.x)) {

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -7,9 +7,11 @@
 # repository.
 
 map <- function(.x, .f, ...) {
+  .f <- as_function(.f)
   lapply(.x, .f, ...)
 }
 map_mold <- function(.x, .f, .mold, ...) {
+  .f <- as_function(.f)
   out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
   names(out) <- names(.x)
   out
@@ -33,6 +35,7 @@ walk <- function(.x, .f, ...) {
 }
 
 map2 <- function(.x, .y, .f, ...) {
+  .f <- as_function(.f)
   out <- mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
   if (length(out) == length(.x)) {
     set_names(out, names(.x))
@@ -64,6 +67,7 @@ args_recycle <- function(args) {
   args
 }
 pmap <- function(.l, .f, ...) {
+  .f <- as.function(.f)
   args <- args_recycle(.l)
   do.call("mapply", c(
     FUN = list(quote(.f)),
@@ -77,6 +81,7 @@ probe <- function(.x, .p, ...) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
+    .p <- as_function(.p)
     map_lgl(.x, .p, ...)
   }
 }

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -10,6 +10,11 @@ map <- function(.x, .f, ...) {
   .f <- as_function(.f)
   lapply(.x, .f, ...)
 }
+walk <- function(.x, .f, ...) {
+  map(.x, .f, ...)
+  invisible(.x)
+}
+
 map_mold <- function(.x, .f, .mold, ...) {
   .f <- as_function(.f)
   out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
@@ -27,11 +32,6 @@ map_dbl <- function(.x, .f, ...) {
 }
 map_chr <- function(.x, .f, ...) {
   map_mold(.x, .f, character(1), ...)
-}
-
-walk <- function(.x, .f, ...) {
-  map(.x, .f, ...)
-  invisible(.x)
 }
 
 map2 <- function(.x, .y, .f, ...) {

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -22,18 +22,18 @@ walk <- function(.x, .f, ...) {
 }
 
 map_lgl <- function(.x, .f, ...) {
-  .map_mold(.x, .f, logical(1), ...)
+  .rlang_purrr_map_mold(.x, .f, logical(1), ...)
 }
 map_int <- function(.x, .f, ...) {
-  .map_mold(.x, .f, integer(1), ...)
+  .rlang_purrr_map_mold(.x, .f, integer(1), ...)
 }
 map_dbl <- function(.x, .f, ...) {
-  .map_mold(.x, .f, double(1), ...)
+  .rlang_purrr_map_mold(.x, .f, double(1), ...)
 }
 map_chr <- function(.x, .f, ...) {
-  .map_mold(.x, .f, character(1), ...)
+  .rlang_purrr_map_mold(.x, .f, character(1), ...)
 }
-.map_mold <- function(.x, .f, .mold, ...) {
+.rlang_purrr_map_mold <- function(.x, .f, .mold, ...) {
   .f <- as_function(.f)
   out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
   names(out) <- names(.x)
@@ -67,14 +67,14 @@ imap <- function(.x, .f, ...) {
 
 pmap <- function(.l, .f, ...) {
   .f <- as.function(.f)
-  args <- .args_recycle(.l)
+  args <- .rlang_purrr_args_recycle(.l)
   do.call("mapply", c(
     FUN = list(quote(.f)),
     args, MoreArgs = quote(list(...)),
     SIMPLIFY = FALSE, USE.NAMES = FALSE
   ))
 }
-.args_recycle <- function(args) {
+.rlang_purrr_args_recycle <- function(args) {
   lengths <- map_int(args, length)
   n <- max(lengths)
 
@@ -86,18 +86,18 @@ pmap <- function(.l, .f, ...) {
 }
 
 keep <- function(.x, .f, ...) {
-  .x[.probe(.x, .f, ...)]
+  .x[.rlang_purrr_probe(.x, .f, ...)]
 }
 discard <- function(.x, .p, ...) {
-  sel <- .probe(.x, .p, ...)
+  sel <- .rlang_purrr_probe(.x, .p, ...)
   .x[is.na(sel) | !sel]
 }
 map_if <- function(.x, .p, .f, ...) {
-  matches <- .probe(.x, .p)
+  matches <- .rlang_purrr_probe(.x, .p)
   .x[matches] <- map(.x[matches], .f, ...)
   .x
 }
-.probe <- function(.x, .p, ...) {
+.rlang_purrr_probe <- function(.x, .p, ...) {
   if (is_logical(.p)) {
     stopifnot(length(.p) == length(.x))
     .p
@@ -166,7 +166,7 @@ detect <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
   .p <- as_function(.p)
   .f <- as_function(.f)
 
-  for (i in .index(.x, .right)) {
+  for (i in .rlang_purrr_index(.x, .right)) {
     if (.p(.f(.x[[i]], ...))) {
       return(.x[[i]])
     }
@@ -177,14 +177,14 @@ detect_index <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
   .p <- as_function(.p)
   .f <- as_function(.f)
 
-  for (i in .index(.x, .right)) {
+  for (i in .rlang_purrr_index(.x, .right)) {
     if (.p(.f(.x[[i]], ...))) {
       return(i)
     }
   }
   0L
 }
-.index <- function(x, right = FALSE) {
+.rlang_purrr_index <- function(x, right = FALSE) {
   idx <- seq_along(x)
   if (right) {
     idx <- rev(idx)

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -7,10 +7,10 @@
 #
 # Changelog:
 # 2020-04-14:
-# * removed pluck*() functions
-# * removed *_cpl() functions
-# * used as_function() to allow use of ~
-# * used . prefix for helpers
+# * Removed `pluck*()` functions
+# * Removed `*_cpl()` functions
+# * Used `as_function()` to allow use of `~`
+# * Used `.` prefix for helpers
 
 map <- function(.x, .f, ...) {
   .f <- as_function(.f)

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -13,7 +13,7 @@
 # * Used `.` prefix for helpers
 
 map <- function(.x, .f, ...) {
-  .f <- as_function(.f)
+  .f <- as_function(.f, env = global_env())
   lapply(.x, .f, ...)
 }
 walk <- function(.x, .f, ...) {
@@ -34,14 +34,14 @@ map_chr <- function(.x, .f, ...) {
   .rlang_purrr_map_mold(.x, .f, character(1), ...)
 }
 .rlang_purrr_map_mold <- function(.x, .f, .mold, ...) {
-  .f <- as_function(.f)
+  .f <- as_function(.f, env = global_env())
   out <- vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
   names(out) <- names(.x)
   out
 }
 
 map2 <- function(.x, .y, .f, ...) {
-  .f <- as_function(.f)
+  .f <- as_function(.f, env = global_env())
   out <- mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
   if (length(out) == length(.x)) {
     set_names(out, names(.x))
@@ -102,7 +102,7 @@ map_if <- function(.x, .p, .f, ...) {
     stopifnot(length(.p) == length(.x))
     .p
   } else {
-    .p <- as_function(.p)
+    .p <- as_function(.p, env = global_env())
     map_lgl(.x, .p, ...)
   }
 }
@@ -125,7 +125,7 @@ transpose <- function(.l) {
 }
 
 every <- function(.x, .p, ...) {
-  .p <- as_function(.p)
+  .p <- as_function(.p, env = global_env())
 
   for (i in seq_along(.x)) {
     if (!rlang::is_true(.p(.x[[i]], ...))) return(FALSE)
@@ -133,7 +133,7 @@ every <- function(.x, .p, ...) {
   TRUE
 }
 some <- function(.x, .p, ...) {
-  .p <- as_function(.p)
+  .p <- as_function(.p, env = global_env())
 
   for (i in seq_along(.x)) {
     if (rlang::is_true(.p(.x[[i]], ...))) return(TRUE)
@@ -141,7 +141,7 @@ some <- function(.x, .p, ...) {
   FALSE
 }
 negate <- function(.p) {
-  .p <- as_function(.p)
+  .p <- as_function(.p, env = global_env())
   function(...) !.p(...)
 }
 
@@ -163,8 +163,8 @@ accumulate_right <- function(.x, .f, ..., .init) {
 }
 
 detect <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
-  .p <- as_function(.p)
-  .f <- as_function(.f)
+  .p <- as_function(.p, env = global_env())
+  .f <- as_function(.f, env = global_env())
 
   for (i in .rlang_purrr_index(.x, .right)) {
     if (.p(.f(.x[[i]], ...))) {
@@ -174,8 +174,8 @@ detect <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
   NULL
 }
 detect_index <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
-  .p <- as_function(.p)
-  .f <- as_function(.f)
+  .p <- as_function(.p, env = global_env())
+  .f <- as_function(.f, env = global_env())
 
   for (i in .rlang_purrr_index(.x, .right)) {
     if (.p(.f(.x[[i]], ...))) {

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -976,7 +976,7 @@ frame_position_global <- function(frame, stack = NULL) {
 
   frame <- get_env(frame)
   stack <- stack %||% stack_trim(ctxt_stack(), n = 2)
-  envs <- pluck(stack, "env")
+  envs <- map(stack, "[[", "env")
 
   i <- 1
   for (env in envs) {

--- a/tests/testthat/test-compat-purrr.R
+++ b/tests/testthat/test-compat-purrr.R
@@ -1,0 +1,47 @@
+test_that("map functions work", {
+  expect_equal(map(1:2, length), list(1, 1))
+  expect_equal(walk(1:2, length), 1:2)
+
+  expect_equal(map_lgl(0:1, as.logical), c(FALSE, TRUE))
+  expect_identical(map_int(1:2, as.integer), 1:2)
+  expect_identical(map_dbl(1:2, as.integer), c(1, 2))
+  expect_equal(map_chr(1:2, as.character), c("1", "2"))
+})
+
+test_that("map2 functions work", {
+  expect_equal(map2(1, 1:2, `+`), list(2, 3))
+
+  expect_equal(map2_lgl(1, 1:2, `==`), c(TRUE, FALSE))
+  expect_identical(map2_int(1, 1:2, `+`), c(2L, 3L))
+  expect_identical(map2_dbl(1, 1:2, `+`), c(2, 3))
+  expect_equal(map2_chr(1, 1:2, paste0), c("11", "12"))
+})
+
+test_that("pmap works", {
+  expect_equal(pmap(list(1, 1:2), paste0), list("11", "12"))
+})
+
+test_that("predicate based functions work", {
+  x <- list(1, 2)
+  expect_equal(keep(x, ~ sum(.x) > 1), list(2))
+  expect_equal(discard(x, ~ sum(.x) > 1), list(1))
+  expect_equal(map_if(x, ~ sum(.x) > 1, ~ 10), list(1, 10))
+
+  expect_true(every(x, ~ .x > 0))
+  expect_false(every(x, ~ .x < 0))
+  expect_true(some(x, ~ .x > 0))
+  expect_false(some(x, ~ .x < 0))
+
+  expect_equal(detect(x, ~ .x > 1), 2)
+  expect_identical(detect_index(x, ~ .x > 0), 1L)
+})
+
+test_that("reduce/accumulate work", {
+  x <- 1:3
+  expect_equal(reduce(x, `+`), 6)
+  expect_equal(reduce_right(x, `+`), 6)
+
+  expect_equal(accumulate(x, `+`), c(1, 3, 6))
+  expect_equal(accumulate_right(x, `+`), c(6, 5, 3))
+
+})

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -361,11 +361,11 @@ test_that("call_stack() trail ignores irrelevant frames", {
   f3 <- function(x) call_stack()
 
   stack1 <- f1()
-  trail1 <- pluck_int(stack1, "pos")
+  trail1 <- map_int(stack1, "[[", "pos")
   expect_equal(fixup_call_trail(trail1), c(3, 2, 1))
 
   stack2 <- identity(identity(f1()))
-  trail2 <- pluck_int(stack2, "pos")
+  trail2 <- map_int(stack2, "[[", "pos")
   expect_equal(fixup_call_trail(trail2), c(5, 4, 3))
 })
 
@@ -373,7 +373,7 @@ test_that("ctxt_stack() exprs is in opposite order to sys calls", {
   syscalls <- sys.calls()
   stack <- ctxt_stack()
   stack <- drop_last(stack) # global frame
-  exprs <- pluck(stack, "expr")
+  exprs <- map(stack, "[[", "expr")
   expect_equal(exprs[[length(exprs)]], syscalls[[1]])
   expect_equal(exprs[[1]], syscalls[[length(syscalls)]])
 })

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -361,11 +361,11 @@ test_that("call_stack() trail ignores irrelevant frames", {
   f3 <- function(x) call_stack()
 
   stack1 <- f1()
-  trail1 <- map_int(stack1, "[[", "pos")
+  trail1 <- map_int(stack1, `[[`, "pos")
   expect_equal(fixup_call_trail(trail1), c(3, 2, 1))
 
   stack2 <- identity(identity(f1()))
-  trail2 <- map_int(stack2, "[[", "pos")
+  trail2 <- map_int(stack2, `[[`, "pos")
   expect_equal(fixup_call_trail(trail2), c(5, 4, 3))
 })
 
@@ -373,7 +373,7 @@ test_that("ctxt_stack() exprs is in opposite order to sys calls", {
   syscalls <- sys.calls()
   stack <- ctxt_stack()
   stack <- drop_last(stack) # global frame
-  exprs <- map(stack, "[[", "expr")
+  exprs <- map(stack, `[[`, "expr")
   expect_equal(exprs[[length(exprs)]], syscalls[[1]])
   expect_equal(exprs[[1]], syscalls[[length(syscalls)]])
 })


### PR DESCRIPTION
* Remove pluck functions (fixes #1159)
* Remove `map_cpl()` and `map2_cpl()`
* Use `as_function()` (fixes #1157)

I didn't namespace because all the options I tried looked ugly.