### PR TITLE
If `glue` is not installed, `rlang` should still be installable

### DIFF
--- a/R/dots.R
+++ b/R/dots.R
@@ -54,8 +54,10 @@
 #' # Unquote a name, showing both the `!!` bang bang and `{}` glue style
 #' nm <- "key"
 #' f(!!nm := "value")
-#' f("{nm}" := "value")
-#' f("prefix_{nm}" := "value")
+#' if (requireNamespace("glue")) {
+#'   f("{nm}" := "value")
+#'   f("prefix_{nm}" := "value")
+#' }
 #'
 #' # Tolerate a trailing comma
 #' f(this = "that", )

--- a/R/dots.R
+++ b/R/dots.R
@@ -54,7 +54,7 @@
 #' # Unquote a name, showing both the `!!` bang bang and `{}` glue style
 #' nm <- "key"
 #' f(!!nm := "value")
-#' if (requireNamespace("glue")) {
+#' if (is_installed("glue")) {
 #'   f("{nm}" := "value")
 #'   f("prefix_{nm}" := "value")
 #' }

--- a/man/dyn-dots.Rd
+++ b/man/dyn-dots.Rd
@@ -50,8 +50,10 @@ f(!!!x)
 # Unquote a name, showing both the `!!` bang bang and `{}` glue style
 nm <- "key"
 f(!!nm := "value")
-f("{nm}" := "value")
-f("prefix_{nm}" := "value")
+if (requireNamespace("glue")) {
+  f("{nm}" := "value")
+  f("prefix_{nm}" := "value")
+}
 
 # Tolerate a trailing comma
 f(this = "that", )

--- a/man/dyn-dots.Rd
+++ b/man/dyn-dots.Rd
@@ -50,7 +50,7 @@ f(!!!x)
 # Unquote a name, showing both the `!!` bang bang and `{}` glue style
 nm <- "key"
 f(!!nm := "value")
-if (requireNamespace("glue")) {
+if (is_installed("glue")) {
   f("{nm}" := "value")
   f("prefix_{nm}" := "value")
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,8 +1,9 @@
 # Workaround for loadNamespace() failure on R 3.2
 requireNamespace("rlang")
 
-if (require("testthat")) {
-  library("rlang")
+if (require(testthat)) {
+  library(rlang)
 
   test_check("rlang")
-}
+} else
+  warning("'rlang' requires 'testthat' for tests")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,9 +1,7 @@
 # Workaround for loadNamespace() failure on R 3.2
 requireNamespace("rlang")
 
-if (require(testthat)) {
-  library(rlang)
+library("testthat")
+library("rlang")
 
-  test_check("rlang")
-} else
-  warning("'rlang' requires 'testthat' for tests")
+test_check("rlang")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,7 +1,8 @@
 # Workaround for loadNamespace() failure on R 3.2
 requireNamespace("rlang")
 
-library("testthat")
-library("rlang")
+if (require("testthat")) {
+  library("rlang")
 
-test_check("rlang")
+  test_check("rlang")
+}


### PR DESCRIPTION
Checks should give only NOTEs about missing suggested packages.  

 - Since `roxygen2` needs `glue`, we need to update docs before getting rid of `glue`.
 - Since `testthat` needs `glue`, we also have to assume it isn't installed.  
 - Since `devtools` needs `glue`, we need to do our checks using standard `R CMD check`.

This PR fixes issue #1178 in that `rlang` can pass CRAN checks without ERRORs or WARNINGs if `glue` is missing, but I don't know if it will still install on winUCRT, because I don't have a test platform set up for that yet.