### PR TITLE
Don't throw error from `s3_register()` if generic does not exist

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rlang (development version)
 
+* `s3_register()` no longer fails when generic does not exist. This
+  prevents failures when users don't have all the last versions of
+  packages (#1112).
+
 * Formulas are now deparsed according to the tidyverse style guide
   (`~symbol` without space and `~ expression()` with a space).
 

--- a/R/compat-s3-register.R
+++ b/R/compat-s3-register.R
@@ -88,6 +88,12 @@ s3_register <- function(generic, class, method = NULL) {
     # Only register if generic can be accessed
     if (exists(generic, envir)) {
       registerS3method(generic, class, method_fn, envir = envir)
+    } else if (identical(Sys.getenv("NOT_CRAN"), "true")) {
+      warning(sprintf(
+        "Can't find generic `%s` in package %s to register S3 method.",
+        generic,
+        package
+      ))
     }
   }
 

--- a/R/compat-s3-register.R
+++ b/R/compat-s3-register.R
@@ -76,32 +76,27 @@ s3_register <- function(generic, class, method = NULL) {
     }
   }
 
-  method_fn <- get_method(method)
-  stopifnot(is.function(method_fn))
+  register <- function(...) {
+    envir <- asNamespace(package)
 
-  # Always register hook in case package is later unloaded & reloaded
-  setHook(
-    packageEvent(package, "onLoad"),
-    function(...) {
-      ns <- asNamespace(package)
+    # Refresh the method each time, it might have been updated by
+    # `devtools::load_all()`
+    method_fn <- get_method(method)
+    stopifnot(is.function(method_fn))
 
-      # Refresh the method, it might have been updated by `devtools::load_all()`
-      method_fn <- get_method(method)
 
-      registerS3method(generic, class, method_fn, envir = ns)
+    # Only register if generic can be accessed
+    if (exists(generic, envir)) {
+      registerS3method(generic, class, method_fn, envir = envir)
     }
-  )
-
-  # Avoid registration failures during loading (pkgload or regular)
-  if (!isNamespaceLoaded(package)) {
-    return(invisible())
   }
 
-  envir <- asNamespace(package)
+  # Always register hook in case package is later unloaded & reloaded
+  setHook(packageEvent(package, "onLoad"), register)
 
-  # Only register if generic can be accessed
-  if (exists(generic, envir)) {
-    registerS3method(generic, class, method_fn, envir = envir)
+  # Avoid registration failures during loading (pkgload or regular)
+  if (isNamespaceLoaded(package)) {
+    register()
   }
 
   invisible()

--- a/tests/testthat/_snaps/compat-s3-register.md
+++ b/tests/testthat/_snaps/compat-s3-register.md
@@ -1,0 +1,8 @@
+# can register for generics that don't exist
+
+    Code
+      (expect_warning(s3_register("base::foobarbaz", "class", method = function(...)
+        NULL)))
+    Output
+      <simpleWarning in register(): Can't find generic `foobarbaz` in package base to register S3 method.>
+

--- a/tests/testthat/test-compat-s3-register.R
+++ b/tests/testthat/test-compat-s3-register.R
@@ -1,0 +1,13 @@
+test_that("can register for generics that don't exist", {
+  withr::with_envvar(c(NOT_CRAN = ""), {
+    expect_silent(
+      s3_register("base::foobarbaz", "class", method = function(...) NULL)
+    )
+  })
+
+  withr::with_envvar(c(NOT_CRAN = "true"), {
+    expect_snapshot({
+      (expect_warning(s3_register("base::foobarbaz", "class", method = function(...) NULL)))
+    })
+  })
+})


### PR DESCRIPTION
Turns out we had disparate code paths, in some cases we threw an error but not others. This is now fixed through a closure that is called in both cases.

Following Slack discussion, we still warn if `NOT_CRAN` is set in case the developer misspelled the generic. I think this warning will only show up when the namespace gets loaded during tests, but I'm not sure how we can do better.

Closes #1112.