### PR TITLE
Include `r_arg_match()` in C library

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* The `arg_nm` argument of `arg_match0()` must now be a string or
+  symbol.
+
 * `inform()` and `warn()` messages can now be silenced with the global
   options `rlib_message_verbosity` and `rlib_warning_verbosity`.
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -56,7 +56,8 @@ arg_match <- function(arg, values = NULL) {
 #' In this case, the first element of `arg` is used.
 #'
 #' @param values The possible values that `arg` can take.
-#' @param arg_nm The label to be used for `arg` in error messages.
+#' @param arg_nm Argument name of `arg` to use in error messages. Can
+#'   be a string or symbol.
 #' @rdname arg_match
 #' @export
 #' @examples
@@ -71,8 +72,8 @@ arg_match <- function(arg, values = NULL) {
 #' fn1()
 #' fn2("bar")
 #' try(fn3("zoo"))
-arg_match0 <- function(arg, values, arg_nm = as_label(substitute(arg))) {
-  .External(ffi_arg_match0, arg, values, environment())
+arg_match0 <- function(arg, values, arg_nm = substitute(arg)) {
+  .External(ffi_arg_match0, arg, values, arg_nm)
 }
 
 stop_arg_match <- function(arg, values, arg_nm) {

--- a/man/arg_match.Rd
+++ b/man/arg_match.Rd
@@ -7,14 +7,15 @@
 \usage{
 arg_match(arg, values = NULL)
 
-arg_match0(arg, values, arg_nm = as_label(substitute(arg)))
+arg_match0(arg, values, arg_nm = substitute(arg))
 }
 \arguments{
 \item{arg}{A symbol referring to an argument accepting strings.}
 
 \item{values}{The possible values that \code{arg} can take.}
 
-\item{arg_nm}{The label to be used for \code{arg} in error messages.}
+\item{arg_nm}{Argument name of \code{arg} to use in error messages. Can
+be a string or symbol.}
 }
 \value{
 The string supplied to \code{arg}.

--- a/src/Makevars
+++ b/src/Makevars
@@ -3,6 +3,7 @@ PKG_CFLAGS = $(C_VISIBILITY)
 
 lib-files = \
         rlang/rlang.h \
+        rlang/arg.c \
         rlang/attrib.c \
         rlang/call.c \
         rlang/cnd.c \

--- a/src/internal/arg.c
+++ b/src/internal/arg.c
@@ -98,13 +98,13 @@ int arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
     r_abort("`%s` must be a string or have the same length as `values`.", unwrap_c_str(arg_nm));
   }
 
-  r_obj* const* p_values = r_chr_cbegin(values);
+  r_obj* const* v_values = r_chr_cbegin(values);
 
   // Simple case: one argument, we check if it's one of the values.
   if (arg_len == 1) {
     r_obj* arg_char = r_chr_get(arg, 0);
     for (int i = 0; i < values_len; ++i) {
-      if (arg_char == p_values[i]) {
+      if (arg_char == v_values[i]) {
         return i;
       }
     }
@@ -113,12 +113,12 @@ int arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
     r_stop_unreached("arg_match");
   }
 
-  r_obj* const* p_arg = r_chr_cbegin(arg);
+  r_obj* const* v_arg = r_chr_cbegin(arg);
 
   // Same-length vector: must be identical, we allow changed order.
   int i = 0;
   for (; i < arg_len; ++i) {
-    if (p_arg[i] != p_values[i]) {
+    if (v_arg[i] != v_values[i]) {
       break;
     }
   }
@@ -129,22 +129,22 @@ int arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
   }
 
   r_obj* my_values = KEEP(r_clone(values));
-  r_obj* const * p_my_values = r_chr_cbegin(my_values);
+  r_obj* const * v_my_values = r_chr_cbegin(my_values);
 
   // Invariant: my_values[i:(len-1)] contains the values we haven't matched yet
   for (; i < arg_len; ++i) {
-    r_obj* current_arg = p_arg[i];
-    if (current_arg == p_my_values[i]) {
+    r_obj* current_arg = v_arg[i];
+    if (current_arg == v_my_values[i]) {
       continue;
     }
 
     bool matched = false;
     for (int j = i + 1; j < arg_len; ++j) {
-      if (current_arg == p_my_values[j]) {
+      if (current_arg == v_my_values[j]) {
         matched = true;
 
         // Replace matched value by the element that failed to match at this iteration
-        r_chr_poke(my_values, j, p_my_values[i]);
+        r_chr_poke(my_values, j, v_my_values[i]);
         break;
       }
     }
@@ -159,7 +159,7 @@ int arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
 
   r_obj* first_elt = r_chr_get(arg, 0);
   for (i = 0; i < values_len; ++i) {
-    if (first_elt == p_values[i]) {
+    if (first_elt == v_values[i]) {
       FREE(1);
       return i;
     }

--- a/src/internal/arg.c
+++ b/src/internal/arg.c
@@ -80,6 +80,7 @@ r_obj* ffi_enquo(r_obj* sym, r_obj* frame) {
 
 // Match ------------------------------------------------------------------
 
+// [[ register("c") ]]
 r_obj* arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
   if (r_typeof(arg) != R_TYPE_character) {
     r_abort("`%s` must be a character vector.", unwrap_c_str(arg_nm));

--- a/src/internal/arg.c
+++ b/src/internal/arg.c
@@ -182,6 +182,8 @@ r_obj* ffi_arg_match0(r_obj* args) {
 static
 r_obj* wrap_chr(r_obj* arg) {
   switch (arg_match_arg_nm_type(arg)) {
+  case R_TYPE_string:
+    return r_str_as_character(arg);
   case R_TYPE_symbol:
     return r_sym_as_character(arg);
   case R_TYPE_character:
@@ -194,6 +196,8 @@ r_obj* wrap_chr(r_obj* arg) {
 static
 r_obj* unwrap_str(r_obj* arg) {
   switch (arg_match_arg_nm_type(arg)) {
+  case R_TYPE_string:
+    return arg;
   case R_TYPE_symbol:
     return r_sym_string(arg);
   case R_TYPE_character:

--- a/src/internal/arg.c
+++ b/src/internal/arg.c
@@ -98,11 +98,13 @@ r_obj* arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
     r_abort("`%s` must be a string or have the same length as `values`.", unwrap_c_str(arg_nm));
   }
 
+  r_obj* const* p_values = r_chr_cbegin(values);
+
   // Simple case: one argument, we check if it's one of the values.
   if (arg_len == 1) {
     r_obj* arg_char = r_chr_get(arg, 0);
     for (r_ssize i = 0; i < values_len; ++i) {
-      if (arg_char == r_chr_get(values, i)) {
+      if (arg_char == p_values[i]) {
         return(arg);
       }
     }
@@ -112,7 +114,6 @@ r_obj* arg_match(r_obj* arg, r_obj* values, r_obj* arg_nm) {
   }
 
   r_obj* const* p_arg = r_chr_cbegin(arg);
-  r_obj* const* p_values = r_chr_cbegin(values);
 
   // Same-length vector: must be identical, we allow changed order.
   r_ssize i = 0;

--- a/src/internal/decl/arg-decl.h
+++ b/src/internal/decl/arg-decl.h
@@ -11,3 +11,8 @@ r_obj* unwrap_str(r_obj* arg);
 
 static
 const char* unwrap_c_str(r_obj* arg);
+
+static
+int arg_match1(r_obj* arg,
+               r_obj* values,
+               r_obj* arg_nm);

--- a/src/internal/decl/arg-decl.h
+++ b/src/internal/decl/arg-decl.h
@@ -1,4 +1,13 @@
 static r_obj* stop_arg_match_call;
-static r_obj* arg_nm_sym;
 
-void arg_match0_abort(const char* msg, r_obj* env);
+static
+enum r_type arg_match_arg_nm_type(r_obj* arg_nm);
+
+static
+r_obj* wrap_chr(r_obj* arg);
+
+static
+r_obj* unwrap_str(r_obj* arg);
+
+static
+const char* unwrap_c_str(r_obj* arg);

--- a/src/internal/decl/dots-decl.h
+++ b/src/internal/decl/dots-decl.h
@@ -1,9 +1,13 @@
 static r_obj* as_label_call;
-static r_obj* empty_spliced_arg;
-static r_obj* splice_box_attrib;
-static r_obj* quosures_attrib;
 static r_obj* auto_name_call;
+static r_obj* dots_homonyms_arg;
+static r_obj* dots_homonyms_values;
+static r_obj* dots_ignore_empty_arg;
+static r_obj* dots_ignore_empty_values;
+static r_obj* empty_spliced_arg;
 static r_obj* glue_unquote_fn;
+static r_obj* quosures_attrib;
+static r_obj* splice_box_attrib;
 
 r_obj* rlang_ns_get(const char* name);
 

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -241,6 +241,7 @@ void R_init_rlang(DllInfo* dll) {
   R_RegisterCCallable("rlang", "rlang_quo_get_expr",        (DL_FUNC) &ffi_quo_get_expr);
   R_RegisterCCallable("rlang", "rlang_quo_set_env",         (DL_FUNC) &ffi_quo_set_env);
   R_RegisterCCallable("rlang", "rlang_quo_set_expr",        (DL_FUNC) &ffi_quo_set_expr);
+  R_RegisterCCallable("rlang", "rlang_arg_match",           (DL_FUNC) &arg_match);
 
   r_obj* r_as_function(r_obj* x, const char* arg);
   R_RegisterCCallable("rlang", "rlang_as_function",         (DL_FUNC) &r_as_function);

--- a/src/rlang/arg.c
+++ b/src/rlang/arg.c
@@ -1,0 +1,7 @@
+#include "rlang.h"
+
+r_obj* (*r_arg_match)(r_obj* arg, r_obj* values, r_obj* arg_nm);
+
+void r_init_library_arg() {
+  r_arg_match = (r_obj* (*)(r_obj*, r_obj*, r_obj*)) r_peek_c_callable("rlang", "rlang_arg_match");
+}

--- a/src/rlang/arg.c
+++ b/src/rlang/arg.c
@@ -1,7 +1,7 @@
 #include "rlang.h"
 
-r_obj* (*r_arg_match)(r_obj* arg, r_obj* values, r_obj* arg_nm);
+int (*r_arg_match)(r_obj* arg, r_obj* values, r_obj* arg_nm);
 
 void r_init_library_arg() {
-  r_arg_match = (r_obj* (*)(r_obj*, r_obj*, r_obj*)) r_peek_c_callable("rlang", "rlang_arg_match");
+  r_arg_match = (int (*)(r_obj*, r_obj*, r_obj*)) r_peek_c_callable("rlang", "rlang_arg_match");
 }

--- a/src/rlang/arg.h
+++ b/src/rlang/arg.h
@@ -1,0 +1,8 @@
+#ifndef RLANG_ARG_H
+#define RLANG_ARG_H
+
+
+extern r_obj* (*r_arg_match)(r_obj* arg, r_obj* values, r_obj* arg_nm);
+
+
+#endif

--- a/src/rlang/arg.h
+++ b/src/rlang/arg.h
@@ -2,7 +2,7 @@
 #define RLANG_ARG_H
 
 
-extern r_obj* (*r_arg_match)(r_obj* arg, r_obj* values, r_obj* arg_nm);
+extern int (*r_arg_match)(r_obj* arg, r_obj* values, r_obj* arg_nm);
 
 
 #endif

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -1,5 +1,6 @@
 #include <rlang.h>
 
+#include "arg.c"
 #include "attrib.c"
 #include "call.c"
 #include "cnd.c"
@@ -79,6 +80,7 @@ r_obj* r_init_library(r_obj* ns) {
   r_init_library_globals();
 
   r_init_rlang_ns_env();
+  r_init_library_arg();
   r_init_library_call();
   r_init_library_cnd();
   r_init_library_dyn_array();

--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -37,6 +37,7 @@ r_ssize r_as_ssize(r_obj* n);
 #include "globals.h"
 
 #include "altrep.h"
+#include "arg.h"
 #include "attrib.h"
 #include "debug.h"
 #include "c-utils.h"

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -77,3 +77,12 @@
       <error/rlang_error>
       `f()` requires the argument `x` to be supplied.
 
+# arg_match() supports scalar strings
+
+    Code
+      (expect_error(arg_match0(chr_get("fo", 0L), c("bar", "foo"), "my_arg")))
+    Output
+      <error/rlang_error>
+      `my_arg` must be one of "bar" or "foo", not "fo".
+      i Did you mean "foo"?
+

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -19,43 +19,49 @@
       `my_arg` must be one of "ba" or "fo", not "fu".
       i Did you mean "fo"?
     Code
-      (expect_error(arg_match0("baq", c("foo", "baz", "bas"))))
+      (expect_error(arg_match0("baq", c("foo", "baz", "bas"), "my_arg")))
     Output
       <error/rlang_error>
-      `"baq"` must be one of "foo", "baz", or "bas", not "baq".
+      `my_arg` must be one of "foo", "baz", or "bas", not "baq".
       i Did you mean "baz"?
     Code
       (expect_error(arg_match0("", character(), "my_arg")))
     Output
       <error/rlang_error>
       `values` must have at least one element.
+    Code
+      (expect_error(arg_match0("fo", "foo", quote(f()))))
+    Output
+      <error/rlang_error>
+      `arg_nm` must be a string or symbol.
 
 # `arg_match()` provides no suggestion when the edit distance is too large
 
     Code
-      (expect_error(arg_match0("foobaz", c("fooquxs", "discrete"))))
+      (expect_error(arg_match0("foobaz", c("fooquxs", "discrete"), "my_arg")))
     Output
       <error/rlang_error>
-      `"foobaz"` must be one of "fooquxs" or "discrete", not "foobaz".
+      `my_arg` must be one of "fooquxs" or "discrete", not "foobaz".
     Code
-      (expect_error(arg_match0("a", c("b", "c"))))
+      (expect_error(arg_match0("a", c("b", "c"), "my_arg")))
     Output
       <error/rlang_error>
-      `"a"` must be one of "b" or "c", not "a".
+      `my_arg` must be one of "b" or "c", not "a".
 
 # `arg_match()` makes case-insensitive match
 
     Code
-      (expect_error(arg_match0("a", c("A", "B")), "Did you mean \"A\"?"))
+      (expect_error(arg_match0("a", c("A", "B"), "my_arg"), "Did you mean \"A\"?"))
     Output
       <error/rlang_error>
-      `"a"` must be one of "A" or "B", not "a".
+      `my_arg` must be one of "A" or "B", not "a".
       i Did you mean "A"?
     Code
-      (expect_error(arg_match0("aa", c("AA", "aA")), "Did you mean \"aA\"?"))
+      (expect_error(arg_match0("aa", c("AA", "aA"), "my_arg"), "Did you mean \"aA\"?")
+      )
     Output
       <error/rlang_error>
-      `"aa"` must be one of "AA" or "aA", not "aa".
+      `my_arg` must be one of "AA" or "aA", not "aa".
       i Did you mean "aA"?
 
 # arg_require() checks argument is supplied (#1118)

--- a/tests/testthat/_snaps/dots.md
+++ b/tests/testthat/_snaps/dots.md
@@ -1,0 +1,5 @@
+# `.ignore_empty` is matched
+
+    Code
+      expect_error(dots_list(.ignore_empty = "t"))
+

--- a/tests/testthat/_snaps/dots.md
+++ b/tests/testthat/_snaps/dots.md
@@ -1,5 +1,9 @@
 # `.ignore_empty` is matched
 
     Code
-      expect_error(dots_list(.ignore_empty = "t"))
+      (expect_error(dots_list(.ignore_empty = "t")))
+    Output
+      <error/rlang_error>
+      `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
+      i Did you mean "trailing"?
 

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -22,7 +22,7 @@ test_that("gives error with different than rearranged arg vs value", {
   expect_error(f(), "`myarg` must be a string or have the same length as `values`.")
 
   expect_error(
-    arg_match0(c("foo", "foo"), c("foo", "bar")),
+    arg_match0(c("foo", "foo"), c("foo", "bar"), arg_nm = "x"),
     regexp = "must be one of \"foo\" or \"bar\""
   )
 })
@@ -55,15 +55,16 @@ test_that("`arg_match()` has informative error messages", {
     (expect_error(arg_match0("continuuos", c("discrete", "continuous"), "my_arg")))
     (expect_error(arg_match0("fou", c("bar", "foo"), "my_arg")))
     (expect_error(arg_match0("fu", c("ba", "fo"), "my_arg")))
-    (expect_error(arg_match0("baq", c("foo", "baz", "bas"))))
+    (expect_error(arg_match0("baq", c("foo", "baz", "bas"), "my_arg")))
     (expect_error(arg_match0("", character(), "my_arg")))
+    (expect_error(arg_match0("fo", "foo", quote(f()))))
   })
 })
 
 test_that("`arg_match()` provides no suggestion when the edit distance is too large", {
   expect_snapshot({
-    (expect_error(arg_match0("foobaz", c("fooquxs", "discrete"))))
-    (expect_error(arg_match0("a", c("b", "c"))))
+    (expect_error(arg_match0("foobaz", c("fooquxs", "discrete"), "my_arg")))
+    (expect_error(arg_match0("a", c("b", "c"), "my_arg")))
   })
 })
 
@@ -76,10 +77,10 @@ test_that("`arg_match()` finds a match even with small possible typos", {
 
 test_that("`arg_match()` makes case-insensitive match", {
   expect_snapshot({
-    (expect_error(arg_match0("a", c("A", "B")), "Did you mean \"A\"?"))
+    (expect_error(arg_match0("a", c("A", "B"), "my_arg"), "Did you mean \"A\"?"))
 
     # Case-insensitive match is done after case-sensitive
-    (expect_error(arg_match0("aa", c("AA", "aA")), "Did you mean \"aA\"?"))
+    (expect_error(arg_match0("aa", c("AA", "aA"), "my_arg"), "Did you mean \"aA\"?"))
   })
 })
 

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -134,3 +134,18 @@ test_that("arg_require() checks argument is supplied (#1118)", {
     (expect_error(g()))
   })
 })
+
+test_that("arg_match() supports symbols and scalar strings", {
+  expect_equal(
+    arg_match0(chr_get("foo", 0L), c("bar", "foo"), "my_arg"),
+    "foo"
+  )
+  expect_equal(
+    arg_match0(sym("foo"), c("bar", "foo"), "my_arg"),
+    "foo"
+  )
+
+  expect_snapshot({
+    (expect_error(arg_match0(chr_get("fo", 0L), c("bar", "foo"), "my_arg")))
+  })
+})

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -302,8 +302,8 @@ test_that("dots_list() optionally auto-names arguments (#957)", {
 })
 
 test_that("`.ignore_empty` is matched", {
-  # Tests the `r_arg_match()` library function`
+  # Tests the `r_arg_match()` library function
   expect_snapshot({
-    expect_error(dots_list(.ignore_empty = "t"))
+    (expect_error(dots_list(.ignore_empty = "t")))
   })
 })

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -300,3 +300,10 @@ test_that("dots_list() optionally auto-names arguments (#957)", {
     list(`<int>` = 1:3, `<int>` = 1:3)
   )
 })
+
+test_that("`.ignore_empty` is matched", {
+  # Tests the `r_arg_match()` library function`
+  expect_snapshot({
+    expect_error(dots_list(.ignore_empty = "t"))
+  })
+})


### PR DESCRIPTION
Closes #1163.

Takes same inputs as `arg_match0()` at R level. Returns an int that can be coerced to an enum (see changes in `dots.c`).