### PR TITLE
Implement `r_normalise_encoding()`

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -44,6 +44,7 @@ internal-files = \
         internal/call.c \
         internal/dots.c \
         internal/dots-ellipsis.c \
+        internal/encoding.c \
         internal/env.c \
         internal/env-binding.c \
         internal/eval.c \

--- a/src/internal/decl/encoding-decl.h
+++ b/src/internal/decl/encoding-decl.h
@@ -1,0 +1,23 @@
+static
+r_obj* chr_normalise_encoding(r_obj* x);
+
+static inline
+r_ssize chr_find_normalise_start(r_obj* x, r_ssize size);
+
+static
+r_obj* list_normalise_encoding(r_obj* x);
+
+static
+r_obj* r_attrib_normalise_encoding(r_obj* x, r_obj* attrib);
+
+static
+r_obj* attrib_normalise_encoding(r_obj* x);
+
+static inline
+r_obj* str_normalise(r_obj* x);
+
+static inline
+bool str_is_normalised(r_obj* x);
+
+static inline
+bool str_is_ascii_or_utf8(r_obj* x);

--- a/src/internal/encoding.c
+++ b/src/internal/encoding.c
@@ -1,0 +1,186 @@
+#include <rlang.h>
+#include "encoding.h"
+#include "decl/encoding-decl.h"
+
+r_obj* r_normalise_encoding(r_obj* x) {
+  switch (r_typeof(x)) {
+  case R_TYPE_character: x = chr_normalise_encoding(x); break;
+  case R_TYPE_list: x = list_normalise_encoding(x); break;
+  default: break;
+  }
+
+  // For performance, avoid `KEEP()` / `FREE()` when not needed
+  r_obj* attrib = r_attrib(x);
+  if (attrib != r_null) {
+    KEEP(x);
+    x = r_attrib_normalise_encoding(x, attrib);
+    FREE(1);
+  }
+
+  return x;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+r_obj* chr_normalise_encoding(r_obj* x) {
+  r_ssize size = r_length(x);
+  r_ssize start = chr_find_normalise_start(x, size);
+
+  if (size == start) {
+    return x;
+  }
+
+  x = KEEP(r_clone_shared(x));
+  r_obj* const* p_x = r_chr_cbegin(x);
+
+  const void* vmax = vmaxget();
+
+  for (r_ssize i = start; i < size; ++i) {
+    r_obj* const elt = p_x[i];
+
+    if (str_is_normalised(elt)) {
+      continue;
+    }
+
+    r_chr_poke(x, i, str_normalise(elt));
+  }
+
+  vmaxset(vmax);
+  FREE(1);
+  return x;
+}
+
+static inline
+r_ssize chr_find_normalise_start(r_obj* x, r_ssize size) {
+  r_obj* const* p_x = r_chr_cbegin(x);
+
+  for (r_ssize i = 0; i < size; ++i) {
+    r_obj* const elt = p_x[i];
+
+    if (str_is_normalised(elt)) {
+      continue;
+    }
+
+    return i;
+  }
+
+  return size;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+r_obj* list_normalise_encoding(r_obj* x) {
+  r_keep_t pi;
+  KEEP_HERE(x, &pi);
+
+  r_ssize size = r_length(x);
+  r_obj* const* p_x = r_list_cbegin(x);
+
+  for (r_ssize i = 0; i < size; ++i) {
+    r_obj* const elt_old = p_x[i];
+
+    r_obj* const elt_new = r_normalise_encoding(elt_old);
+    if (elt_old == elt_new) {
+      continue;
+    }
+    KEEP(elt_new);
+
+    if (r_is_shared(x)) {
+      // Cloned once, at which point `x` is free of references
+      x = r_clone(x);
+      KEEP_AT(x, pi);
+      p_x = r_list_cbegin(x);
+    }
+
+    r_list_poke(x, i, elt_new);
+    FREE(1);
+  }
+
+  FREE(1);
+  return x;
+}
+
+// -----------------------------------------------------------------------------
+
+static
+r_obj* r_attrib_normalise_encoding(r_obj* x, r_obj* attrib) {
+  r_obj* attrib_new = attrib_normalise_encoding(attrib);
+  if (attrib_new == attrib) {
+    return x;
+  }
+  KEEP(attrib_new);
+
+  x = KEEP(r_clone_shared(x));
+  r_poke_attrib(x, attrib_new);
+
+  FREE(2);
+  return x;
+}
+
+static
+r_obj* attrib_normalise_encoding(r_obj* x) {
+  r_ssize loc = 0;
+  bool owned = false;
+
+  r_keep_t pi;
+  KEEP_HERE(x, &pi);
+
+  for (r_obj* node = x; node != r_null; node = r_node_cdr(node), ++loc) {
+    r_obj* elt_old = r_node_car(node);
+
+    r_obj* elt_new = r_normalise_encoding(elt_old);
+    if (elt_old == elt_new) {
+      continue;
+    }
+    KEEP(elt_new);
+
+    if (!owned) {
+      // Shallow clone entire pairlist if not owned.
+      // Should be fast because these are generally short.
+      x = r_clone(x);
+      KEEP_AT(x, pi);
+      owned = true;
+
+      node = x;
+
+      // Restore original positioning post-clone
+      for (r_ssize i = 0; i < loc; ++i) {
+        node = r_node_cdr(node);
+      }
+    }
+
+    r_node_poke_car(node, elt_new);
+    FREE(1);
+  }
+
+  FREE(1);
+  return x;
+}
+
+// -----------------------------------------------------------------------------
+
+static inline
+r_obj* str_normalise(r_obj* x) {
+  return r_str(Rf_translateCharUTF8(x));
+}
+
+static inline
+bool str_is_normalised(r_obj* x) {
+  return str_is_ascii_or_utf8(x) || (x == NA_STRING);
+}
+
+#define MASK_ASCII 8
+#define MASK_UTF8 64
+
+// The first 128 values are ASCII, and are the same regardless of the encoding.
+// Otherwise we enforce UTF-8.
+static inline
+bool str_is_ascii_or_utf8(r_obj* x) {
+  const int levels = LEVELS(x);
+  return (levels & MASK_ASCII) || (levels & MASK_UTF8);
+}
+
+#undef MASK_ASCII
+#undef MASK_UTF8

--- a/src/internal/encoding.h
+++ b/src/internal/encoding.h
@@ -1,0 +1,32 @@
+#ifndef RLANG_INTERNAL_ENCODING_H
+#define RLANG_INTERNAL_ENCODING_H
+
+
+/*
+ * Recursively normalise encodings of character vectors.
+ *
+ * A CHARSXP is considered normalised if:
+ * - It is the NA_STRING
+ * - It is ASCII, which means the encoding will be unmarked
+ * - It is marked as UTF-8
+ *
+ * Attributes are normalised as well.
+ *
+ * ASCII strings will never get marked with an encoding when they go
+ * through `Rf_mkCharLenCE()`, but they will get marked as ASCII. Since
+ * UTF-8 is fully compatible with ASCII, they are treated like UTF-8.
+ *
+ * This converts vectors that are completely marked as Latin-1 to UTF-8, rather
+ * than leaving them as Latin-1. This ensures that two vectors can be compared
+ * consistently if they have both been normalised.
+ *
+ * Bytes-encoded vectors are not supported, as they cannot be
+ * converted to UTF-8 by `Rf_translateCharUTF8()`.
+ *
+ * If `x` is not shared (i.e. `r_is_shared(x) == false`), this function will
+ * modify `x` in place. Otherwise, a copy is made.
+ */
+r_obj* r_normalise_encoding(r_obj* x);
+
+
+#endif

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -182,6 +182,7 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_test_lgl_sum",                 (DL_FUNC) &ffi_test_lgl_sum, 2},
   {"ffi_test_lgl_which",               (DL_FUNC) &ffi_test_lgl_which, 2},
   {"ffi_test_node_list_clone_until",   (DL_FUNC) &ffi_test_node_list_clone_until, 2},
+  {"ffi_test_normalise_encoding",      (DL_FUNC) &r_normalise_encoding, 1},
   {"ffi_test_parse",                   (DL_FUNC) &ffi_test_parse, 1},
   {"ffi_test_parse_eval",              (DL_FUNC) &ffi_test_parse_eval, 2},
   {"ffi_test_r_on_exit",               (DL_FUNC) &r_on_exit, 2},

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -253,6 +253,7 @@ void R_init_rlang(DllInfo* dll) {
   R_RegisterCCallable("rlang", "rlang_env_dots_list",       (DL_FUNC) &ffi_env_dots_list);
   R_RegisterCCallable("rlang", "rlang_env_dots_values",     (DL_FUNC) &ffi_env_dots_values);
   R_RegisterCCallable("rlang", "rlang_is_splice_box",       (DL_FUNC) &is_splice_box);
+  R_RegisterCCallable("rlang", "rlang_normalise_encoding",  (DL_FUNC) &r_normalise_encoding);
   R_RegisterCCallable("rlang", "rlang_str_as_symbol",       (DL_FUNC) &r_str_as_symbol);
   R_RegisterCCallable("rlang", "rlang_sym_as_character",    (DL_FUNC) &ffi_sym_as_character);
   R_RegisterCCallable("rlang", "rlang_unbox",               (DL_FUNC) &rlang_unbox);

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -7,6 +7,7 @@
 #include "call.c"
 #include "dots.c"
 #include "dots-ellipsis.c"
+#include "encoding.c"
 #include "env.c"
 #include "env-binding.c"
 #include "eval.c"

--- a/src/rlang/obj.c
+++ b/src/rlang/obj.c
@@ -86,6 +86,9 @@ r_obj* r_obj_address(r_obj* x) {
   return Rf_mkChar(buf);
 }
 
+r_obj* (*r_obj_fix_encoding)(r_obj* x) = NULL;
+
+
 void r_init_library_obj(r_obj* ns) {
   p_precious_dict = r_new_dict(PRECIOUS_DICT_INIT_SIZE);
   KEEP(p_precious_dict->shelter);
@@ -98,4 +101,6 @@ void r_init_library_obj(r_obj* ns) {
   if (null_addr[0] != '0' || null_addr[1] != 'x') {
     obj_address_formatter = "0x%p";
   }
+
+  r_obj_fix_encoding = (r_obj* (*)(r_obj*)) r_peek_c_callable("rlang", "rlang_normalise_encoding");
 }

--- a/src/rlang/obj.h
+++ b/src/rlang/obj.h
@@ -59,6 +59,10 @@ static inline
 r_obj* r_clone(r_obj* x) {
   return Rf_shallow_duplicate(x);
 }
+static inline
+r_obj* r_clone_shared(r_obj* x) {
+  return r_is_shared(x) ? r_clone(x) : x;
+}
 
 static inline
 r_obj* r_poke_type(r_obj* x, enum r_type type) {

--- a/src/rlang/obj.h
+++ b/src/rlang/obj.h
@@ -112,4 +112,8 @@ bool r_is_identical(r_obj* x, r_obj* y) {
 
 r_obj* r_obj_address(r_obj* x);
 
+
+extern r_obj* (*r_obj_fix_encoding)(r_obj* x);
+
+
 #endif

--- a/tests/testthat/_snaps/c-api.md
+++ b/tests/testthat/_snaps/c-api.md
@@ -1,0 +1,28 @@
+# normalisation fails purposefully with any bytes
+
+    Code
+      (expect_error(r_normalise_encoding(bytes)))
+    Output
+      <simpleError in r_normalise_encoding(bytes): translating strings with "bytes" encoding is not allowed>
+
+---
+
+    Code
+      (expect_error(r_normalise_encoding(c(enc, bytes))))
+    Output
+      <simpleError in r_normalise_encoding(c(enc, bytes)): translating strings with "bytes" encoding is not allowed>
+
+---
+
+    Code
+      (expect_error(r_normalise_encoding(c(enc, bytes))))
+    Output
+      <simpleError in r_normalise_encoding(c(enc, bytes)): translating strings with "bytes" encoding is not allowed>
+
+---
+
+    Code
+      (expect_error(r_normalise_encoding(c(enc, bytes))))
+    Output
+      <simpleError in r_normalise_encoding(c(enc, bytes)): translating strings with "bytes" encoding is not allowed>
+

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -16,3 +16,19 @@ r_lgl_which <- function(x, na_propagate) {
   stopifnot(is_logical(x), is_bool(na_propagate))
   .Call(ffi_test_lgl_which, x, na_propagate)
 }
+
+r_normalise_encoding <- function(x) {
+  .Call(ffi_test_normalise_encoding, x)
+}
+test_encodings <- function() {
+  string <- "\u00B0C"
+
+  utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
+  latin1 <- iconv(string, from = Encoding(string), to = "latin1")
+
+  list(utf8 = utf8, unknown = unknown, latin1 = latin1)
+}
+expect_utf8_encoded <- function(object) {
+  expect_identical(Encoding(object), rep("UTF-8", length(object)))
+}

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -1109,7 +1109,7 @@ test_that("normalisation treats data frames elements of lists as lists (r-lib/vc
   encs <- test_encodings()
   a <- c(encs$utf8, encs$latin1)
 
-  df <- data.frame(a = a, b = 1:2)
+  df <- data.frame(a = a, b = 1:2, stringsAsFactors = FALSE)
   x <- list(df)
 
   result <- r_normalise_encoding(x)

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -1041,6 +1041,135 @@ test_that("addresses have hexadecimal prefix `0x` (#1135)", {
   )
 })
 
+test_that("can normalise a character vector of various encodings (r-lib/vctrs#553)", {
+  x <- unlist(test_encodings(), use.names = FALSE)
+  results <- r_normalise_encoding(x)
+  expect_utf8_encoded(results)
+})
+
+test_that("normalises all encodings to UTF-8", {
+  for (enc in test_encodings()) {
+    expect_utf8_encoded(r_normalise_encoding(enc))
+  }
+})
+
+test_that("can normalise a list containing character vectors with different encodings", {
+  results <- r_normalise_encoding(test_encodings())
+  results <- unlist(results)
+  expect_utf8_encoded(results)
+})
+
+test_that("normalisation fails purposefully with any bytes", {
+  bytes <- rawToChar(as.raw(0xdc))
+  Encoding(bytes) <- "bytes"
+
+  expect_snapshot(
+    (expect_error(r_normalise_encoding(bytes)))
+  )
+
+  for (enc in test_encodings()) {
+    expect_snapshot(
+      (expect_error(r_normalise_encoding(c(enc, bytes))))
+    )
+  }
+})
+
+test_that("attributes are kept on normalisation (r-lib/vctrs#599)", {
+  encs <- test_encodings()
+
+  x <- c(encs$utf8, encs$latin1)
+  x <- structure(x, names = c("a", "b"), extra = 1)
+
+  expect_identical(attributes(r_normalise_encoding(x)), attributes(x))
+})
+
+test_that("normalisation is robust against scalar types contained in lists (r-lib/vctrs#633)", {
+  x <- list(a = z ~ y, b = z ~ z)
+  expect_identical(r_normalise_encoding(x), x)
+})
+
+test_that("normalisation can still occur even if a scalar type is in a list", {
+  x <- list(a = z ~ y, b = test_encodings()$latin1)
+  expect_utf8_encoded(r_normalise_encoding(x)$b)
+})
+
+test_that("normalisation occurs inside scalars contained in a list", {
+  encs <- test_encodings()
+
+  x <- list(
+    structure(list(x = encs$latin1), class = "scalar_list")
+  )
+
+  result <- r_normalise_encoding(x)
+
+  expect_utf8_encoded(result[[1]]$x)
+})
+
+test_that("normalisation treats data frames elements of lists as lists (r-lib/vctrs#1233)", {
+  encs <- test_encodings()
+  a <- c(encs$utf8, encs$latin1)
+
+  df <- data.frame(a = a, b = 1:2)
+  x <- list(df)
+
+  result <- r_normalise_encoding(x)
+
+  expect_utf8_encoded(result[[1]]$a)
+})
+
+test_that("attributes are normalised", {
+  utf8 <- test_encodings()$utf8
+  latin1 <- test_encodings()$latin1
+
+  a <- structure(1, enc = utf8)
+  b <- structure(1, enc = latin1)
+  c <- structure(1, enc1 = utf8, enc2 = list(latin1), enc3 = latin1)
+  x <- list(a, b, c)
+
+  result <- r_normalise_encoding(x)
+
+  a_enc <- attr(result[[1]], "enc")
+  b_enc <- attr(result[[2]], "enc")
+  c_enc1 <- attr(result[[3]], "enc1")
+  c_enc2 <- attr(result[[3]], "enc2")[[1]]
+  c_enc3 <- attr(result[[3]], "enc3")
+
+  expect_utf8_encoded(a_enc)
+  expect_utf8_encoded(b_enc)
+  expect_utf8_encoded(c_enc1)
+  expect_utf8_encoded(c_enc2)
+  expect_utf8_encoded(c_enc3)
+})
+
+test_that("attributes are normalised recursively", {
+  utf8 <- test_encodings()$utf8
+  latin1 <- test_encodings()$latin1
+
+  nested <- structure(1, latin1 = latin1)
+  x <- structure(2, nested = nested, foo = 1, latin1 = latin1)
+
+  result <- r_normalise_encoding(x)
+  attrib <- attributes(result)
+  attrib_nested <- attributes(attrib$nested)
+
+  expect_utf8_encoded(attrib$latin1)
+  expect_utf8_encoded(attrib_nested$latin1)
+})
+
+test_that("NAs aren't normalised to 'NA' (r-lib/vctrs#1291)", {
+  utf8 <- c(NA, test_encodings()$utf8)
+  latin1 <- c(NA, test_encodings()$latin1)
+
+  result1 <- r_normalise_encoding(utf8)
+  result2 <- r_normalise_encoding(latin1)
+
+  expect_identical(result1[[1]], NA_character_)
+  expect_identical(result2[[1]], NA_character_)
+
+  expect_utf8_encoded(result1[[2]])
+  expect_utf8_encoded(result2[[2]])
+})
+
 local({
   df <- c_tests()
   for (i in seq_len(nrow(df))) {


### PR DESCRIPTION
Pulled over from https://github.com/r-lib/vctrs/blob/master/src/translate.c

I've left in the maybe-referenced copy semantics, as that seems to work best with vctrs.

Otherwise, I've done minor tweaks to use more of the rlang lib, but nothing major.

I've pulled in all the relevant tests from vctrs, with a few testthat utilities. There are quite a few tests, but I went through each one and none of them feel redundant. I think they are required to ensure we hit all the code paths, but we could move them out of `test-c-api.R` if you feel it clutters it too much.