### PR TITLE
Add legacy support for `peek_option("rlang:::message_always")`

### DIFF
--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -227,6 +227,10 @@ needs_signal <- function(frequency, id, env, opt) {
   if (is_string(frequency, "always")) {
     return(TRUE)
   }
+  # Safe to remove in 2022
+  if (is_true(peek_option("rlang:::message_always"))) {
+    return(TRUE)
+  }
 
   if (is_null(id)) {
     abort("`.frequency_id` should be supplied with `.frequency`.")


### PR DESCRIPTION
https://github.com/r-lib/rlang/pull/1188 removed support for `rlang:::message_always`. 

Currently, CRAN version of `shiny` has a test that is using this option.  The test has been updated https://github.com/rstudio/shiny/pull/3379 for the next regular release of shiny.

I suggested a date of 2022. Shiny should be released by then. Feel free to change the comment / time.

-----------------

If you'd rather not take the PR, we could make a patch release for `shiny` to disable the test. I'd prefer to **not** go down that route.

Thank you!

cc @cpsievert