### PR TITLE
Add `repair_auto` and `repair_quiet` to `exprs_auto_name()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `exprs_auto_name()` gains a `repair_auto` argument to make automatic
+  names unique (#1116).
+
 * The `.named` argument of `dots_list()` can now be set to `NULL` to
   give the result default names. With this option, fully unnamed
   inputs produce a fully unnamed result with `NULL` names instead of a

--- a/R/attr.R
+++ b/R/attr.R
@@ -76,6 +76,7 @@ have_name <- function(x) {
     !detect_void_name(nms)
   }
 }
+detect_named <- have_name
 
 detect_void_name <- function(x) {
   x == "" | is.na(x)

--- a/man/exprs_auto_name.Rd
+++ b/man/exprs_auto_name.Rd
@@ -5,19 +5,35 @@
 \alias{quos_auto_name}
 \title{Ensure that all elements of a list of expressions are named}
 \usage{
-exprs_auto_name(exprs, width = NULL, printer = NULL)
+exprs_auto_name(
+  exprs,
+  ...,
+  repair_auto = c("minimal", "unique"),
+  repair_quiet = FALSE,
+  width = deprecated(),
+  printer = deprecated()
+)
 
 quos_auto_name(quos, width = NULL)
 }
 \arguments{
 \item{exprs}{A list of expressions.}
 
-\item{width}{Deprecated. Maximum width of names.}
+\item{...}{These dots are for future extensions and must be empty.}
 
-\item{printer}{Deprecated. A function that takes an expression
-and converts it to a string. This function must take an
-expression as the first argument and \code{width} as the second
-argument.}
+\item{repair_auto}{Whether to repair the automatic names. By
+default, minimal names are returned. See \code{?vctrs::vec_as_names}
+for information about name repairing.}
+
+\item{repair_quiet}{Whether to inform user about repaired names.}
+
+\item{width}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Maximum width of
+names.}
+
+\item{printer}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} A function that
+takes an expression and converts it to a string. This function
+must take an expression as the first argument and \code{width} as the
+second argument.}
 
 \item{quos}{A list of quosures.}
 }

--- a/tests/testthat/_snaps/nse-defuse.md
+++ b/tests/testthat/_snaps/nse-defuse.md
@@ -1,0 +1,17 @@
+# auto-named expressions can be unique-repaired
+
+    Code
+      expect_equal(dots_names(1, foo = 1, 1, foo = 2), c("1...1", "foo", "1...3",
+        "foo"))
+    Message <message>
+      New names:
+      * 1 -> 1...1
+      * 1 -> 1...3
+    Code
+      expect_equal(dots_names(bar, foo = 1, bar, foo = 2), c("bar...1", "foo",
+        "bar...3", "foo"))
+    Message <message>
+      New names:
+      * `bar` -> `bar...1`
+      * `bar` -> `bar...3`
+

--- a/tests/testthat/test-nse-defuse.R
+++ b/tests/testthat/test-nse-defuse.R
@@ -570,3 +570,23 @@ test_that("`defer()` does not crash with environments containing quosures (#1085
   }
   expect_no_error(f()) # No crash
 })
+
+test_that("auto-named expressions can be unique-repaired", {
+  dots_names <- function(...) {
+    dots <- enquos(...)
+    dots <- exprs_auto_name(dots, repair_auto = "unique")
+    names(dots)
+  }
+
+  expect_snapshot({
+    expect_equal(
+      dots_names(1, foo = 1, 1, foo = 2),
+      c("1...1", "foo", "1...3", "foo")
+    )
+
+    expect_equal(
+      dots_names(bar, foo = 1, bar, foo = 2),
+      c("bar...1", "foo", "bar...3", "foo")
+    )
+  })
+})


### PR DESCRIPTION
Branched from #1193.
Closes #1116.

`exprs_auto_name()` gains a `repair_auto` argument to repair the automatic names. The non-automatic names are never repaired (if that is needed, just repair the whole vector separately):

```r
dots_names <- function(...) {
  dots <- enquos(...)
  dots <- exprs_auto_name(dots, repair_auto = "unique")
  names(dots)
}

dots_names(bar, foo = 1, bar, foo = 2)
#> New names:
#> • `bar` -> `bar...1`
#> • `bar` -> `bar...3`
#> [1] "bar...1" "foo"     "bar...3" "foo"
```

The message can be disabled with the `repair_quiet` argument. Currently only unique repairing is possible as universal repairing is still implemented in vctrs.

Because of potential issues of backward-compatibility , the default is set to `"minimal"`, the same behaviour as before. This way we can try out the unique repair in individual packages before deciding to change the default.