### PR TITLE
Prompt user for outdated downstream deps

### DIFF
--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -124,7 +124,10 @@ check_downstream <- function(ver, ..., with_rlang = requireNamespace("rlang")) {
     return()
   }
 
-  prompt <- c("!" = sprintf("Would you like to update the package %s now?", dep_pkg))
+  prompt <- c(
+    "!" = sprintf("Would you like to update the package %s now?", dep_pkg),
+    " " = "You will likely need to reload R if you update now."
+  )
   inform(c(header, info_pkg, prompt))
 
   if (utils::menu(c("Yes", "No")) != 1) {

--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -49,6 +49,7 @@ check_downstream <- function(ver, ..., with_rlang = requireNamespace("rlang")) {
   # Must be `lapply()` instead of a `for` loop so that each `dep` is
   # bound to its own closure env
   lapply(deps, function(dep) {
+    force(dep)
     on_package_load(
       dep[["pkg"]],
       .rlang_downstream_check(pkg, ver, dep, with_rlang = with_rlang)

--- a/R/compat-downstream-dep.R
+++ b/R/compat-downstream-dep.R
@@ -158,7 +158,7 @@ check_downstream <- function(ver, ..., with_rlang = requireNamespace("rlang")) {
   }
   prompt <- c(
     "!" = question,
-    " " = "You will likely need to reload R if you update now."
+    " " = "You will likely need to restart R if you update now."
   )
   inform(c(header, prompt))
 

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -3,7 +3,12 @@
 
 on_load({
   check_downstream("0.4.0", "dplyr (>= 0.8.0)")
-  check_downstream("0.5.0", "ellipsis (>= 0.3.2)")
+  check_downstream(
+    "0.5.0",
+    "ellipsis (>= 0.3.2)",
+    "vctrs (>= 0.3.8)",
+    info = "Not updating now is completely safe and will only cause import warnings."
+  )
 })
 
 .rlang_use_cli_format <- "try"

--- a/R/rlang.R
+++ b/R/rlang.R
@@ -2,10 +2,8 @@
 "_PACKAGE"
 
 on_load({
-  check_downstream(
-    "0.4.0",
-    "dplyr (>= 0.8.0)"
-  )
+  check_downstream("0.4.0", "dplyr (>= 0.8.0)")
+  check_downstream("0.5.0", "ellipsis (>= 0.3.2)")
 })
 
 .rlang_use_cli_format <- "try"


### PR DESCRIPTION
User is now prompted to update outdated dependencies when they are loaded in the session:

```r
As of rlang 0.4.11.9000, pkgFoo must be at least version 1.0.0.
x pkgFoo 0.1.0 is too old for rlang 0.4.11.9000.
! Would you like to update the package pkgFoo now?

1: Yes
2: No

Selection: 
```

If they accept, the package is installed with pak if available. If they decline, they are informed about a global option to turn off the checks. This should be useful for users who are not able to update right away:

```r
> Selection: 2
Set `options(rlib_downstream_check = FALSE)` to disable this prompt.
```

In non-interactive sessions, the usual warning is displayed:

```r
Warning message:
As of rlang 0.4.11.9000, pkgFoo must be at least version 1.0.0.
x pkgFoo 0.1.0 is too old for rlang 0.4.11.9000.
i Please update pkgFoo with `install.packages("pkgFoo")` and restart R. 
```

Added ellipsis 0.3.2 as a requirement to avoid import warnings for `check_dots_empty()` etc. This uses the new UI based on the DESCRIPTION syntax (implemented outside this PR):

```r
on_load({
  check_downstream("0.5.0", "ellipsis (>= 0.3.2)")
})
```