### PR TITLE
Flesh out `compat-cli.R`

### DIFF
--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -25,17 +25,17 @@
 #' @param x A string.
 #'
 #' @noRd
-ansi_red       <- function(x) if (.rlang_cli_has_cli()) cli::col_red(x) else x
-ansi_blue      <- function(x) if (.rlang_cli_has_cli()) cli::col_blue(x) else x
-ansi_green     <- function(x) if (.rlang_cli_has_cli()) cli::col_green(x) else x
-ansi_yellow    <- function(x) if (.rlang_cli_has_cli()) cli::col_yellow(x) else x
-ansi_magenta   <- function(x) if (.rlang_cli_has_cli()) cli::col_magenta(x) else x
-ansi_cyan      <- function(x) if (.rlang_cli_has_cli()) cli::col_cyan(x) else x
-ansi_silver    <- function(x) if (.rlang_cli_has_cli()) cli::col_silver(x) else x
-ansi_blurred   <- function(x) if (.rlang_cli_has_cli()) cli::style_blurred(x) else x
-ansi_bold      <- function(x) if (.rlang_cli_has_cli()) cli::style_bold(x) else x
-ansi_italic    <- function(x) if (.rlang_cli_has_cli()) cli::style_italic(x) else x
-ansi_underline <- function(x) if (.rlang_cli_has_cli()) cli::style_underline(x) else x
+ansi_red       <- function(x) if (.rlang_cli_has_ansi()) cli::col_red(x) else x
+ansi_blue      <- function(x) if (.rlang_cli_has_ansi()) cli::col_blue(x) else x
+ansi_green     <- function(x) if (.rlang_cli_has_ansi()) cli::col_green(x) else x
+ansi_yellow    <- function(x) if (.rlang_cli_has_ansi()) cli::col_yellow(x) else x
+ansi_magenta   <- function(x) if (.rlang_cli_has_ansi()) cli::col_magenta(x) else x
+ansi_cyan      <- function(x) if (.rlang_cli_has_ansi()) cli::col_cyan(x) else x
+ansi_silver    <- function(x) if (.rlang_cli_has_ansi()) cli::col_silver(x) else x
+ansi_blurred   <- function(x) if (.rlang_cli_has_ansi()) cli::style_blurred(x) else x
+ansi_bold      <- function(x) if (.rlang_cli_has_ansi()) cli::style_bold(x) else x
+ansi_italic    <- function(x) if (.rlang_cli_has_ansi()) cli::style_italic(x) else x
+ansi_underline <- function(x) if (.rlang_cli_has_ansi()) cli::style_underline(x) else x
 
 style_emph   <- function(x) .rlang_cli_style(x, "emph", "_%s_")
 style_strong <- function(x) .rlang_cli_style(x, "strong", "*%s*")
@@ -71,7 +71,7 @@ style_cls <- function(x) {
   }
 }
 
-.rlang_cli_has_cli <- function() {
+.rlang_cli_has_ansi <- function() {
   requireNamespace("cli") && cli::num_ansi_colors() > 1
 }
 

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -6,8 +6,36 @@
 # used to format the elements. Otherwise a fallback format is used.
 #
 # Changelog:
+#
+# 2021-05-18:
+#
+# * Added `ansi_` functions to apply ANSI styling (colours, slant, weight).
+#
+#
 # 2021-05-11:
+#
 # * Initial version.
+
+
+#' Apply ANSI styling
+#'
+#' The `ansi_` functions style their inputs using the relevant ANSI
+#' escapes if cli is installed and ANSI colours are enabled.
+#'
+#' @param x A string.
+#'
+#' @noRd
+ansi_red       <- function(x) if (.rlang_cli_has_cli()) cli::col_red(x) else x
+ansi_blue      <- function(x) if (.rlang_cli_has_cli()) cli::col_blue(x) else x
+ansi_green     <- function(x) if (.rlang_cli_has_cli()) cli::col_green(x) else x
+ansi_yellow    <- function(x) if (.rlang_cli_has_cli()) cli::col_yellow(x) else x
+ansi_magenta   <- function(x) if (.rlang_cli_has_cli()) cli::col_magenta(x) else x
+ansi_cyan      <- function(x) if (.rlang_cli_has_cli()) cli::col_cyan(x) else x
+ansi_silver    <- function(x) if (.rlang_cli_has_cli()) cli::col_silver(x) else x
+ansi_blurred   <- function(x) if (.rlang_cli_has_cli()) cli::style_blurred(x) else x
+ansi_bold      <- function(x) if (.rlang_cli_has_cli()) cli::style_bold(x) else x
+ansi_italic    <- function(x) if (.rlang_cli_has_cli()) cli::style_italic(x) else x
+ansi_underline <- function(x) if (.rlang_cli_has_cli()) cli::style_underline(x) else x
 
 style_emph   <- function(x) .rlang_cli_style(x, "emph", "_%s_")
 style_strong <- function(x) .rlang_cli_style(x, "strong", "*%s*")
@@ -41,6 +69,10 @@ style_cls <- function(x) {
   } else {
     sprintf(fallback, x)
   }
+}
+
+.rlang_cli_has_cli <- function() {
+  requireNamespace("cli") && cli::num_ansi_colors() > 1
 }
 
 # nocov end

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -9,12 +9,38 @@
 #
 # 2021-05-18:
 #
+# * Added `symbol_` and corresponding `ansi_` functions to create
+#   unicode symbols if possible. The `ansi_` variants apply default
+#   colours to these symbols if possible.
+#
 # * Added `ansi_` functions to apply ANSI styling (colours, slant, weight).
 #
 #
 # 2021-05-11:
 #
 # * Initial version.
+
+
+#' Create unicode symbols
+#'
+#' The `symbol_` functions generate Unicode symbols if cli is
+#' installed and Unicode is enabled. The corresponding `ansi_`
+#' functions apply default ANSI colours to these symbols if possible.
+#'
+#' @noRd
+symbol_info   <- function() if (requireNamespace("cli")) cli::symbol$info else "i"
+symbol_cross  <- function() if (requireNamespace("cli")) cli::symbol$cross else "x"
+symbol_tick   <- function() if (requireNamespace("cli")) cli::symbol$tick else "v"
+symbol_bullet <- function() if (requireNamespace("cli")) cli::symbol$bullet else "*"
+symbol_arrow  <- function() if (requireNamespace("cli")) cli::symbol$arrow_right else ">"
+symbol_alert  <- function() "!"
+
+ansi_info   <- function() ansi_blue(symbol_info())
+ansi_cross  <- function() ansi_red(symbol_cross())
+ansi_tick   <- function() ansi_green(symbol_tick())
+ansi_bullet <- function() ansi_cyan(symbol_bullet())
+ansi_arrow  <- function() symbol_arrow()
+ansi_alert  <- function() ansi_yellow(symbol_alert())
 
 
 #' Apply ANSI styling

--- a/tests/testthat/_snaps/compat-cli.md
+++ b/tests/testthat/_snaps/compat-cli.md
@@ -148,3 +148,108 @@
     Output
       [1] "\033[1m\033[22m\033[34m\033[34m<foo/bar>\033[34m\033[39m"
 
+# can apply ANSI styles with cli [plain]
+
+    Code
+      ansi_red("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_blue("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_green("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_yellow("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_magenta("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_cyan("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_silver("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_blurred("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_bold("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_italic("foo")
+    Output
+      [1] "foo"
+    Code
+      ansi_underline("foo")
+    Output
+      [1] "foo"
+
+# can apply ANSI styles with cli [ansi]
+
+    Code
+      ansi_red("foo")
+    Output
+      <ansi_string>
+      [1] [31mfoo[39m
+    Code
+      ansi_blue("foo")
+    Output
+      <ansi_string>
+      [1] [34mfoo[39m
+    Code
+      ansi_green("foo")
+    Output
+      <ansi_string>
+      [1] [32mfoo[39m
+    Code
+      ansi_yellow("foo")
+    Output
+      <ansi_string>
+      [1] [33mfoo[39m
+    Code
+      ansi_magenta("foo")
+    Output
+      <ansi_string>
+      [1] [35mfoo[39m
+    Code
+      ansi_cyan("foo")
+    Output
+      <ansi_string>
+      [1] [36mfoo[39m
+    Code
+      ansi_silver("foo")
+    Output
+      <ansi_string>
+      [1] [90mfoo[39m
+    Code
+      ansi_blurred("foo")
+    Output
+      <ansi_string>
+      [1] [2mfoo[22m
+    Code
+      ansi_bold("foo")
+    Output
+      <ansi_string>
+      [1] [1mfoo[22m
+    Code
+      ansi_italic("foo")
+    Output
+      <ansi_string>
+      [1] [3mfoo[23m
+    Code
+      ansi_underline("foo")
+    Output
+      <ansi_string>
+      [1] [4mfoo[24m
+

--- a/tests/testthat/_snaps/compat-cli.md
+++ b/tests/testthat/_snaps/compat-cli.md
@@ -253,3 +253,229 @@
       <ansi_string>
       [1] [4mfoo[24m
 
+# can create symbols with cli [plain]
+
+    Code
+      symbol_info()
+    Output
+      [1] "i"
+    Code
+      symbol_cross()
+    Output
+      [1] "x"
+    Code
+      symbol_tick()
+    Output
+      [1] "v"
+    Code
+      symbol_bullet()
+    Output
+      [1] "*"
+    Code
+      symbol_arrow()
+    Output
+      [1] ">"
+    Code
+      symbol_alert()
+    Output
+      [1] "!"
+
+# can create symbols with cli [ansi]
+
+    Code
+      symbol_info()
+    Output
+      [1] "i"
+    Code
+      symbol_cross()
+    Output
+      [1] "x"
+    Code
+      symbol_tick()
+    Output
+      [1] "v"
+    Code
+      symbol_bullet()
+    Output
+      [1] "*"
+    Code
+      symbol_arrow()
+    Output
+      [1] ">"
+    Code
+      symbol_alert()
+    Output
+      [1] "!"
+
+# can create symbols with cli [unicode]
+
+    Code
+      symbol_info()
+    Output
+      [1] "ℹ"
+    Code
+      symbol_cross()
+    Output
+      [1] "✖"
+    Code
+      symbol_tick()
+    Output
+      [1] "✔"
+    Code
+      symbol_bullet()
+    Output
+      [1] "•"
+    Code
+      symbol_arrow()
+    Output
+      [1] "→"
+    Code
+      symbol_alert()
+    Output
+      [1] "!"
+
+# can create symbols with cli [fancy]
+
+    Code
+      symbol_info()
+    Output
+      [1] "ℹ"
+    Code
+      symbol_cross()
+    Output
+      [1] "✖"
+    Code
+      symbol_tick()
+    Output
+      [1] "✔"
+    Code
+      symbol_bullet()
+    Output
+      [1] "•"
+    Code
+      symbol_arrow()
+    Output
+      [1] "→"
+    Code
+      symbol_alert()
+    Output
+      [1] "!"
+
+# can create ANSI symbols with cli [plain]
+
+    Code
+      ansi_info()
+    Output
+      [1] "i"
+    Code
+      ansi_cross()
+    Output
+      [1] "x"
+    Code
+      ansi_tick()
+    Output
+      [1] "v"
+    Code
+      ansi_bullet()
+    Output
+      [1] "*"
+    Code
+      ansi_arrow()
+    Output
+      [1] ">"
+    Code
+      ansi_alert()
+    Output
+      [1] "!"
+
+# can create ANSI symbols with cli [ansi]
+
+    Code
+      ansi_info()
+    Output
+      <ansi_string>
+      [1] [34mi[39m
+    Code
+      ansi_cross()
+    Output
+      <ansi_string>
+      [1] [31mx[39m
+    Code
+      ansi_tick()
+    Output
+      <ansi_string>
+      [1] [32mv[39m
+    Code
+      ansi_bullet()
+    Output
+      <ansi_string>
+      [1] [36m*[39m
+    Code
+      ansi_arrow()
+    Output
+      [1] ">"
+    Code
+      ansi_alert()
+    Output
+      <ansi_string>
+      [1] [33m![39m
+
+# can create ANSI symbols with cli [unicode]
+
+    Code
+      ansi_info()
+    Output
+      [1] "ℹ"
+    Code
+      ansi_cross()
+    Output
+      [1] "✖"
+    Code
+      ansi_tick()
+    Output
+      [1] "✔"
+    Code
+      ansi_bullet()
+    Output
+      [1] "•"
+    Code
+      ansi_arrow()
+    Output
+      [1] "→"
+    Code
+      ansi_alert()
+    Output
+      [1] "!"
+
+# can create ANSI symbols with cli [fancy]
+
+    Code
+      ansi_info()
+    Output
+      <ansi_string>
+      [1] [34mℹ[39m
+    Code
+      ansi_cross()
+    Output
+      <ansi_string>
+      [1] [31m✖[39m
+    Code
+      ansi_tick()
+    Output
+      <ansi_string>
+      [1] [32m✔[39m
+    Code
+      ansi_bullet()
+    Output
+      <ansi_string>
+      [1] [36m•[39m
+    Code
+      ansi_arrow()
+    Output
+      [1] "→"
+    Code
+      ansi_alert()
+    Output
+      <ansi_string>
+      [1] [33m![39m
+

--- a/tests/testthat/test-compat-cli.R
+++ b/tests/testthat/test-compat-cli.R
@@ -26,3 +26,19 @@ cli::test_that_cli(configs = c("plain", "ansi"), "can style strings with cli", {
 cli::test_that_cli(configs = "plain", "styled strings may contain `{` syntax", {
   expect_equal(style_emph("{foo {}"), "_{foo {}_")
 })
+
+cli::test_that_cli(configs = c("plain", "ansi"), "can apply ANSI styles with cli", {
+  expect_snapshot({
+    ansi_red("foo")
+    ansi_blue("foo")
+    ansi_green("foo")
+    ansi_yellow("foo")
+    ansi_magenta("foo")
+    ansi_cyan("foo")
+    ansi_silver("foo")
+    ansi_blurred("foo")
+    ansi_bold("foo")
+    ansi_italic("foo")
+    ansi_underline("foo")
+  })
+})

--- a/tests/testthat/test-compat-cli.R
+++ b/tests/testthat/test-compat-cli.R
@@ -42,3 +42,25 @@ cli::test_that_cli(configs = c("plain", "ansi"), "can apply ANSI styles with cli
     ansi_underline("foo")
   })
 })
+
+cli::test_that_cli("can create symbols with cli", {
+  expect_snapshot({
+    symbol_info()
+    symbol_cross()
+    symbol_tick()
+    symbol_bullet()
+    symbol_arrow()
+    symbol_alert()
+  })
+})
+
+cli::test_that_cli("can create ANSI symbols with cli", {
+  expect_snapshot({
+    ansi_info()
+    ansi_cross()
+    ansi_tick()
+    ansi_bullet()
+    ansi_arrow()
+    ansi_alert()
+  })
+})


### PR DESCRIPTION
* Add `ansi_` functions for colours and typography.

* Add `symbol_` and corresponding `ansi_` functions for unicode symbols. The `ansi_` variants apply a default colour to the symbol (e.g. red for crosses).

Some of the functions prefixed with `ansi_` in the compat file are prefixed with `style_` in the cli API. This inconsistency is deliberate because  #1213 reserves the `style_` prefix for styler functions that must be paired with a cli-formatting function.