### PR TITLE
Set `warning.length` to maximum value before throwing or warning

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rlang (development version)
 
+* `abort()` and `warn()` now temporarily set the `warning.length`
+  global option to the maximum value (8170). The default limit (1000
+  characters) is especially easy to hit when the message contains a
+  lot of ANSI escapes, as created by the crayon or cli packages (#1211).
+
 * A `knitr::sew()` method is registered for `rlang_error`. This makes
   it possible to consult `last_error()` (the call must occur in a
   different chunk than the error) and to set

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -77,6 +77,12 @@
 #'     )
 #'     ```
 #'
+#' - `abort()` and `warn()` temporarily set the `warning.length`
+#'   global option to the maximum value (8170), unless that option has
+#'   been changed from the default value. The default limit (1000
+#'   characters) is especially easy to hit when the message contains a
+#'   lot of ANSI escapes, as created by the crayon or cli packages
+#'
 #' @inheritParams cnd
 #' @param message The message to display. Character vectors are
 #'   formatted with [format_error_bullets()]. The first element
@@ -234,6 +240,7 @@ signal_abort <- function(cnd) {
     local_options(show.error.messages = FALSE)
   }
 
+  local_long_messages()
   stop(fallback)
 }
 cnd_unhandled_message <- function(cnd) {

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -118,6 +118,8 @@ warn <- function(message = NULL,
   }
 
   cnd <- warning_cnd(class, ..., message = message)
+
+  local_long_messages()
   warning(cnd)
 }
 #' @rdname abort
@@ -171,6 +173,15 @@ signal <- function(message,
   message <- cli_format_message(message, caller_env())
   cnd <- cnd(class, ..., message = message)
   cnd_signal(cnd)
+}
+
+# Increase message length temporarily if it set to the default
+# value. The limit can quickly be hit if the message includes a lot of
+# ANSI escapes.
+local_long_messages <- function(..., frame = caller_env()) {
+  if (peek_option("warning.length") == 1000) {
+    local_options(warning.length = 8170, .frame = frame)
+  }
 }
 
 default_message_file <- function() {

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -122,6 +122,11 @@ setting this option in a hidden chunk:\preformatted{options(
   rlang_trace_top_env = environment()
 )
 }
+\item \code{abort()} and \code{warn()} temporarily set the \code{warning.length}
+global option to the maximum value (8170), unless that option has
+been changed from the default value. The default limit (1000
+characters) is especially easy to hit when the message contains a
+lot of ANSI escapes, as created by the crayon or cli packages
 }
 }
 \section{Backtrace}{

--- a/tests/testthat/test-cnd-signal.R
+++ b/tests/testthat/test-cnd-signal.R
@@ -215,6 +215,22 @@ test_that("`inform()` and `warn()` with recurrent footer handle newlines correct
   })
 })
 
+test_that("`warning.length` is increased (#1211)", {
+  code <- 'rlang::with_interactive(rlang::abort(paste0(strrep("_", 1000), "foo")))'
+  out <- Rscript(shQuote(c("--vanilla", "-e", code)))
+  expect_true(any(grepl("foo", out$out)))
+
+  code <- 'rlang::with_interactive(rlang::warn(paste0(strrep("_", 1000), "foo")))'
+  out <- Rscript(shQuote(c("--vanilla", "-e", code)))
+  expect_true(any(grepl("foo", out$out)))
+
+  # Messages are not controlled by `warning.length`
+  code <- 'rlang::inform(paste0(strrep("_", 1000), "foo"))'
+  out <- Rscript(shQuote(c("--vanilla", "-e", code)))
+  expect_true(any(grepl("foo", out$out)))
+})
+
+
 # Lifecycle ----------------------------------------------------------
 
 test_that("deprecated arguments of cnd_signal() still work", {


### PR DESCRIPTION
Closes #1211