### PR TITLE
WIP: Overwrite deprecated with lifecycle::deprecated

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,6 +6,16 @@
   .Call(ffi_init_rlang, rlang_ns)
 
   run_on_load()
+
+  # Avoid warnings from clash between rlang::deprecated and lifecycle::deprecated
+  on_package_load("lifecycle", {
+    env <- get_env(deprecated)
+    old <- env_binding_unlock(env, "deprecated")
+    assign("deprecated", lifecycle::deprecated, env)
+    if (old) {
+      env_binding_lock(env, "deprecated")
+    }
+  })
 }
 .onUnload <- function(lib) {
   .Call(ffi_fini_rlang)


### PR DESCRIPTION
as soon as it becomes available.