### PR TITLE
compat-purrr.R: fix typo in `imap()`

### DIFF
--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -62,7 +62,7 @@ map2_chr <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "character")
 }
 imap <- function(.x, .f, ...) {
-  map2(.x, names(x) %||% seq_along(x), .f, ...)
+  map2(.x, names(.x) %||% seq_along(.x), .f, ...)
 }
 
 pmap <- function(.l, .f, ...) {

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -11,6 +11,9 @@
 # * Removed `*_cpl()` functions
 # * Used `as_function()` to allow use of `~`
 # * Used `.` prefix for helpers
+#
+# 2021-05-21:
+# * Fixed "object `x` not found" error in `imap()` (@mgirlich)
 
 map <- function(.x, .f, ...) {
   .f <- as_function(.f, env = global_env())

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,16 +27,6 @@ set_names2 <- function(x, nms = names2(x)) {
   x
 }
 
-imap <- function(.x, .f, ...) {
-  idx <- names(.x) %||% seq_along(.x)
-  out <- Map(.f, idx, .x, ...)
-  names(out) <- names(.x)
-  out
-}
-imap_chr <- function(.x, .f, ...) {
-  as.vector(imap(.x, .f, ...), "character")
-}
-
 map_around <- function(.x, .neighbour = c("right", "left"), .f, ...) {
   where <- arg_match(.neighbour)
   n <- length(.x)

--- a/tests/testthat/test-compat-purrr.R
+++ b/tests/testthat/test-compat-purrr.R
@@ -17,6 +17,12 @@ test_that("map2 functions work", {
   expect_equal(map2_chr(1, 1:2, paste0), c("11", "12"))
 })
 
+test_that("imap works", {
+  expect_equal(imap(c("a", "b"), list), list(list("a", 1L), list("b", 2L)))
+  expect_equal(imap(c(x = "a", y = "b"), list), list(x = list("a", "x"), y = list("b", "y")))
+  expect_equal(imap(c(x = "a", "b"), list), list(x = list("a", "x"), list("b", "")))
+})
+
 test_that("pmap works", {
   expect_equal(pmap(list(1, 1:2), paste0), list("11", "12"))
 })


### PR DESCRIPTION
use `.x` instead of `x`