### PR TITLE
Fix bug in overflow condition of `r__intmax_subtract()`

### DIFF
--- a/src/rlang/c-utils.h
+++ b/src/rlang/c-utils.h
@@ -34,7 +34,7 @@ intmax_t r__intmax_add(intmax_t x, intmax_t y) {
 static inline
 intmax_t r__intmax_subtract(intmax_t x, intmax_t y) {
   if ((y > 0 && x < (INTMAX_MIN + y)) ||
-      (y < 0 && x < (INTMAX_MAX + y))) {
+      (y < 0 && x > (INTMAX_MAX + y))) {
     r_stop_internal("intmax_subtract", "Subtraction resulted in overflow or underflow.");
   }
 


### PR DESCRIPTION
See r-lib/vctrs#1399