### PR TITLE
Make `is_expression()` recursive over calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,9 @@
 
 ## Features and bugfixes
 
+* `is_expression()` now returns `FALSE` for manually constructed
+  expressions that cannot be created by the R parser.
+
 * New C callable `rlang_env_unbind()`. This is a wrapper around
   `R_removeVarFromFrame()` on R >= 4.0.0. On older R this wraps the R
   function `base::rm()`. Unlike `rm()`, this function does not warn

--- a/R/expr.R
+++ b/R/expr.R
@@ -12,7 +12,9 @@
 #'   (testable with `is_syntactic_literal()`)
 #'
 #' `is_expression()` returns `TRUE` if the input is either a symbolic
-#' object or a syntactic literal.
+#' object or a syntactic literal. If a call, the elements of the call
+#' must all be expressions as well. Unparsable calls are not
+#' considered expressions in this narrow definition.
 #'
 #' Note that in base R, there exists [expression()] vectors, a data
 #' type similar to a list that supports special attributes created by
@@ -91,7 +93,20 @@
 #' is_expression(fmls)
 #' is_pairlist(fmls)
 is_expression <- function(x) {
-  is_symbolic(x) || is_syntactic_literal(x)
+  stack <- new_stack()
+  stack$push(x)
+
+  while (!is_exhausted(elt <- stack$pop())) {
+    switch(
+      typeof(elt),
+      language = stack$push(!!!as.list(elt)),
+      if (!is_symbol(elt) && !is_syntactic_literal(elt)) {
+        return(FALSE)
+      }
+    )
+  }
+
+  TRUE
 }
 #' @export
 #' @rdname is_expression

--- a/R/utils.R
+++ b/R/utils.R
@@ -312,3 +312,33 @@ with_srcref <- function(src, env = caller_env(), file = NULL) {
 chr_has_curly <- function(x) {
   .Call(ffi_chr_has_curly, x)
 }
+
+
+new_stack <- function() {
+  stack <- new_dyn_vector("list", 100)
+
+  push <- function(...) {
+    for (obj in list2(...)) {
+      arr_push_back(stack, obj)
+    }
+  }
+
+  # Can be used as a coro generator
+  pop <- function() {
+    if (arr_count(stack)) {
+      arr_pop_back(stack)
+    } else {
+      exhausted()
+    }
+  }
+
+  new_environment(list(
+    push = push,
+    pop = pop
+  ))
+}
+
+# FIXME: Use an unlikely sentinel like `as.symbol(".__exhausted__.")`
+# https://github.com/r-lib/coro/issues/35
+exhausted <- function() as.symbol("exhausted")
+is_exhausted <- function(x) identical(x, exhausted())

--- a/man/is_expression.Rd
+++ b/man/is_expression.Rd
@@ -28,7 +28,9 @@ and function calls. These objects can be classified as:
 }
 
 \code{is_expression()} returns \code{TRUE} if the input is either a symbolic
-object or a syntactic literal.
+object or a syntactic literal. If a call, the elements of the call
+must all be expressions as well. Unparsable calls are not
+considered expressions in this narrow definition.
 
 Note that in base R, there exists \code{\link[=expression]{expression()}} vectors, a data
 type similar to a list that supports special attributes created by

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -80,3 +80,9 @@ test_that("imaginary numbers with real part are not syntactic", {
   expect_true(is_syntactic_literal(na_cpl))
   expect_false(is_syntactic_literal(1 + 1i))
 })
+
+test_that("is_expression() detects non-parsable parse trees", {
+  expect_true(is_expression(quote(foo(bar = baz(1, NULL)))))
+  expect_false(is_expression(expr(foo(bar = baz(!!(1:2), NULL)))))
+  expect_false(is_expression(call2(identity)))
+})


### PR DESCRIPTION
This makes `is_expression()` in line with the documented definition. It also makes it more useful as it can now be used to detect calls that can't be roundtripped with parse/deparse.

This is implemented using iteration instead of recursion, using a dynamic stack whose `pop()` method is a coro generator as outlined in https://github.com/r-lib/rlang/issues/1129#issuecomment-874224656.