### PR TITLE
Handle `call` fields in errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rlang
-Version: 0.4.11.9000
+Version: 0.4.11.9001
 Title: Functions for Base Types and Core R and 'Tidyverse' Features
 Description: A toolbox for working with base types, core R features
   like the condition system, and core 'Tidyverse' features like tidy

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,12 @@
 
 ## Features and bugfixes
 
+* `abort()` now displays `call` field in error messages. The call is
+  only displayed if it is a simple expression (e.g. no inlined
+  function) and the arguments are not displayed to avoid distracting
+  from the error message. The message is formatted with the tidyverse
+  style (`code` formatting by the cli package if available).
+
 * The `.ignore_empty` argument of `enexprs()` and `enquos()` no longer
   treats named arguments supplied through `...` as empty, consistently
   with `exprs()` and `quos()` (#1229).

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -108,6 +108,11 @@ format.rlang_error <- function(x,
     )
   }
 
+  ctxt <- cnd_context(x)
+  if (!is_null(ctxt)) {
+    out <- paste_line(out, paste0(bold("Context: "), ctxt))
+  }
+
   simplify <- arg_match(simplify)
 
   if (backtrace && !is_null(trace) && trace_length(trace)) {

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -101,6 +101,18 @@ cnd_footer.default <- function(cnd, ...) {
   chr()
 }
 
+cnd_prefix <- function(cnd) {
+  call <- conditionCall(cnd)
+
+  if (is_call(call) && is_expression(call)) {
+    # Remove distracting arguments from the call
+    fn <- as_label(call[1])
+    sprintf("Error in %s: ", format_code(fn))
+  } else {
+    "Error: "
+  }
+}
+
 #' Format bullets for error messages
 #'
 #' @description

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -102,14 +102,23 @@ cnd_footer.default <- function(cnd, ...) {
 }
 
 cnd_prefix <- function(cnd) {
+  ctxt <- cnd_context(cnd)
+  if (is_null(ctxt)) {
+    "Error: "
+  } else {
+    sprintf("Error in %s: ", ctxt)
+  }
+}
+
+cnd_context <- function(cnd) {
   call <- conditionCall(cnd)
 
   if (is_call(call) && is_expression(call)) {
     # Remove distracting arguments from the call
-    fn <- as_label(call[1])
-    sprintf("Error in %s: ", format_code(fn))
+    fn <- call[1]
+    format_code(as_label(fn))
   } else {
-    "Error: "
+    NULL
   }
 }
 

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -12,6 +12,7 @@ abort(
   message = NULL,
   class = NULL,
   ...,
+  call = NULL,
   trace = NULL,
   parent = NULL,
   .subclass = deprecated()
@@ -58,6 +59,10 @@ incrementally.}
 to selectively handle the conditions signalled by your functions.}
 
 \item{...}{Additional data to be stored in the condition object.}
+
+\item{call}{A call representing the context in which the error
+occurred. If present, \code{abort()} displays the call (stripped from
+its arguments to keep it simple) before \code{message}.}
 
 \item{trace}{A \code{trace} object created by \code{\link[=trace_back]{trace_back()}}.}
 

--- a/src/version.c
+++ b/src/version.c
@@ -1,7 +1,7 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 
-const char* rlang_version = "0.4.11.9000";
+const char* rlang_version = "0.4.11.9001";
 
 /**
  * This file records the expected package version in the shared

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -251,3 +251,19 @@
        11. rlang:::bar(cnd)
        12. rlang:::baz(cnd)
 
+# abort() displays call in error prefix
+
+    Code
+      run("rlang::abort('foo', call = quote(bar(baz)))")
+    Output
+      Error in `bar()`: foo
+      Execution halted
+
+---
+
+    Code
+      run("rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))")
+    Output
+      Error in `bar()`: foo
+      Execution halted
+

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -208,3 +208,12 @@
     Output
       <error/bar>
 
+# errors are printed with call
+
+    Code
+      print(err)
+    Output
+      <error/rlang_error>
+      msg
+      Context: `foo()`
+

--- a/tests/testthat/helper-rlang.R
+++ b/tests/testthat/helper-rlang.R
@@ -65,6 +65,10 @@ Rscript <- function(args, ...) {
     status = attr(out, "status")
   )
 }
+run <- function(code) {
+  out <- Rscript(shQuote(c("--vanilla", "-e", code)))
+  cat_line(out$out)
+}
 
 expect_reference <- function(object, expected) {
   expect_true(is_reference(object, expected))

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -268,3 +268,18 @@ test_that("report-specific backtrace-on-error option has precedence", {
     expect_equal(peek_backtrace_on_error(), "full")
   )
 })
+
+test_that("abort() displays call in error prefix", {
+  skip_if_not_installed("rlang", "0.4.11.9001")
+
+  expect_snapshot(
+    run("rlang::abort('foo', call = quote(bar(baz)))")
+  )
+
+  # errorCondition()
+  skip_if_not_installed("base", "3.6.0")
+
+  expect_snapshot(
+    run("rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))")
+  )
+})

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -123,3 +123,9 @@ test_that("base parent errors are printed with rlang method", {
   rlang_err <- error_cnd("bar", message = "", parent = base_err)
   expect_snapshot(print(rlang_err))
 })
+
+test_that("errors are printed with call", {
+  err <- catch_cnd(abort("msg", call = quote(foo(bar, baz))), "error")
+  err$trace <- NULL
+  expect_snapshot(print(err))
+})

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -212,3 +212,14 @@ cli::test_that_cli(configs = c("plain", "fancy"), "can use cli syntax in `cnd_me
   )
   expect_snapshot(cnd_message(cnd))
 })
+
+test_that("prefix takes call into account", {
+  err <- error_cnd(message = "Message.", call = quote(foo(bar = TRUE)))
+  expect_equal(cnd_prefix(err), "Error in `foo()`: ")
+
+  # Inlined objects disable context deparsing
+  err1 <- error_cnd(call = expr(foo(bar = !!(1:3))))
+  err2 <- error_cnd(call = call2(identity))
+  expect_equal(cnd_prefix(err1), "Error: ")
+  expect_equal(cnd_prefix(err2), "Error: ")
+})


### PR DESCRIPTION
To support https://github.com/tidymodels/recipes/pull/734 (cc @DavisVaughan).

1. Display the whole message ourselves including the `Error: ` prefix. This removes the limitation on the length of error messages (the limit can easily be reached because of ANSI markup by cli). This also makes it possible to format calls according to our standards.

2. Include `call` fields in error prefixes if present. Complex calls containing inlined objects are ignored and the arguments of the call are stripped to keep it simple. The call is formatted as code using cli if available. Unlike `stop(call. = TRUE)`, there is no space after `:`.

```r
abort("msg", call = quote(foo(bar, baz)))
#> Error in `foo()`: msg
```

Rethrowing with a context added in `call` field:

```r
f <- function() g()
g <- function() h()
h <- function() abort("msg")

a <- function() b()
b <- function() c()
c <- function() {
  withCallingHandlers(f(), error = function(c) {
    c$call <- quote(foo())
    cnd_signal(c)
  })
}

a()
#> Error in `foo()`: msg
#> Run `rlang::last_error()` to see where the error occurred.

last_error()
#> <error/rlang_error>
#> msg
#> Context: `foo()`          <---
#> Backtrace:
#>  1. global::a()
#>  2. global::b()
#>  3. global::c()
#>  5. global::f()
#>  6. global::g()
#>  7. global::h()
```