### PR TITLE
better arg_match description

### DIFF
--- a/R/arg.R
+++ b/R/arg.R
@@ -50,12 +50,12 @@ arg_match <- function(arg, values = NULL) {
 
 #' @description
 #' `arg_match0()` is a bare-bones version if performance is at a premium.
-#' It requires a string as `arg` and explicit `values`.
+#' It requires a string as `arg` and explicit character `values`.
 #' For convenience, `arg` may also be a character vector containing
 #' every element of `values`, possibly permuted.
 #' In this case, the first element of `arg` is used.
 #'
-#' @param values The possible values that `arg` can take.
+#' @param values A character vector of possible values that `arg` can take.
 #' @param arg_nm Argument name of `arg` to use in error messages. Can
 #'   be a string or symbol.
 #' @rdname arg_match

--- a/man/arg_match.Rd
+++ b/man/arg_match.Rd
@@ -12,7 +12,7 @@ arg_match0(arg, values, arg_nm = substitute(arg))
 \arguments{
 \item{arg}{A symbol referring to an argument accepting strings.}
 
-\item{values}{The possible values that \code{arg} can take.}
+\item{values}{A character vector of possible values that \code{arg} can take.}
 
 \item{arg_nm}{Argument name of \code{arg} to use in error messages. Can
 be a string or symbol.}
@@ -32,7 +32,7 @@ standards.
 \link[=caller_frame]{caller frame}.
 
 \code{arg_match0()} is a bare-bones version if performance is at a premium.
-It requires a string as \code{arg} and explicit \code{values}.
+It requires a string as \code{arg} and explicit character \code{values}.
 For convenience, \code{arg} may also be a character vector containing
 every element of \code{values}, possibly permuted.
 In this case, the first element of \code{arg} is used.


### PR DESCRIPTION
While the docs say

> This is equivalent to `base::match.arg()`

it is not obvious that `rlang::arg_match()` should only be used when the argument takes character values. 
