### PR TITLE
Allow `names_inform_repair()` to be silenced by a global option

### DIFF
--- a/R/names.R
+++ b/R/names.R
@@ -3,7 +3,24 @@ names_as_unique <- function(names, ..., quiet = FALSE) {
   .Call(ffi_names_as_unique, names, quiet)
 }
 
-#' Inform about names repair
+#' Inform about name repair
+#'
+#' @section Muffling and silencing messages:
+#'
+#' Name repair messages are signaled with [inform()] and are given the class
+#' `"rlib_message_name_repair"`. These messages can be muffled with
+#' [base::suppressMessages()].
+#'
+#' Name repair messages can also be silenced with the global option
+#' `rlib_name_repair_verbosity`. This option takes the values:
+#'
+#' - `"verbose"`: Always verbose.
+#' - `"quiet"`: Always quiet.
+#'
+#' When set to quiet, the message is not displayed and the condition is not
+#' signaled. This is particularly useful for silencing messages during testing
+#' when combined with [local_options()].
+#'
 #' @param old Original names vector.
 #' @param new Repaired names vector.
 #' @keywords internal
@@ -18,20 +35,37 @@ names_inform_repair <- function(old, new) {
     length(old) == length(new)
   )
 
+  if (peek_name_repair_verbosity() == "quiet") {
+    return(invisible())
+  }
+
   old <- old %|% ""
   new_names <- new != old
-  if (any(new_names)) {
-    bullets <- paste0(
-      tick_if_needed(old[new_names]),
-      " -> ",
-      tick_if_needed(new[new_names]),
-      .problem = ""
-    )
-    inform(c(
-      "New names:",
-      set_names(bullets, "*"))
-    )
+
+  if (!any(new_names)) {
+    return(invisible())
   }
+
+  bullets <- paste0(
+    tick_if_needed(old[new_names]),
+    " -> ",
+    tick_if_needed(new[new_names]),
+    .problem = ""
+  )
+
+  message <- c(
+    "New names:",
+    set_names(bullets, "*")
+  )
+
+  inform(message = message, class = "rlib_message_name_repair")
+}
+
+peek_name_repair_verbosity <- function() {
+  opt <- "rlib_name_repair_verbosity"
+  out <- peek_option(opt) %||% "verbose"
+  out <- arg_match0(out, c("verbose", "quiet"), opt)
+  out
 }
 
 tick_if_needed <- function(x) {

--- a/man/names_inform_repair.Rd
+++ b/man/names_inform_repair.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/names.R
 \name{names_inform_repair}
 \alias{names_inform_repair}
-\title{Inform about names repair}
+\title{Inform about name repair}
 \usage{
 names_inform_repair(old, new)
 }
@@ -12,6 +12,25 @@ names_inform_repair(old, new)
 \item{new}{Repaired names vector.}
 }
 \description{
-Inform about names repair
+Inform about name repair
 }
+\section{Muffling and silencing messages}{
+
+
+Name repair messages are signaled with \code{\link[=inform]{inform()}} and are given the class
+\code{"rlib_message_name_repair"}. These messages can be muffled with
+\code{\link[base:message]{base::suppressMessages()}}.
+
+Name repair messages can also be silenced with the global option
+\code{rlib_name_repair_verbosity}. This option takes the values:
+\itemize{
+\item \code{"verbose"}: Always verbose.
+\item \code{"quiet"}: Always quiet.
+}
+
+When set to quiet, the message is not displayed and the condition is not
+signaled. This is particularly useful for silencing messages during testing
+when combined with \code{\link[=local_options]{local_options()}}.
+}
+
 \keyword{internal}

--- a/tests/testthat/_snaps/nse-defuse.md
+++ b/tests/testthat/_snaps/nse-defuse.md
@@ -3,14 +3,14 @@
     Code
       expect_equal(dots_names(1, foo = 1, 1, foo = 2), c("1...1", "foo", "1...3",
         "foo"))
-    Message <message>
+    Message <rlib_message_name_repair>
       New names:
       * 1 -> 1...1
       * 1 -> 1...3
     Code
       expect_equal(dots_names(bar, foo = 1, bar, foo = 2), c("bar...1", "foo",
         "bar...3", "foo"))
-    Message <message>
+    Message <rlib_message_name_repair>
       New names:
       * `bar` -> `bar...1`
       * `bar` -> `bar...3`

--- a/tests/testthat/test-names.R
+++ b/tests/testthat/test-names.R
@@ -99,3 +99,21 @@ test_that("names_as_unique() handles encodings", {
   expect_equal(out, paste0(rep(x[[1]], 2), "...", 1:2))
   expect_equal(Encoding(out), c("UTF-8", "UTF-8"))
 })
+
+test_that("names_inform_repair() signals classed messages", {
+  local_options(rlib_message_verbosity = "default")
+  expect_message(names_inform_repair("x", "y"), class = "rlib_message_name_repair")
+})
+
+test_that("names_inform_repair() can be silenced by `rlib_name_repair_verbosity`", {
+  local_options(rlib_message_verbosity = "default", rlib_name_repair_verbosity = "quiet")
+  expect_message(names_inform_repair("x", "y"), NA)
+})
+
+test_that("`rlib_name_repair_verbosity` is validated", {
+  local_options(rlib_name_repair_verbosity = 1)
+  expect_error(peek_name_repair_verbosity())
+
+  local_options(rlib_name_repair_verbosity = "qu")
+  expect_error(peek_name_repair_verbosity())
+})


### PR DESCRIPTION
This also adds the `"rlib_message_name_repair"` class to the message signaled by `names_inform_repair()`, giving us yet another method to handle it.

I did not add a NEWS bullet because there isn't one for `names_inform_repair()` being a new function.

_Side note:_ Should this function be named `inform_name_repair()`? We normally use `stop_*()` and `warn_*()` elsewhere for our error/warning naming conventions, and that form matches the global option / class name better.