### PR TITLE
Use error style guide in `env_get()` error for missing binding

### DIFF
--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -381,6 +381,16 @@ env_get <- function(env = caller_env(),
                     inherit = FALSE,
                     last = empty_env()) {
   env <- get_env_retired(env, "env_get()")
+
+  if (missing(default)) {
+    default %<~% {
+      abort(sprintf(
+        "Can't find %s in environment.",
+        format_arg(nm)
+      ))
+    }
+  }
+
   .Call(
     ffi_env_get,
     env = env,

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -383,12 +383,7 @@ env_get <- function(env = caller_env(),
   env <- get_env_retired(env, "env_get()")
 
   if (missing(default)) {
-    default %<~% {
-      abort(sprintf(
-        "Can't find %s in environment.",
-        format_arg(nm)
-      ))
-    }
+    default %<~% stop_env_get_missing(nm)
   }
 
   .Call(
@@ -416,6 +411,13 @@ env_get_list <- function(env = caller_env(),
     last = last,
     closure_env = environment()
   )
+}
+
+stop_env_get_missing <- function(nm) {
+  abort(sprintf(
+    "Can't find %s in environment.",
+    format_arg(nm)
+  ))
 }
 
 #' Poke an object in an environment

--- a/src/internal/env-binding.c
+++ b/src/internal/env-binding.c
@@ -53,6 +53,18 @@ r_obj* env_get_sym(r_obj* env,
   }
 
   if (out == r_syms.unbound) {
+    if (r_env_find(closure_env, r_sym("default")) == r_missing_arg) {
+      struct r_pair args[] = {
+        { r_sym("nm"), KEEP(r_str_as_character(r_sym_string(sym))) }
+      };
+      r_exec_n(r_null,
+               r_sym("stop_env_get_missing"),
+               args,
+               R_ARR_SIZEOF(args),
+               closure_env);
+      r_stop_unreached("env_get_sym");
+    }
+
     out = r_eval(r_sym("default"), closure_env);
   }
 

--- a/src/rlang/eval.c
+++ b/src/rlang/eval.c
@@ -114,6 +114,18 @@ r_obj* r_exec_mask_n(r_obj* fn_sym,
   return out;
 }
 
+r_obj* r_exec_n(r_obj* fn_sym,
+                r_obj* fn,
+                const struct r_pair* args,
+                int n,
+                r_obj* env) {
+  r_obj* call = KEEP(r_exec_mask_n_call_poke(fn_sym, fn, args, n, env));
+  r_obj* out = r_eval(call, env);
+
+  FREE(1);
+  return out;
+}
+
 // Create a call from arguments and poke elements with a non-NULL
 // symbol in `env`
 r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,

--- a/src/rlang/eval.h
+++ b/src/rlang/eval.h
@@ -18,6 +18,12 @@ r_obj* r_exec_mask_n(r_obj* fn_sym,
                      int n,
                      r_obj* parent);
 
+r_obj* r_exec_n(r_obj* fn_sym,
+                r_obj* fn,
+                const struct r_pair* args,
+                int n,
+                r_obj* env);
+
 r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,
                                r_obj* fn,
                                const struct r_pair* args,

--- a/tests/testthat/_snaps/env-binding.md
+++ b/tests/testthat/_snaps/env-binding.md
@@ -1,0 +1,7 @@
+# env_get() without default fails
+
+    Code
+      env_get(env(), "foobar")
+    Error <rlang_error>
+      Can't find `foobar` in environment.
+

--- a/tests/testthat/_snaps/env-binding.md
+++ b/tests/testthat/_snaps/env-binding.md
@@ -1,7 +1,13 @@
 # env_get() without default fails
 
     Code
-      env_get(env(), "foobar")
-    Error <rlang_error>
+      (expect_error(env_get(env(), "foobar")))
+    Output
+      <error/rlang_error>
+      Can't find `foobar` in environment.
+    Code
+      (expect_error(env_get_list(env(), "foobar")))
+    Output
+      <error/rlang_error>
       Can't find `foobar` in environment.
 

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -66,7 +66,7 @@ test_that("env_get_list() retrieves multiple bindings", {
   expect_identical(env_get_list(env, c("foo", "bar")), list(foo = 1L, bar =2L))
 
   baz <- 0L
-  expect_error(env_get_list(env, "baz"), "missing")
+  expect_error(env_get_list(env, "baz"), "Can't find")
   expect_identical(env_get_list(env, c("foo", "baz"), inherit = TRUE), list(foo = 1L, baz =0L))
 })
 
@@ -146,14 +146,17 @@ test_that("env_get() and env_get_list() accept default value", {
   env <- env(a = 1)
 
   expect_error(env_get(env, "b"), "Can't find")
-  expect_error(env_get_list(env, "b"), "missing")
+  expect_error(env_get_list(env, "b"), "Can't find")
 
   expect_identical(env_get(env, "b", default = "foo"), "foo")
   expect_identical(env_get_list(env, c("a", "b"), default = "foo"), list(a = 1, b = "foo"))
 })
 
 test_that("env_get() without default fails", {
-  expect_snapshot(env_get(env(), "foobar"), error = TRUE)
+  expect_snapshot({
+    (expect_error(env_get(env(), "foobar")))
+    (expect_error(env_get_list(env(), "foobar")))
+  })
 
   fn <- function(env, default) env_get(env, "_foobar", default = default)
   expect_error(fn(env()), "Can't find")

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -145,7 +145,7 @@ test_that("env_unbind() doesn't warn if binding doesn't exist (#177)", {
 test_that("env_get() and env_get_list() accept default value", {
   env <- env(a = 1)
 
-  expect_error(env_get(env, "b"), "missing")
+  expect_error(env_get(env, "b"), "Can't find")
   expect_error(env_get_list(env, "b"), "missing")
 
   expect_identical(env_get(env, "b", default = "foo"), "foo")
@@ -153,10 +153,10 @@ test_that("env_get() and env_get_list() accept default value", {
 })
 
 test_that("env_get() without default fails", {
-  expect_error(env_get(env(), "_foobar"), "argument .* is missing")
+  expect_snapshot(env_get(env(), "foobar"), error = TRUE)
 
   fn <- function(env, default) env_get(env, "_foobar", default = default)
-  expect_error(fn(env()), "argument .* is missing")
+  expect_error(fn(env()), "Can't find")
 })
 
 test_that("env_get() evaluates `default` lazily", {


### PR DESCRIPTION
Previously:

```r
env_get(nm = "foobar")
#> Error in env_get(nm = "foobar") : 
#>   argument "default" is missing, with no default
```

Now:

```r
env_get(nm = "foobar")
#> Error: Can't find `foobar` in environment.
```