### PR TITLE
Store last error on the search path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,12 @@
 
 ## Features and bugfixes
 
+* The error returned by `last_error()` is now stored on the search
+  path as the `.Last.error` binding of the `"org:r-lib"`
+  environment. This is consistent with how the processx package
+  records error conditions. Printing the `.Last.error` object is now
+  equivalent to running `last_error()`.
+
 * Backtraces now print dangling srcrefs (#1206). Paths are shortened
   to show only three components (two levels of folder and the file).
 

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -270,7 +270,7 @@ signal_abort <- function(cnd, file = NULL) {
   }
 
   # Save the unhandled error for `rlang::last_error()`.
-  last_error_env$cnd <- cnd
+  poke_last_error(cnd)
 
   # Print the backtrace manually to work around limitations on the
   # length of error messages (#856)
@@ -700,7 +700,7 @@ on_load({
     local_interactive()
 
     # Save the unhandled error for `rlang::last_error()`.
-    last_error_env$cnd <- x
+    poke_last_error(x)
 
     # By default, we display no reminder or backtrace for errors
     # captured by knitr. This default can be overridden.
@@ -937,14 +937,15 @@ peek_backtrace_on_error <- function() {
 #'
 #' @export
 last_error <- function() {
-  if (is_null(last_error_env$cnd)) {
+  err <- peek_last_error()
+
+  if (is_null(err)) {
     local_options(rlang_backtrace_on_error = "none")
     stop("Can't show last error because no error was recorded yet", call. = FALSE)
   }
 
-  cnd <- last_error_env$cnd
-  cnd$rlang$internal$from_last_error <- TRUE
-  cnd
+  err$rlang$internal$from_last_error <- TRUE
+  err
 }
 #' @rdname last_error
 #' @export
@@ -954,6 +955,29 @@ last_trace <- function() {
   err
 }
 
-# This is where we save errors for `last_error()`
-last_error_env <- new.env(parent = emptyenv())
-last_error_env$cnd <- NULL
+peek_last_error <- function(cnd) {
+  last_error_env()$.Last.error
+}
+poke_last_error <- function(cnd) {
+  env <- last_error_env()
+
+  env$.Last.error <- cnd
+  env$.Last.error.trace <- cnd$trace
+
+  invisible(cnd)
+}
+last_error_env <- function() {
+  if (!is_attached("org:r-lib")) {
+    exec(
+      attach,
+      list(
+        .Last.error = NULL,
+        .Last.error.trace = NULL
+      ),
+      pos = length(search()),
+      name = "org:r-lib"
+    )
+  }
+
+  search_env("org:r-lib")
+}

--- a/R/cnd-entrace.R
+++ b/R/cnd-entrace.R
@@ -199,7 +199,7 @@ entrace_handle_top <- function(trace) {
 
   # Save a fake rlang error containing the backtrace
   err <- error_cnd(message = msg, error = cnd, trace = trace, parent = cnd)
-  last_error_env$cnd <- err
+  poke_last_error(err)
 
   # Print backtrace for current error
   backtrace_lines <- format_onerror_backtrace(err)

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -178,7 +178,7 @@
     Code
       # Saved from `last_error()`, but no longer last
       {
-        last_error_env$cnd <- error_cnd("foo")
+        poke_last_error(error_cnd("foo"))
         print(saved)
       }
     Output

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -148,7 +148,7 @@ test_that("backtrace reminder is displayed when called from `last_error()`", {
   h <- function() abort("foo")
   err <- catch_error(f())
 
-  last_error_env$cnd <- err
+  poke_last_error(err)
 
   expect_snapshot({
     "Normal case"
@@ -165,7 +165,7 @@ test_that("backtrace reminder is displayed when called from `last_error()`", {
 
     "Saved from `last_error()`, but no longer last"
     {
-      last_error_env$cnd <- error_cnd("foo")
+      poke_last_error(error_cnd("foo"))
       print(saved)
     }
   })


### PR DESCRIPTION
So that user can type `.Last.error`. This has the advantage that other packages may easily store error objects themselves, actually processx already uses this protocol.

cc @hadley