### PR TITLE
Improve display of chained errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@
 
 ## Features and bugfixes
 
+* The `print()` method of rlang errors (commonly invoked with
+  `last_error()`) has been improved:
+    - Display calls if present.
+    - Chained errors are displayed more clearly.
+
 * `as_function()` gains `arg` and `call` arguments to provide
   contextual information about erroring inputs.
 

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -289,10 +289,10 @@ signal_abort <- function(cnd, file = NULL) {
   # length of error messages (#856)
   fallback$message <- conditionMessage(cnd)
   msg <- cnd_unhandled_message(cnd)
-  prefix <- cnd_prefix(cnd)
+  msg <- cnd_prefix_error_message(cnd, msg)
+  msg <- paste0(msg, "\n")
 
-  file <- file %||% default_message_file()
-  cat(prefix, msg, "\n", sep = "", file = file)
+  cat(msg, file = file %||% default_message_file())
 
   # Use `stop()` to run the `getOption("error")` handler (used by
   # RStudio to record a backtrace) and cause a long jump. Running the

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -62,7 +62,7 @@ format.rlang_error <- function(x,
     header <- header_add_tree_node(header, style, parent)
     header <-   paste_line(trace_root(), header)
 
-    message <- with_reduced_width(assemble_error_message(x))
+    message <- assemble_error_message(x)
     message <- message_add_tree_prefix(message, style, parent)
   } else {
     message <- assemble_error_message(x)
@@ -86,11 +86,11 @@ format.rlang_error <- function(x,
     header <- rlang_error_header(x)
     header <- header_add_tree_node(header, style, parent)
 
-    message <- with_reduced_width(assemble_error_message(x, message = cnd_header(x)))
+    message <- assemble_error_message(x, message = cnd_header(x))
     message <- message_add_tree_prefix(message, style, parent)
 
     if (is_rlang_error(parent)) {
-      message <- with_reduced_width(assemble_error_message(x))
+      message <- assemble_error_message(x)
       message <- message_add_tree_prefix(message, style, parent)
     }
 
@@ -122,13 +122,6 @@ format.rlang_error <- function(x,
   }
 
   out
-}
-
-with_reduced_width <- function(expr) {
-  with_options(
-    width = max(peek_option("width") - 2L, 10L),
-    expr
-  )
 }
 
 assemble_error_message <- function(cnd,

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -66,7 +66,7 @@ format.rlang_error <- function(x,
 
   trace <- x$trace
 
-  while (is_rlang_error(parent)) {
+  while (!is_null(parent)) {
     x <- parent
     parent <- parent$parent
 

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -62,12 +62,10 @@ format.rlang_error <- function(x,
     header <- header_add_tree_node(header, style, parent)
     header <-   paste_line(trace_root(), header)
 
-    message <- with_reduced_width(
-      as_rlang_error_message(conditionMessage(x))
-    )
+    message <- with_reduced_width(assemble_error_message(x))
     message <- message_add_tree_prefix(message, style, parent)
   } else {
-    message <- as_rlang_error_message(conditionMessage(x))
+    message <- assemble_error_message(x)
   }
 
   out <- paste_line(
@@ -88,15 +86,11 @@ format.rlang_error <- function(x,
     header <- rlang_error_header(x)
     header <- header_add_tree_node(header, style, parent)
 
-    message <- with_reduced_width(
-      as_rlang_error_message(cnd_header(x))
-    )
+    message <- with_reduced_width(assemble_error_message(x, message = cnd_header(x)))
     message <- message_add_tree_prefix(message, style, parent)
 
     if (is_rlang_error(parent)) {
-      message <- with_reduced_width(
-        as_rlang_error_message(conditionMessage(x))
-      )
+      message <- with_reduced_width(assemble_error_message(x))
       message <- message_add_tree_prefix(message, style, parent)
     }
 
@@ -105,11 +99,6 @@ format.rlang_error <- function(x,
       header,
       message
     )
-  }
-
-  ctxt <- format_error_call(x$call)
-  if (!is_null(ctxt)) {
-    out <- paste_line(out, paste0(bold("Call: "), ctxt))
   }
 
   simplify <- arg_match(simplify)
@@ -142,14 +131,16 @@ with_reduced_width <- function(expr) {
   )
 }
 
-as_rlang_error_message <- function(message) {
+assemble_error_message <- function(cnd,
+                                   message = conditionMessage(cnd),
+                                   prefix = "Error") {
   message <- strip_trailing_newline(message)
 
-  if (nzchar(message)) {
-    message
-  } else {
-    NULL
+  if (!nzchar(message)) {
+    return(NULL)
   }
+
+  cnd_prefix_error_message(cnd, message)
 }
 
 header_add_tree_node <- function(header, style, parent) {

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -57,16 +57,7 @@ format.rlang_error <- function(x,
   style <- cli_box_chars()
 
   header <- rlang_error_header(x)
-
-  if (is_rlang_error(parent)) {
-    header <- header_add_tree_node(header, style, parent)
-    header <-   paste_line(trace_root(), header)
-
-    message <- assemble_error_message(x)
-    message <- message_add_tree_prefix(message, style, parent)
-  } else {
-    message <- assemble_error_message(x)
-  }
+  message <- assemble_error_message(x)
 
   out <- paste_line(
     header,
@@ -83,22 +74,13 @@ format.rlang_error <- function(x,
       trace <- x$trace
     }
 
-    header <- rlang_error_header(x)
-    header <- header_add_tree_node(header, style, parent)
-
-    message <- assemble_error_message(x, message = cnd_header(x))
-    message <- message_add_tree_prefix(message, style, parent)
-
-    if (is_rlang_error(parent)) {
-      message <- assemble_error_message(x)
-      message <- message_add_tree_prefix(message, style, parent)
-    }
-
-    out <- paste_line(
-      out,
-      header,
-      message
+    message <- assemble_error_message(
+      x,
+      message = cnd_header(x),
+      prefix = "Caused by error"
     )
+
+    out <- paste_line(out, message)
   }
 
   simplify <- arg_match(simplify)
@@ -133,7 +115,7 @@ assemble_error_message <- function(cnd,
     return(NULL)
   }
 
-  cnd_prefix_error_message(cnd, message)
+  cnd_prefix_error_message(cnd, message, prefix = prefix)
 }
 
 header_add_tree_node <- function(header, style, parent) {

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -101,16 +101,18 @@ cnd_footer.default <- function(cnd, ...) {
   chr()
 }
 
-cnd_prefix <- function(cnd, prefix = "Error") {
+cnd_prefix_error_message <- function(cnd, message, prefix = "Error") {
   call <- format_error_call(cnd$call)
 
   if (is_null(call)) {
-    out <- sprintf("%s: ", prefix)
+    prefix <- sprintf("%s: ", prefix)
   } else {
-    out <- sprintf("%s in %s: ", prefix, call)
+    prefix <- sprintf("%s in %s: ", prefix, call)
   }
+  prefix <- style_bold(prefix)
 
-  style_bold(out)
+  # TODO: srcref, line break
+  paste0(prefix, message)
 }
 
 #' Format bullets for error messages

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -101,14 +101,16 @@ cnd_footer.default <- function(cnd, ...) {
   chr()
 }
 
-cnd_prefix <- function(cnd) {
-  error <- style_bold("Error")
-  ctxt <- format_error_call(cnd$call)
-  if (is_null(ctxt)) {
-    sprintf("%s: ", error)
+cnd_prefix <- function(cnd, prefix = "Error") {
+  call <- format_error_call(cnd$call)
+
+  if (is_null(call)) {
+    out <- sprintf("%s: ", prefix)
   } else {
-    sprintf("%s in %s: ", error, ctxt)
+    out <- sprintf("%s in %s: ", prefix, call)
   }
+
+  style_bold(out)
 }
 
 #' Format bullets for error messages

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -21,40 +21,36 @@
       "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "discrete" or "continuous", not "continuuos".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "discrete" or "continuous", not "continuuos".
       i Did you mean "continuous"?
-      Call: `arg_match0_wrapper()`
     Code
       (expect_error(arg_match_wrapper("fou", c("bar", "foo"), "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "bar" or "foo", not "fou".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "bar" or "foo", not "fou".
       i Did you mean "foo"?
-      Call: `arg_match0_wrapper()`
     Code
       (expect_error(arg_match_wrapper("fu", c("ba", "fo"), "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "ba" or "fo", not "fu".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "ba" or "fo", not "fu".
       i Did you mean "fo"?
-      Call: `arg_match0_wrapper()`
     Code
       (expect_error(arg_match_wrapper("baq", c("foo", "baz", "bas"), "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "foo", "baz", or "bas", not "baq".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "foo", "baz", or "bas", not "baq".
       i Did you mean "baz"?
-      Call: `arg_match0_wrapper()`
     Code
       (expect_error(arg_match_wrapper("", character(), "my_arg")))
     Output
       <error/rlang_error>
-      `values` must have at least one element.
+      Error: `values` must have at least one element.
     Code
       (expect_error(arg_match_wrapper("fo", "foo", quote(f()))))
     Output
       <error/rlang_error>
-      `arg_nm` must be a string or symbol.
+      Error: `arg_nm` must be a string or symbol.
 
 # `arg_match()` provides no suggestion when the edit distance is too large
 
@@ -62,14 +58,12 @@
       (expect_error(arg_match0_wrapper("foobaz", c("fooquxs", "discrete"), "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "fooquxs" or "discrete", not "foobaz".
-      Call: `arg_match0_wrapper()`
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "fooquxs" or "discrete", not "foobaz".
     Code
       (expect_error(arg_match0_wrapper("a", c("b", "c"), "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "b" or "c", not "a".
-      Call: `arg_match0_wrapper()`
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "b" or "c", not "a".
 
 # `arg_match()` makes case-insensitive match
 
@@ -78,17 +72,15 @@
       "Did you mean \"A\"?"))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "A" or "B", not "a".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "A" or "B", not "a".
       i Did you mean "A"?
-      Call: `arg_match0_wrapper()`
     Code
       (expect_error(arg_match0_wrapper("aa", c("AA", "aA"), "my_arg"),
       "Did you mean \"aA\"?"))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "AA" or "aA", not "aa".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "AA" or "aA", not "aa".
       i Did you mean "aA"?
-      Call: `arg_match0_wrapper()`
 
 # arg_require() checks argument is supplied (#1118)
 
@@ -96,14 +88,12 @@
       (expect_error(f()))
     Output
       <error/rlang_error>
-      `x` must be supplied.
-      Call: `f()`
+      Error in `f()`: `x` must be supplied.
     Code
       (expect_error(g()))
     Output
       <error/rlang_error>
-      `x` must be supplied.
-      Call: `f()`
+      Error in `f()`: `x` must be supplied.
 
 # arg_match() supports symbols and scalar strings
 
@@ -111,9 +101,8 @@
       (expect_error(arg_match0_wrapper(chr_get("fo", 0L), c("bar", "foo"), "my_arg")))
     Output
       <error/rlang_error>
-      `my_arg` must be one of "bar" or "foo", not "fo".
+      Error in `arg_match0_wrapper()`: `my_arg` must be one of "bar" or "foo", not "fo".
       i Did you mean "foo"?
-      Call: `arg_match0_wrapper()`
 
 # arg_match() requires an argument symbol
 
@@ -121,7 +110,6 @@
       (expect_error(wrapper()))
     Output
       <error/rlang_error>
-      `arg` must be a symbol.
+      Error in `wrapper()`: `arg` must be a symbol.
       ! This is an internal error, please report it to the package authors.
-      Call: `wrapper()`
 

--- a/tests/testthat/_snaps/attr.md
+++ b/tests/testthat/_snaps/attr.md
@@ -4,10 +4,10 @@
       (expect_error(set_names(environment())))
     Output
       <error/rlang_error>
-      `x` must be a vector
+      Error: `x` must be a vector
     Code
       (expect_error(set_names(1:10, letters[1:4])))
     Output
       <error/rlang_error>
-      The size of `nm` (4) must be compatible with the size of `x` (10).
+      Error: The size of `nm` (4) must be compatible with the size of `x` (10).
 

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -4,7 +4,8 @@
       cat_line(default_interactive)
     Output
       Error in `h()`: Error message
-      Run `rlang::last_error()` to see where the error occurred.Execution halted
+      Run `rlang::last_error()` to see where the error occurred.
+      Execution halted
     Code
       cat_line(default_non_interactive)
     Output
@@ -15,11 +16,13 @@
        2.   +-base::tryCatch(g())
        3.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        4.   \-global::g()
-       5.     \-global::h()Execution halted
+       5.     \-global::h()
+      Execution halted
     Code
       cat_line(reminder)
     Output
-      Error in `h()`: Error messageExecution halted
+      Error in `h()`: Error message
+      Execution halted
     Code
       cat_line(branch)
     Output
@@ -27,7 +30,8 @@
       Backtrace:
        1. global::f()
        4. global::g()
-       5. global::h()Execution halted
+       5. global::h()
+      Execution halted
     Code
       cat_line(collapse)
     Output
@@ -37,7 +41,8 @@
        1. \-global::f()
        2.   +-[ base::tryCatch(...) ] with 1 more call
        4.   \-global::g()
-       5.     \-global::h()Execution halted
+       5.     \-global::h()
+      Execution halted
     Code
       cat_line(full)
     Output
@@ -48,12 +53,14 @@
        2.   +-base::tryCatch(g())
        3.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        4.   \-global::g()
-       5.     \-global::h()Execution halted
+       5.     \-global::h()
+      Execution halted
     Code
       cat_line(rethrown_interactive)
     Output
       Error in `h()`: Error message
-      Run `rlang::last_error()` to see where the error occurred.Execution halted
+      Run `rlang::last_error()` to see where the error occurred.
+      Execution halted
     Code
       cat_line(rethrown_non_interactive)
     Output
@@ -68,31 +75,36 @@
        6.   +-base::tryCatch(g())
        7.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        8.   \-global::g()
-       9.     \-global::h()Execution halted
+       9.     \-global::h()
+      Execution halted
 
 # empty backtraces are not printed
 
     Code
       cat_line(branch_depth_0)
     Output
-      Error: fooExecution halted
+      Error: foo
+      Execution halted
     Code
       cat_line(full_depth_0)
     Output
-      Error: fooExecution halted
+      Error: foo
+      Execution halted
     Code
       cat_line(branch_depth_1)
     Output
       Error in `f()`: foo
       Backtrace:
-       1. global::f()Execution halted
+       1. global::f()
+      Execution halted
     Code
       cat_line(full_depth_1)
     Output
       Error in `f()`: foo
       Backtrace:
           x
-       1. \-global::f()Execution halted
+       1. \-global::f()
+      Execution halted
 
 # parent errors are not displayed in error message and backtrace
 
@@ -100,7 +112,8 @@
       cat_line(interactive)
     Output
       Error: bar
-      Run `rlang::last_error()` to see where the error occurred.Execution halted
+      Run `rlang::last_error()` to see where the error occurred.
+      Execution halted
     Code
       cat_line(non_interactive)
     Output
@@ -116,7 +129,8 @@
         7.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
         8.       \-global::f()
         9.         \-global::g()
-       10.           \-global::h()Execution halted
+       10.           \-global::h()
+      Execution halted
 
 # backtrace reminder is displayed when called from `last_error()`
 
@@ -226,11 +240,9 @@
       # withCallingHandlers()
       print(err_wch)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: bar
-      \-<error/rlang_error>
-        Error in `baz()`: foo
+      <error/rlang_error>
+      Error: bar
+      Caused by error in `baz()`: foo
       Backtrace:
         1. rlang:::catch_error(...)
        10. rlang:::foo()
@@ -242,14 +254,16 @@
     Code
       run("rlang::abort('foo', call = quote(bar(baz)))")
     Output
-      Error in `bar()`: fooExecution halted
+      Error in `bar()`: foo
+      Execution halted
 
 ---
 
     Code
       run("rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))")
     Output
-      Error in `bar()`: fooExecution halted
+      Error in `bar()`: foo
+      Execution halted
 
 # abort() accepts environment as `call` field.
 

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -201,6 +201,7 @@
     Output
       <error/rlang_error>
       Error: no wrapper
+      Caused by error in `failing()`: low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -216,6 +217,7 @@
     Output
       <error/rlang_error>
       Error: wrapper
+      Caused by error in `failing()`: low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -231,6 +233,7 @@
     Output
       <error/rlang_error>
       Error: wrapper
+      Caused by error in `failing()`: low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -4,8 +4,7 @@
       cat_line(default_interactive)
     Output
       Error in `h()`: Error message
-      Run `rlang::last_error()` to see where the error occurred.
-      Execution halted
+      Run `rlang::last_error()` to see where the error occurred.Execution halted
     Code
       cat_line(default_non_interactive)
     Output
@@ -16,13 +15,11 @@
        2.   +-base::tryCatch(g())
        3.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        4.   \-global::g()
-       5.     \-global::h()
-      Execution halted
+       5.     \-global::h()Execution halted
     Code
       cat_line(reminder)
     Output
-      Error in `h()`: Error message
-      Execution halted
+      Error in `h()`: Error messageExecution halted
     Code
       cat_line(branch)
     Output
@@ -30,8 +27,7 @@
       Backtrace:
        1. global::f()
        4. global::g()
-       5. global::h()
-      Execution halted
+       5. global::h()Execution halted
     Code
       cat_line(collapse)
     Output
@@ -41,8 +37,7 @@
        1. \-global::f()
        2.   +-[ base::tryCatch(...) ] with 1 more call
        4.   \-global::g()
-       5.     \-global::h()
-      Execution halted
+       5.     \-global::h()Execution halted
     Code
       cat_line(full)
     Output
@@ -53,14 +48,12 @@
        2.   +-base::tryCatch(g())
        3.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        4.   \-global::g()
-       5.     \-global::h()
-      Execution halted
+       5.     \-global::h()Execution halted
     Code
       cat_line(rethrown_interactive)
     Output
       Error in `h()`: Error message
-      Run `rlang::last_error()` to see where the error occurred.
-      Execution halted
+      Run `rlang::last_error()` to see where the error occurred.Execution halted
     Code
       cat_line(rethrown_non_interactive)
     Output
@@ -75,36 +68,31 @@
        6.   +-base::tryCatch(g())
        7.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        8.   \-global::g()
-       9.     \-global::h()
-      Execution halted
+       9.     \-global::h()Execution halted
 
 # empty backtraces are not printed
 
     Code
       cat_line(branch_depth_0)
     Output
-      Error: foo
-      Execution halted
+      Error: fooExecution halted
     Code
       cat_line(full_depth_0)
     Output
-      Error: foo
-      Execution halted
+      Error: fooExecution halted
     Code
       cat_line(branch_depth_1)
     Output
       Error in `f()`: foo
       Backtrace:
-       1. global::f()
-      Execution halted
+       1. global::f()Execution halted
     Code
       cat_line(full_depth_1)
     Output
       Error in `f()`: foo
       Backtrace:
           x
-       1. \-global::f()
-      Execution halted
+       1. \-global::f()Execution halted
 
 # parent errors are not displayed in error message and backtrace
 
@@ -112,8 +100,7 @@
       cat_line(interactive)
     Output
       Error: bar
-      Run `rlang::last_error()` to see where the error occurred.
-      Execution halted
+      Run `rlang::last_error()` to see where the error occurred.Execution halted
     Code
       cat_line(non_interactive)
     Output
@@ -129,8 +116,7 @@
         7.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
         8.       \-global::f()
         9.         \-global::g()
-       10.           \-global::h()
-      Execution halted
+       10.           \-global::h()Execution halted
 
 # backtrace reminder is displayed when called from `last_error()`
 
@@ -139,8 +125,7 @@
       print(err)
     Output
       <error/rlang_error>
-      foo
-      Call: `h()`
+      Error in `h()`: foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -151,8 +136,7 @@
       print(last_error())
     Output
       <error/rlang_error>
-      foo
-      Call: `h()`
+      Error in `h()`: foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -167,8 +151,7 @@
       }
     Output
       <error/rlang_error>
-      foo
-      Call: `h()`
+      Error in `h()`: foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -183,8 +166,7 @@
       }
     Output
       <error/rlang_error>
-      foo
-      Call: `h()`
+      Error in `h()`: foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -204,7 +186,7 @@
       }
     Output
       <error/rlang_error>
-      no wrapper
+      Error: no wrapper
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -219,7 +201,7 @@
       }
     Output
       <error/rlang_error>
-      wrapper
+      Error: wrapper
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -234,7 +216,7 @@
       }
     Output
       <error/rlang_error>
-      wrapper
+      Error: wrapper
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -246,10 +228,9 @@
     Output
       x
       +-<error/rlang_error>
-      | bar
+      | Error: bar
       \-<error/rlang_error>
-        foo
-      Call: `baz()`
+        Error in `baz()`: foo
       Backtrace:
         1. rlang:::catch_error(...)
        10. rlang:::foo()
@@ -261,16 +242,14 @@
     Code
       run("rlang::abort('foo', call = quote(bar(baz)))")
     Output
-      Error in `bar()`: foo
-      Execution halted
+      Error in `bar()`: fooExecution halted
 
 ---
 
     Code
       run("rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))")
     Output
-      Error in `bar()`: foo
-      Execution halted
+      Error in `bar()`: fooExecution halted
 
 # abort() accepts environment as `call` field.
 
@@ -278,8 +257,7 @@
       (expect_error(f()))
     Output
       <error/rlang_error>
-      `arg` must be supplied.
-      Call: `h()`
+      Error in `h()`: `arg` must be supplied.
 
 # local_error_call() works
 
@@ -287,8 +265,7 @@
       (expect_error(foo()))
     Output
       <error/rlang_error>
-      tilt
-      Call: `expected()`
+      Error in `expected()`: tilt
 
 # can disable error call inference for unexported functions
 
@@ -296,8 +273,7 @@
       (expect_error(foo()))
     Output
       <error/rlang_error>
-      foo
-      Call: `foo()`
+      Error in `foo()`: foo
     Code
       local({
         local_options(`rlang:::restrict_default_error_call` = TRUE)
@@ -305,7 +281,7 @@
       })
     Output
       <error/rlang_error>
-      foo
+      Error: foo
     Code
       local({
         local_options(`rlang:::restrict_default_error_call` = TRUE)
@@ -313,9 +289,8 @@
       })
     Output
       <error/rlang_error>
-      `.homonyms` must be one of "keep", "first", "last", or "error", not "k".
+      Error in `dots_list()`: `.homonyms` must be one of "keep", "first", "last", or "error", not "k".
       i Did you mean "keep"?
-      Call: `dots_list()`
 
 # NSE doesn't interfere with error call contexts
 
@@ -323,18 +298,18 @@
       (expect_error(local(arg_match0("f", "foo"))))
     Output
       <error/rlang_error>
-      `f` must be one of "foo", not "f".
+      Error: `f` must be one of "foo", not "f".
       i Did you mean "foo"?
     Code
       (expect_error(eval_bare(quote(arg_match0("f", "foo")))))
     Output
       <error/rlang_error>
-      `f` must be one of "foo", not "f".
+      Error: `f` must be one of "foo", not "f".
       i Did you mean "foo"?
     Code
       (expect_error(eval_bare(quote(arg_match0("f", "foo")), env())))
     Output
       <error/rlang_error>
-      `f` must be one of "foo", not "f".
+      Error: `f` must be one of "foo", not "f".
       i Did you mean "foo"?
 

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -3,11 +3,9 @@
     Code
       print(err)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/rlang_error>
-        Error in `h()`: Low-level message
+      <error/rlang_error>
+      Error: High-level message
+      Caused by error in `h()`: Low-level message
       Backtrace:
         1. base::identity(catch_error(a()))
        10. rlang:::a()
@@ -19,11 +17,9 @@
     Code
       summary(err)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/rlang_error>
-        Error in `h()`: Low-level message
+      <error/rlang_error>
+      Error: High-level message
+      Caused by error in `h()`: Low-level message
       Backtrace:
            x
         1. +-base::identity(catch_error(a()))
@@ -74,7 +70,8 @@
       cat_line(rlang)
     Output
       Error in `h()`: foo
-      Run `rlang::last_error()` to see where the error occurred.<error/rlang_error>
+      Run `rlang::last_error()` to see where the error occurred.
+      <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
        1. global::f()

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -5,10 +5,9 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/rlang_error>
-        Low-level message
-      Call: `h()`
+        Error in `h()`: Low-level message
       Backtrace:
         1. base::identity(catch_error(a()))
        10. rlang:::a()
@@ -22,10 +21,9 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/rlang_error>
-        Low-level message
-      Call: `h()`
+        Error in `h()`: Low-level message
       Backtrace:
            x
         1. +-base::identity(catch_error(a()))
@@ -59,14 +57,14 @@
       Calls: f -> g -> h
       Run `rlang::last_error()` to see where the error occurred.
       <error/rlang_error>
-      foo
+      Error: foo
       Backtrace:
        1. global::f()
        2. global::g()
        3. global::h()
       Run `rlang::last_trace()` to see the full context.
       <error/rlang_error>
-      foo
+      Error: foo
       Backtrace:
           x
        1. \-global::f()
@@ -76,18 +74,15 @@
       cat_line(rlang)
     Output
       Error in `h()`: foo
-      Run `rlang::last_error()` to see where the error occurred.
-      <error/rlang_error>
-      foo
-      Call: `h()`
+      Run `rlang::last_error()` to see where the error occurred.<error/rlang_error>
+      Error in `h()`: foo
       Backtrace:
        1. global::f()
        2. global::g()
        3. global::h()
       Run `rlang::last_trace()` to see the full context.
       <error/rlang_error>
-      foo
-      Call: `h()`
+      Error in `h()`: foo
       Backtrace:
           x
        1. \-global::f()

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -23,8 +23,7 @@
       print(err)
     Output
       <error/foobar>
-      Low-level message
-      Call: `h()`
+      Error in `h()`: Low-level message
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -38,9 +37,8 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/foobar>
-      Call: `h()`
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang:::a()
@@ -54,10 +52,9 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/foobar>
-        Low-level message
-      Call: `h()`
+        Error in `h()`: Low-level message
       Backtrace:
         1. rlang::with_options(...)
        10. rlang:::a()
@@ -74,9 +71,8 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/foobar>
-      Call: `h()`
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -106,9 +102,8 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/foobar>
-      Call: `h()`
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -135,9 +130,8 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/foobar>
-      Call: `h()`
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
@@ -154,9 +148,8 @@
     Output
       x
       +-<error/rlang_error>
-      | High-level message
+      | Error: High-level message
       \-<error/foobar>
-      Call: `h()`
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang:::a()
@@ -173,12 +166,11 @@
     Output
       x
       +-<error/high>
-      | High-level
+      | Error: High-level
       +-<error/mid>
-      | Mid-level
+      | Error: Mid-level
       \-<error/low>
-        Low-level
-      Call: `low()`
+        Error in `low()`: Low-level
 
 # summary.rlang_error() prints full backtrace
 
@@ -187,10 +179,9 @@
     Output
       x
       +-<error/rlang_error>
-      | The high-level error message
+      | Error: The high-level error message
       \-<error/rlang_error>
-        The low-level error message
-      Call: `h()`
+        Error in `h()`: The low-level error message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -236,6 +227,5 @@
       print(err)
     Output
       <error/rlang_error>
-      msg
-      Call: `foo()`
+      Error in `foo()`: msg
 

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -203,6 +203,7 @@
       print(rlang_err)
     Output
       <error/bar>
+      Caused by error: foo
 
 # errors are printed with call
 
@@ -211,4 +212,19 @@
     Output
       <error/rlang_error>
       Error in `foo()`: msg
+
+# calls are consistently displayed on rethrow (#1240)
+
+    Code
+      (expect_error(with_context(base_problem(), "step_dummy")))
+    Output
+      <error/rlang_error>
+      Error in `step_dummy()`: Problem while executing step.
+      Caused by error in `base_problem()`: oh no!
+    Code
+      (expect_error(with_context(rlang_problem(), "step_dummy")))
+    Output
+      <error/rlang_error>
+      Error in `step_dummy()`: Problem while executing step.
+      Caused by error in `rlang_problem()`: oh no!
 

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -35,10 +35,8 @@
     Code
       print(err)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/foobar>
+      <error/rlang_error>
+      Error: High-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang:::a()
@@ -50,11 +48,9 @@
     Code
       print(err_force)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/foobar>
-        Error in `h()`: Low-level message
+      <error/rlang_error>
+      Error: High-level message
+      Caused by error in `h()`: Low-level message
       Backtrace:
         1. rlang::with_options(...)
        10. rlang:::a()
@@ -69,10 +65,8 @@
     Code
       print(err, simplify = "none")
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/foobar>
+      <error/rlang_error>
+      Error: High-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -100,10 +94,8 @@
       # Full
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/foobar>
+      <error/rlang_error>
+      Error: High-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -128,10 +120,8 @@
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/foobar>
+      <error/rlang_error>
+      Error: High-level message
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
@@ -146,10 +136,8 @@
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: High-level message
-      \-<error/foobar>
+      <error/rlang_error>
+      Error: High-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang:::a()
@@ -164,24 +152,19 @@
     Code
       catch_error(high())
     Output
-      x
-      +-<error/high>
-      | Error: High-level
-      +-<error/mid>
-      | Error: Mid-level
-      \-<error/low>
-        Error in `low()`: Low-level
+      <error/high>
+      Error: High-level
+      Caused by error: Mid-level
+      Caused by error in `low()`: Low-level
 
 # summary.rlang_error() prints full backtrace
 
     Code
       summary(err)
     Output
-      x
-      +-<error/rlang_error>
-      | Error: The high-level error message
-      \-<error/rlang_error>
-        Error in `h()`: The low-level error message
+      <error/rlang_error>
+      Error: The high-level error message
+      Caused by error in `h()`: The low-level error message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -5,7 +5,7 @@
         "Header 2", x = "Bullet 3", x = "Bullet 4"))))
     Output
       <error/rlang_error>
-      Main header.
+      Error: Main header.
       Header 1
       x Bullet 1
       x Bullet 2
@@ -18,7 +18,7 @@
       )
     Output
       <error/rlang_error>
-      Main header.
+      Error: Main header.
       Header 1
       x Bullet 1
         Break line

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -9,12 +9,11 @@
       (expect_error(f(1, 2, 3, xy = 4, x = 5), class = "rlib_error_dots_named"))
     Output
       <error/rlib_error_dots_named>
-      2 arguments in `...` had unexpected names.
+      Error in `f()`: 2 arguments in `...` had unexpected names.
       x We detected these problematic arguments:
       * `xy`
       * `x`
       i Did you misspecify an argument?
-      Call: `f()`
 
 # error if if dots not empty
 
@@ -22,20 +21,18 @@
       (expect_error(f(xy = 4), class = "rlib_error_dots_nonempty"))
     Output
       <error/rlib_error_dots_nonempty>
-      `...` is not empty.
+      Error in `f()`: `...` is not empty.
       i These dots only exist to allow future extensions and should be empty.
       x We detected these problematic arguments:
       * `xy`
       i Did you misspecify an argument?
-      Call: `f()`
     Code
       (expect_error(f0(xy = 4), class = "rlib_error_dots_nonempty"))
     Output
       <error/rlib_error_dots_nonempty>
-      `...` is not empty.
+      Error in `f0()`: `...` is not empty.
       i These dots only exist to allow future extensions and should be empty.
       x We detected these problematic arguments:
       * `xy`
       i Did you misspecify an argument?
-      Call: `f0()`
 

--- a/tests/testthat/_snaps/dots.md
+++ b/tests/testthat/_snaps/dots.md
@@ -4,25 +4,22 @@
       (expect_error(list_error(1, a = 2, a = 3)))
     Output
       <error/rlang_error>
-      Arguments can't have the same name.
+      Error in `list_error()`: Arguments can't have the same name.
       x Multiple arguments named `a` at positions 2 and 3.
-      Call: `list_error()`
     Code
       (expect_error(list_error(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8)))
     Output
       <error/rlang_error>
-      Arguments can't have the same name.
+      Error in `list_error()`: Arguments can't have the same name.
       x Multiple arguments named `a` at positions 2 and 8.
       x Multiple arguments named `b` at positions 3, 5, and 6.
-      Call: `list_error()`
     Code
       (expect_error(list_error(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8)))
     Output
       <error/rlang_error>
-      Arguments can't have the same name.
+      Error in `list_error()`: Arguments can't have the same name.
       x Multiple arguments named `a` at positions 2 and 8.
       x Multiple arguments named `b` at positions 3, 5, and 6.
-      Call: `list_error()`
 
 # `.ignore_empty` is matched
 
@@ -30,15 +27,13 @@
       (expect_error(dots_list(.ignore_empty = "t")))
     Output
       <error/rlang_error>
-      `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
+      Error in `dots_list()`: `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
       i Did you mean "trailing"?
-      Call: `dots_list()`
     Code
       foo <- (function() dots_list(.ignore_empty = "t"))
       (expect_error(foo()))
     Output
       <error/rlang_error>
-      `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
+      Error in `dots_list()`: `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
       i Did you mean "trailing"?
-      Call: `dots_list()`
 

--- a/tests/testthat/_snaps/env-binding.md
+++ b/tests/testthat/_snaps/env-binding.md
@@ -4,12 +4,10 @@
       (expect_error(env_get(env(), "foobar")))
     Output
       <error/rlang_error>
-      Can't find `foobar` in environment.
-      Call: `env_get()`
+      Error in `env_get()`: Can't find `foobar` in environment.
     Code
       (expect_error(env_get_list(env(), "foobar")))
     Output
       <error/rlang_error>
-      Can't find `foobar` in environment.
-      Call: `env_get_list()`
+      Error in `env_get_list()`: Can't find `foobar` in environment.
 

--- a/tests/testthat/_snaps/fn.md
+++ b/tests/testthat/_snaps/fn.md
@@ -4,28 +4,25 @@
       (expect_error(as_function(1)))
     Output
       <error/rlang_error>
-      Can't convert `1`, a double vector, to a function.
+      Error: Can't convert `1`, a double vector, to a function.
     Code
       (expect_error(as_function(1, arg = "foo")))
     Output
       <error/rlang_error>
-      Can't convert `foo`, a double vector, to a function.
+      Error: Can't convert `foo`, a double vector, to a function.
     Code
       (expect_error(my_function(1 + 2)))
     Output
       <error/rlang_error>
-      Can't convert `my_arg`, a double vector, to a function.
-      Call: `my_function()`
+      Error in `my_function()`: Can't convert `my_arg`, a double vector, to a function.
     Code
       (expect_error(my_function(1)))
     Output
       <error/rlang_error>
-      Can't convert `my_arg`, a double vector, to a function.
-      Call: `my_function()`
+      Error in `my_function()`: Can't convert `my_arg`, a double vector, to a function.
     Code
       (expect_error(my_function(a ~ b)))
     Output
       <error/rlang_error>
-      Can't convert `my_arg`, a two-sided formula, to a function.
-      Call: `my_function()`
+      Error in `my_function()`: Can't convert `my_arg`, a two-sided formula, to a function.
 

--- a/tests/testthat/_snaps/operators.md
+++ b/tests/testthat/_snaps/operators.md
@@ -4,22 +4,22 @@
       (expect_error(c(1L, NA) %|% 2))
     Output
       <error/rlang_error>
-      Replacement values must have type integer, not type double
+      Error: Replacement values must have type integer, not type double
     Code
       (expect_error(c(1, NA) %|% ""))
     Output
       <error/rlang_error>
-      Replacement values must have type double, not type character
+      Error: Replacement values must have type double, not type character
     Code
       (expect_error(c(1, NA) %|% call("fn")))
     Output
       <error/rlang_error>
-      Replacement values must have type double, not type language
+      Error: Replacement values must have type double, not type language
     Code
       (expect_error(call("fn") %|% 1))
     Output
       <error/rlang_error>
-      Cannot replace missing values in an object of type language
+      Error: Cannot replace missing values in an object of type language
 
 # %|% fails with wrong length
 
@@ -27,15 +27,15 @@
       (expect_error(c(1L, NA) %|% 1:3))
     Output
       <error/rlang_error>
-      The replacement values must have size 1 or 2, not 3
+      Error: The replacement values must have size 1 or 2, not 3
     Code
       (expect_error(1:10 %|% 1:4))
     Output
       <error/rlang_error>
-      The replacement values must have size 1 or 10, not 4
+      Error: The replacement values must have size 1 or 10, not 4
     Code
       (expect_error(1L %|% 1:4))
     Output
       <error/rlang_error>
-      The replacement values must have size 1, not 4
+      Error: The replacement values must have size 1, not 4
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -4,20 +4,17 @@
       (expect_error(check_installed("_foo")))
     Output
       <error/rlang_error>
-      The package `_foo` is required.
-      Call: `my_wrapper()`
+      Error in `my_wrapper()`: The package `_foo` is required.
     Code
       (expect_error(check_installed(c("_foo", "_bar"))))
     Output
       <error/rlang_error>
-      The packages `_foo` and `_bar` are required.
-      Call: `my_wrapper()`
+      Error in `my_wrapper()`: The packages `_foo` and `_bar` are required.
     Code
       (expect_error(check_installed(c("_foo", "_bar"), "to proceed.")))
     Output
       <error/rlang_error>
-      The packages `_foo` and `_bar` are required to proceed.
-      Call: `my_wrapper()`
+      Error in `my_wrapper()`: The packages `_foo` and `_bar` are required to proceed.
 
 # check_installed() checks minimal versions
 
@@ -25,21 +22,21 @@
       (expect_error(check_installed("_foo", version = "1.0")))
     Output
       <error/rlang_error>
-      The package `_foo` (>= 1.0) is required.
+      Error: The package `_foo` (>= 1.0) is required.
     Code
       (expect_error(check_installed(c("_foo", "_bar"), version = c("1.0", NA))))
     Output
       <error/rlang_error>
-      The packages `_foo` (>= 1.0) and `_bar` are required.
+      Error: The packages `_foo` (>= 1.0) and `_bar` are required.
     Code
       (expect_error(check_installed(c("_foo", "_bar"), version = c(NA, "2.0"))))
     Output
       <error/rlang_error>
-      The packages `_foo` and `_bar` (>= 2.0) are required.
+      Error: The packages `_foo` and `_bar` (>= 2.0) are required.
     Code
       (expect_error(check_installed(c("_foo", "_bar"), "to proceed.", version = c(
         "1.0", "2.0"))))
     Output
       <error/rlang_error>
-      The packages `_foo` (>= 1.0) and `_bar` (>= 2.0) are required to proceed.
+      Error: The packages `_foo` (>= 1.0) and `_bar` (>= 2.0) are required to proceed.
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -981,8 +981,7 @@
           last_error()
       
           ## <error/rlang_error>
-          ## foo
-          ## Call: `h()`
+          ## Error in `h()`: foo
           ## Backtrace:
           ##  1. global::f()
           ##  2. global::g()
@@ -992,8 +991,7 @@
           last_trace()
       
           ## <error/rlang_error>
-          ## foo
-          ## Call: `h()`
+          ## Error in `h()`: foo
           ## Backtrace:
           ##     x
           ##  1. \-global::f()

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -177,12 +177,13 @@ test_that("capture context doesn't leak into low-level backtraces", {
     rlang_trace_top_env = current_env()
   )
 
+  failing <- function() stop("low-level")
   stop_wrapper <- function(...) abort("wrapper", ...)
   f <- function() g()
   g <- function() h()
   h <- function() {
     tryCatch(
-      stop("low-level"),
+      failing(),
       error = function(err) {
         if (wrapper) {
           stop_wrapper(parent = err)

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -159,3 +159,26 @@ test_that("errors are printed with call", {
   err$trace <- NULL
   expect_snapshot(print(err))
 })
+
+test_that("calls are consistently displayed on rethrow (#1240)", {
+  base_problem <- function() stop("oh no!")
+  rlang_problem <- function() abort("oh no!")
+
+  with_context <- function(expr, step_name) {
+    withCallingHandlers(
+      expr = force(expr),
+      error = function(cnd) {
+        rlang::abort(
+          message = "Problem while executing step.", 
+          call = call(step_name), 
+          parent = cnd
+        )
+      }
+    )
+  }
+
+  expect_snapshot({
+    (expect_error(with_context(base_problem(), "step_dummy")))
+    (expect_error(with_context(rlang_problem(), "step_dummy")))
+  })
+})

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -215,13 +215,13 @@ cli::test_that_cli(configs = c("plain", "fancy"), "can use cli syntax in `cnd_me
 
 test_that("prefix takes call into account", {
   err <- error_cnd(message = "Message.", call = quote(foo(bar = TRUE)))
-  expect_equal(cnd_prefix(err), "Error in `foo()`: ")
+  expect_equal(cnd_prefix_error_message(err, ""), "Error in `foo()`: ")
 
   # Inlined objects disable context deparsing
   err1 <- error_cnd(call = expr(foo(bar = !!(1:3))))
   err2 <- error_cnd(call = quote(foo$bar()))
   err3 <- error_cnd(call = call2(identity))
-  expect_equal(cnd_prefix(err1), "Error in `foo()`: ")
-  expect_equal(cnd_prefix(err2), "Error: ")
-  expect_equal(cnd_prefix(err3), "Error: ")
+  expect_equal(cnd_prefix_error_message(err1, ""), "Error in `foo()`: ")
+  expect_equal(cnd_prefix_error_message(err2, ""), "Error: ")
+  expect_equal(cnd_prefix_error_message(err3, ""), "Error: ")
 })


### PR DESCRIPTION
Display call inline when printing errors (e.g. by calling `last_error()`). Closes #1259.

```r
f <- function() g()
g <- function() h()
h <- function() rlang::abort("Low-level.")

f()
#> Error in `h()`: Low-level.
#> Run `rlang::last_error()` to see where the error occurred.

### Before
last_error()
#> <error/rlang_error>
#> Low-level.
#> Call: `h()`
#> Backtrace:
#>  1. global::f()
#>  2. global::g()
#>  3. global::h()
#> Run `rlang::last_trace()` to see the full context.

### After
last_error()
#> <error/rlang_error>
#> Error in `h()`: Low-level.
#> Backtrace:
#>  1. global::f()
#>  2. global::g()
#>  3. global::h()
#> Run `rlang::last_trace()` to see the full context.
```

With chained errors:

```r
a <- function() b()
b <- function() c()
c <- function() {
  withCallingHandlers(
    error = function(cnd) {
      rlang::abort(
        "High-level",
        parent = cnd,
        call = env_parent()
      )
    },
    f()
  )
}

a()
#> Error in `c()`: High-level
#> Run `rlang::last_error()` to see where the error occurred.

### Before
last_error()
#> ▆
#> ├─<error/rlang_error>
#> │ High-level
#> └─<error/rlang_error>
#>   Low-level.
#> Call: `h()`
#> Backtrace:
#>  1. global::a()
#>  2. global::b()
#>  3. global::c()
#>  5. global::f()
#>  6. global::g()
#>  7. global::h()
#> Run `rlang::last_trace()` to see the full context.

### After
last_error()
#> <error/rlang_error>
#> Error in `c()`: High-level
#> Caused by error in `h()`: Low-level.
#> Backtrace:
#>  1. global::a()
#>  2. global::b()
#>  3. global::c()
#>  5. global::f()
#>  6. global::g()
#>  7. global::h()
#> Run `rlang::last_trace()` to see the full context.
```

Fixes #1240.