### PR TITLE
Display source locations in error messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,8 +69,10 @@
     carries a source reference. Source locations are not displayed
     when testthat is running to avoid brittle snapshots.
 
-  - If the "Error:" prefix (including the call and source location) is
-    too long, the error message is printed on the line below.
+  - If the "Error:" prefix including the call is too long, a line
+    break is introduced to print the error message on the line below.
+    If a source location is displayed in the prefix, a line break is
+    always included.
 
 * The `.ignore_empty` argument of `enexprs()` and `enquos()` no longer
   treats named arguments supplied through `...` as empty, consistently

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,11 +54,23 @@
 * `abort()` now outputs error messages to `stdout` in interactive
   sessions, following the same approach as `inform()`.
 
-* `abort()` now displays `call` field in error messages. The call is
-  only displayed if it is a simple expression (e.g. no inlined
-  function) and the arguments are not displayed to avoid distracting
-  from the error message. The message is formatted with the tidyverse
-  style (`code` formatting by the cli package if available).
+* The "Error:" part of error messages is now printed by rlang instead
+  of R. This introduces several cosmetic and informative changes in
+  errors thrown by `abort()`:
+
+  - The `call` field of error messages is now displayed, as is the
+    default in `base::stop()`. The call is only displayed if it is a
+    simple expression (e.g. no inlined function) and the arguments are
+    not displayed to avoid distracting from the error message. The
+    message is formatted with the tidyverse style (`code` formatting
+    by the cli package if available).
+
+  - The source location is displayed (as in `base::stop()`) if `call`
+    carries a source reference. Source locations are not displayed
+    when testthat is running to avoid brittle snapshots.
+
+  - If the "Error:" prefix (including the call and source location) is
+    too long, the error message is printed on the line below.
 
 * The `.ignore_empty` argument of `enexprs()` and `enquos()` no longer
   treats named arguments supplied through `...` as empty, consistently

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -622,7 +622,7 @@ error_call <- function(call) {
   }
 
   # Remove distracting arguments from the call
-  call[1]
+  call_restore(call[1], call)
 }
 #' @rdname error_call
 #' @export
@@ -633,6 +633,11 @@ format_error_call <- function(call) {
   }
 
   format_code(as_label(call))
+}
+
+call_restore <- function(x, to) {
+  attr(x, "srcref") <- attr(to, "srcref")
+  x
 }
 
 error_flag <- function(env, top = topenv(env)) {

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -17,6 +17,24 @@
 #' kind that is signalled with `Ctrl-C`. It is currently not possible
 #' to create custom interrupt condition objects.
 #'
+#' @section Error prefix:
+#'
+#' As with [base::stop()], errors thrown with `abort()` are prefixed
+#' with `"Error: "`. Calls and source references are included in the
+#' prefix, e.g. `"Error in `my_function()` at myfile.R:1:2:"`. There
+#' are a few cosmetic differences:
+#'
+#' - The call is stripped from its arguments to keep it simple. It is
+#'   then formatted using the cli package if available.
+#'
+#' - A line break between the prefix and the message when the former
+#'   is too long.
+#'
+#' If your throwing code is highly structured, you may have to
+#' explicitly inform `abort()` about the relevant user-facing call to
+#' include in the prefix. Internal helpers are rarely relevant to end
+#' users. See the `call` argument of `abort()`.
+#'
 #' @section Backtrace:
 #'
 #' Unlike `stop()` and `warning()`, these functions don't include call

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -28,7 +28,8 @@
 #'   then formatted using the cli package if available.
 #'
 #' - A line break between the prefix and the message when the former
-#'   is too long.
+#'   is too long. When a source location is included, a line break is
+#'   always inserted.
 #'
 #' If your throwing code is highly structured, you may have to
 #' explicitly inform `abort()` about the relevant user-facing call to

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -101,6 +101,7 @@ cnd_footer.default <- function(cnd, ...) {
   chr()
 }
 
+# TODO: Add srcref info
 cnd_prefix_error_message <- function(cnd, message, prefix = "Error") {
   call <- format_error_call(cnd$call)
 
@@ -111,8 +112,11 @@ cnd_prefix_error_message <- function(cnd, message, prefix = "Error") {
   }
   prefix <- style_bold(prefix)
 
-  # TODO: srcref, line break
-  paste0(prefix, message)
+  if (nchar(strip_style(prefix)) > (peek_option("width") / 2)) {
+    paste0(prefix, "\n", message)
+  } else {
+    paste0(prefix, message)
+  }
 }
 
 #' Format bullets for error messages

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -103,6 +103,7 @@ cnd_footer.default <- function(cnd, ...) {
 
 cnd_prefix_error_message <- function(cnd, message, prefix = "Error") {
   call <- format_error_call(cnd$call)
+  has_loc <- FALSE
 
   if (is_null(call)) {
     prefix <- sprintf("%s: ", prefix)
@@ -110,13 +111,14 @@ cnd_prefix_error_message <- function(cnd, message, prefix = "Error") {
     src_loc <- src_loc(attr(cnd$call, "srcref"))
     if (nzchar(src_loc) && !is_testing()) {
       prefix <- sprintf("%s in %s at %s: ", prefix, call, src_loc)
+      has_loc <- TRUE
     } else {
       prefix <- sprintf("%s in %s: ", prefix, call)
     }
   }
   prefix <- style_bold(prefix)
 
-  if (nchar(strip_style(prefix)) > (peek_option("width") / 2)) {
+  if (has_loc || nchar(strip_style(prefix)) > (peek_option("width") / 2)) {
     paste0(prefix, "\n", message)
   } else {
     paste0(prefix, message)

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -101,14 +101,18 @@ cnd_footer.default <- function(cnd, ...) {
   chr()
 }
 
-# TODO: Add srcref info
 cnd_prefix_error_message <- function(cnd, message, prefix = "Error") {
   call <- format_error_call(cnd$call)
 
   if (is_null(call)) {
     prefix <- sprintf("%s: ", prefix)
   } else {
-    prefix <- sprintf("%s in %s: ", prefix, call)
+    src_loc <- src_loc(attr(cnd$call, "srcref"))
+    if (nzchar(src_loc) && !is_testing()) {
+      prefix <- sprintf("%s in %s at %s: ", prefix, call, src_loc)
+    } else {
+      prefix <- sprintf("%s in %s: ", prefix, call)
+    }
   }
   prefix <- style_bold(prefix)
 

--- a/R/eval.R
+++ b/R/eval.R
@@ -367,3 +367,18 @@ exec <- function(.fn, ..., .env = caller_env()) {
 inject <- function(expr, env = caller_env()) {
   .External2(ffi_eval, enexpr(expr), env)
 }
+
+eval_parse <- function(code, env = caller_env()) {
+  file <- tempfile("rlang_eval_parsed_", fileext = ".R")
+  on.exit(if (file.exists(file)) file.remove(file))
+
+  writeLines(code, file)
+  exprs <- parse(file, keep.source = TRUE)
+
+  out <- NULL
+  for (expr in exprs) {
+    out <- eval_bare(expr, env)
+  }
+
+  out
+}

--- a/R/trace.R
+++ b/R/trace.R
@@ -360,11 +360,6 @@ format_collapsed <- function(what, n) {
 
   paste0(what, n_text)
 }
-format_collapsed_branch <- function(what, n, style = NULL) {
-  style <- style %||% cli_box_chars()
-  what <- sprintf(" %s %s", style$h, what)
-  format_collapsed(what, n)
-}
 
 cli_branch <- function(tree,
                        max = NULL,
@@ -376,16 +371,10 @@ cli_branch <- function(tree,
     return(chr())
   }
 
-  numbered <- length(indices)
-  if (numbered) {
-    indices <- pad_spaces(as.character(indices))
-    indices <- paste0(" ", indices, ". ")
-    padding <- nchar(indices[[1]])
-    lines <- paste0(silver(indices), lines)
-  } else {
-    style <- style %||% cli_box_chars()
-    lines <- paste0(" ", style$h, lines)
-  }
+  indices <- pad_spaces(as.character(indices))
+  indices <- paste0(" ", indices, ". ")
+  padding <- nchar(indices[[1]])
+  lines <- paste0(silver(indices), lines)
 
   if (is_null(max)) {
     return(lines)
@@ -404,11 +393,7 @@ cli_branch <- function(tree,
   style <- style %||% cli_box_chars()
   n_collapsed <- n - max
 
-  if (numbered) {
-    collapsed_line <- paste0(spaces(padding), "...")
-  } else {
-    collapsed_line <- format_collapsed_branch("...", n_collapsed, style = style)
-  }
+  collapsed_line <- paste0(spaces(padding), "...")
 
   if (max == 1L) {
     lines <- chr(

--- a/R/utils-cli-tree.R
+++ b/R/utils-cli-tree.R
@@ -13,6 +13,9 @@ cli_tree <- function(data,
   style <- style %||% cli_box_chars()
 
   labels <- data$call_text
+  src_locs <- chr(map_if(data$src_loc, nzchar, ~ paste0(" at ", .x)))
+  labels <- paste0(labels, style_locs(src_locs))
+
   res <- character()
 
   pt <- function(root, n = integer(), mx = integer()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -386,9 +386,5 @@ df_print <- function(x, ...) {
 }
 
 is_testing <- function() {
-  if (is_bool(opt <- peek_option("rlang:::is_testing"))) {
-    return(opt)
-  }
-
-  is_installed("testthat") && testthat::is_testing()
+  identical(Sys.getenv("TESTTHAT"), "true")
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -384,3 +384,11 @@ df_print <- function(x, ...) {
   print(x, ...)
   invisible(x)
 }
+
+is_testing <- function() {
+  if (is_bool(opt <- peek_option("rlang:::is_testing"))) {
+    return(opt)
+  }
+
+  is_installed("testthat") && testthat::is_testing()
+}

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -124,6 +124,26 @@ characters) is especially easy to hit when the message contains a
 lot of ANSI escapes, as created by the crayon or cli packages
 }
 }
+\section{Error prefix}{
+
+
+As with \code{\link[base:stop]{base::stop()}}, errors thrown with \code{abort()} are prefixed
+with \code{"Error: "}. Calls and source references are included in the
+prefix, e.g. \verb{"Error in }my_function()\verb{ at myfile.R:1:2:"}. There
+are a few cosmetic differences:
+\itemize{
+\item The call is stripped from its arguments to keep it simple. It is
+then formatted using the cli package if available.
+\item A line break between the prefix and the message when the former
+is too long.
+}
+
+If your throwing code is highly structured, you may have to
+explicitly inform \code{abort()} about the relevant user-facing call to
+include in the prefix. Internal helpers are rarely relevant to end
+users. See the \code{call} argument of \code{abort()}.
+}
+
 \section{Backtrace}{
 
 

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -135,7 +135,8 @@ are a few cosmetic differences:
 \item The call is stripped from its arguments to keep it simple. It is
 then formatted using the cli package if available.
 \item A line break between the prefix and the message when the former
-is too long.
+is too long. When a source location is included, a line break is
+always inserted.
 }
 
 If your throwing code is highly structured, you may have to

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -71,3 +71,12 @@
     Output
       [1] "\033[1m\033[22m\033[1m\033[1mHeader: \033[3m\033[1m\033[3mUser { {field}.\033[3m\033[1m\033[23m\033[1m\033[22m\n\033[1m\033[22m\033[36mℹ\033[39m Bullet: \033[3m\033[3mUser { {field}.\033[3m\033[23m\n\033[1m\033[22mFooter: \033[3m\033[3mUser { {field}.\033[3m\033[23m"
 
+# long prefixes cause a line break
+
+    Code
+      (expect_error(very_very_very_very_very_long_function_name()))
+    Output
+      <error/rlang_error>
+      Error in `very_very_very_very_very_long_function_name()`: 
+      My somewhat longish and verbose error message.
+

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -80,3 +80,11 @@
       Error in `very_very_very_very_very_long_function_name()`: 
       My somewhat longish and verbose error message.
 
+# prefixes include srcrefs
+
+    Code
+      (expect_error(f()))
+    Output
+      <error/rlang_error>
+      Error in `g()` at bar/baz/myfile.R:2:9: Foo.
+

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -86,5 +86,6 @@
       (expect_error(f()))
     Output
       <error/rlang_error>
-      Error in `g()` at bar/baz/myfile.R:2:9: Foo.
+      Error in `g()` at bar/baz/myfile.R:2:9: 
+      Foo.
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -4,10 +4,10 @@
       print(trace, dir = dir)
     Output
           x
-       1. \-rlang:::i() test-trace.R:25:2
-       2.   \-rlang:::j(i) test-trace.R:18:7
-       3.     \-rlang:::k(i) test-trace.R:19:21
-       4.       \-rlang:::l(i) test-trace.R:22:4
+       1. \-rlang:::i() at test-trace.R:25:2
+       2.   \-rlang:::j(i) at test-trace.R:18:7
+       3.     \-rlang:::k(i) at test-trace.R:19:21
+       4.       \-rlang:::l(i) at test-trace.R:22:4
     Code
       cat("\n")
     Output
@@ -25,8 +25,8 @@
     Output
            x
         1. \-rlang:::f()
-        2.   \-rlang:::g() test-trace.R:49:20
-        3.     +-base::tryCatch(h(), foo = identity, bar = identity) test-trace.R:50:20
+        2.   \-rlang:::g() at test-trace.R:49:20
+        3.     +-base::tryCatch(h(), foo = identity, bar = identity) at test-trace.R:50:20
         4.     | \-base:::tryCatchList(expr, classes, parentenv, handlers)
         5.     |   +-base:::tryCatchOne(...)
         6.     |   | \-base:::doTryCatch(return(expr), name, parentenv, handler)
@@ -34,12 +34,12 @@
         8.     |     \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
         9.     |       \-base:::doTryCatch(return(expr), name, parentenv, handler)
        10.     \-rlang:::h()
-       11.       +-base::tryCatch(i(), baz = identity) test-trace.R:51:20
+       11.       +-base::tryCatch(i(), baz = identity) at test-trace.R:51:20
        12.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        13.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
        14.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
        15.       \-rlang:::i()
-       16.         +-base::tryCatch(trace_back(e, bottom = 0)) test-trace.R:52:20
+       16.         +-base::tryCatch(trace_back(e, bottom = 0)) at test-trace.R:52:20
        17.         | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        18.         \-rlang::trace_back(e, bottom = 0)
     Code
@@ -48,12 +48,12 @@
     Output
            x
         1. \-rlang:::f()
-        2.   \-rlang:::g() test-trace.R:49:20
-        3.     +-[ base::tryCatch(...) ] with 6 more calls test-trace.R:50:20
+        2.   \-rlang:::g() at test-trace.R:49:20
+        3.     +-[ base::tryCatch(...) ] with 6 more calls at test-trace.R:50:20
        10.     \-rlang:::h()
-       11.       +-[ base::tryCatch(...) ] with 3 more calls test-trace.R:51:20
+       11.       +-[ base::tryCatch(...) ] with 3 more calls at test-trace.R:51:20
        15.       \-rlang:::i()
-       16.         +-[ base::tryCatch(...) ] with 1 more call test-trace.R:52:20
+       16.         +-[ base::tryCatch(...) ] with 1 more call at test-trace.R:52:20
        18.         \-rlang::trace_back(e, bottom = 0)
     Code
       # Branch
@@ -74,12 +74,12 @@
     Output
            x
         1. \-rlang:::f()
-        2.   +-base::eval(quote(eval(quote(g())))) test-trace.R:61:7
+        2.   +-base::eval(quote(eval(quote(g())))) at test-trace.R:61:7
         3.   | \-base::eval(quote(eval(quote(g()))))
         4.   +-base::eval(quote(g()))
         5.   | \-base::eval(quote(g()))
         6.   \-rlang:::g()
-        7.     +-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) test-trace.R:62:7
+        7.     +-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) at test-trace.R:62:7
         8.     | \-base:::tryCatchList(expr, classes, parentenv, handlers)
         9.     |   +-base:::tryCatchOne(...)
        10.     |   | \-base:::doTryCatch(return(expr), name, parentenv, handler)
@@ -95,10 +95,10 @@
     Output
            x
         1. \-rlang:::f()
-        2.   +-[ base::eval(...) ] with 1 more call test-trace.R:61:7
+        2.   +-[ base::eval(...) ] with 1 more call at test-trace.R:61:7
         4.   +-[ base::eval(...) ] with 1 more call
         6.   \-rlang:::g()
-        7.     +-[ base::tryCatch(...) ] with 6 more calls test-trace.R:62:7
+        7.     +-[ base::tryCatch(...) ] with 6 more calls at test-trace.R:62:7
        14.     +-[ base::eval(...) ] with 1 more call
        16.     \-rlang:::h()
     Code
@@ -827,14 +827,14 @@
     Output
           x
        1. \-rlang:::f(current_env())
-       2.   \-rlang:::g(e) fixtures/trace-srcref2.R:2:2
+       2.   \-rlang:::g(e) at fixtures/trace-srcref2.R:2:2
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. \-rlang:::f(current_env())
-       2.   \-rlang:::g(e) fixtures/trace-srcref2.R:2:2
+       2.   \-rlang:::g(e) at fixtures/trace-srcref2.R:2:2
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
@@ -910,14 +910,14 @@
       summary(trace0)
     Output
            x
-        1. \-rlang:::f(0) test-trace.R:456:2
-        2.   +-base::identity(identity(g(n))) test-trace.R:452:7
+        1. \-rlang:::f(0) at test-trace.R:456:2
+        2.   +-base::identity(identity(g(n))) at test-trace.R:452:7
         3.   +-base::identity(g(n))
         4.   \-rlang:::g(n)
-        5.     +-base::identity(identity(h(n))) test-trace.R:453:7
+        5.     +-base::identity(identity(h(n))) at test-trace.R:453:7
         6.     +-base::identity(h(n))
         7.     \-rlang:::h(n)
-        8.       +-base::identity(identity(trace_back(e, bottom = n))) test-trace.R:454:7
+        8.       +-base::identity(identity(trace_back(e, bottom = n))) at test-trace.R:454:7
         9.       +-base::identity(trace_back(e, bottom = n))
        10.       \-rlang::trace_back(e, bottom = n)
     Code
@@ -930,11 +930,11 @@
       summary(trace1)
     Output
           x
-       1. \-rlang:::f(1) test-trace.R:457:2
-       2.   +-base::identity(identity(g(n))) test-trace.R:452:7
+       1. \-rlang:::f(1) at test-trace.R:457:2
+       2.   +-base::identity(identity(g(n))) at test-trace.R:452:7
        3.   +-base::identity(g(n))
        4.   \-rlang:::g(n)
-       5.     +-base::identity(identity(h(n))) test-trace.R:453:7
+       5.     +-base::identity(identity(h(n))) at test-trace.R:453:7
        6.     +-base::identity(h(n))
        7.     \-rlang:::h(n)
     Code
@@ -947,8 +947,8 @@
       summary(trace2)
     Output
           x
-       1. \-rlang:::f(2) test-trace.R:458:2
-       2.   +-base::identity(identity(g(n))) test-trace.R:452:7
+       1. \-rlang:::f(2) at test-trace.R:458:2
+       2.   +-base::identity(identity(g(n))) at test-trace.R:452:7
        3.   +-base::identity(g(n))
        4.   \-rlang:::g(n)
     Code
@@ -961,7 +961,7 @@
       summary(trace3)
     Output
           x
-       1. \-rlang:::f(3) test-trace.R:459:2
+       1. \-rlang:::f(3) at test-trace.R:459:2
 
 # caught error does not display backtrace in knitted files
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -60,7 +60,8 @@
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
         1. rlang:::f()
-        2. rlang:::g() test-trace.R:49:20
+        2. rlang:::g()
+           at test-trace.R:49:20
        10. rlang:::h()
        15. rlang:::i()
        18. rlang::trace_back(e, bottom = 0)
@@ -839,7 +840,8 @@
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. rlang:::f(current_env())
-       2. rlang:::g(e) fixtures/trace-srcref2.R:2:2
+       2. rlang:::g(e)
+          at fixtures/trace-srcref2.R:2:2
 
 # summary.rlang_trace() prints the full tree
 

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -383,3 +383,14 @@ test_that("local_error_call() returns old error call", {
   out <- withVisible(local_error_call(quote(bar())))
   expect_equal(out, list(value = quote(foo()), visible = FALSE))
 })
+
+test_that("error_call() preserves srcrefs", {
+  eval_parse("{
+    f <- function() g()
+    g <- function() h()
+    h <- function() abort('Foo.')
+  }")
+
+  out <- error_call(catch_error(f())$call)
+  expect_s3_class(attr(out, "srcref"), "srcref")
+})

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -233,3 +233,17 @@ test_that("long prefixes cause a line break", {
 
   expect_snapshot((expect_error(very_very_very_very_very_long_function_name())))
 })
+
+test_that("prefixes include srcrefs", {
+  local_options("rlang:::is_testing" = FALSE)
+
+  eval_parse("{
+    f <- function() g()
+    g <- function() abort('Foo.')
+  }")
+
+  src_file <- g %@% srcref %@% srcfile
+  src_file$filename <- "/foo/bar/baz/myfile.R"
+
+  expect_snapshot((expect_error(f())))
+})

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -235,7 +235,7 @@ test_that("long prefixes cause a line break", {
 })
 
 test_that("prefixes include srcrefs", {
-  local_options("rlang:::is_testing" = FALSE)
+  withr::local_envvar("TESTTHAT" = "")
 
   eval_parse("{
     f <- function() g()

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -225,3 +225,11 @@ test_that("prefix takes call into account", {
   expect_equal(cnd_prefix_error_message(err2, ""), "Error: ")
   expect_equal(cnd_prefix_error_message(err3, ""), "Error: ")
 })
+
+test_that("long prefixes cause a line break", {
+  very_very_very_very_very_long_function_name <- function() {
+    abort("My somewhat longish and verbose error message.")
+  }
+
+  expect_snapshot((expect_error(very_very_very_very_very_long_function_name())))
+})


### PR DESCRIPTION
- Add a line break between the error prefix (the "Error:" part) and the error message when the former gets too long. A long prefix is currently defined as longer than half the screen width or when a source location is included.

- Add srcref information in the error prefix (closes #1260). This is not displayed when testthat is running to avoid making snapshots brittle. testthat provides source locations for unexpected errors and warnings via other means.

- Add an "Error prefix:" section in `?abort`.

- Include srcrefs on their own lines in simplified backtraces.

- Use "at" to introduce srcrefs in backtraces, consistently with the error prefix.

```r
rlang:::eval_parse("{
    f <- function() g()
    g <- function() h()
    h <- function() abort('Foo.')
  }")

src_file <- h %@% srcref %@% srcfile
src_file$filename <- "/foo/bar/baz/myfile.R"

f()
#> Error in `h()` at bar/baz/myfile.R:3:9:
#> Foo.
#> Run `rlang::last_error()` to see where the error occurred.

last_error()
#> <error/rlang_error>
#> Error in `h()` at bar/baz/myfile.R:3:9:
#> Foo.
#> Backtrace:
#>  1. global::f()
#>  2. global::g()
#>     at bar/baz/myfile.R:2:9
#>  3. global::h()
#>     bar/baz/myfile.R:3:9
```