### PR TITLE
Print parent errors at throw time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,6 +73,10 @@
     break is introduced to print the error message on the line below.
     If a source location is displayed in the prefix, a line break is
     always included.
+    
+* The display of chained errors created with the `parent` argument of
+  `abort()` has been improved. Chains of errors are now displayed at
+  throw time with the error prefix "Caused by error:".
 
 * The `.ignore_empty` argument of `enexprs()` and `enquos()` no longer
   treats named arguments supplied through `...` as empty, consistently

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -306,13 +306,13 @@ signal_abort <- function(cnd, file = NULL) {
   # Save the unhandled error for `rlang::last_error()`.
   poke_last_error(cnd)
 
-  # Print the backtrace manually to work around limitations on the
-  # length of error messages (#856)
-  msg <- cnd_unhandled_message(cnd)
-  msg <- cnd_prefix_error_message(cnd, msg)
-  msg <- paste0(msg, "\n")
+  # Print the error manually. This allows us to use our own style,
+  # include parent errors, and work around limitations on the length
+  # of error messages (#856).
+  msg <- cnd_build_error_message(cnd)
+  msg <- cnd_unhandled_message(cnd, message = msg)
 
-  cat(msg, file = file %||% default_message_file())
+  cat_line(msg, file = file %||% default_message_file())
 
   # Use `stop()` to run the `getOption("error")` handler (used by
   # RStudio to record a backtrace) and cause a long jump. Running the
@@ -705,11 +705,8 @@ cnd_as_unhandled_error <- function(cnd) {
     call = cnd$call
   )
 }
-cnd_unhandled_message <- function(cnd) {
-  paste_line(
-    conditionMessage(cnd),
-    format_onerror_backtrace(cnd)
-  )
+cnd_unhandled_message <- function(cnd, message = conditionMessage(cnd)) {
+  paste_line(message, format_onerror_backtrace(cnd))
 }
 
 on_load({

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -57,7 +57,7 @@ format.rlang_error <- function(x,
   style <- cli_box_chars()
 
   header <- rlang_error_header(x)
-  message <- cnd_prefix_error_message(x)
+  message <- cnd_prefix_error_message(x, indent = is_error(parent))
 
   out <- paste_line(
     header,
@@ -77,7 +77,8 @@ format.rlang_error <- function(x,
     message <- cnd_prefix_error_message(
       x,
       message = cnd_header(x),
-      prefix = "Caused by error"
+      prefix = "Caused by error",
+      indent = TRUE
     )
 
     out <- paste_line(out, message)

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -111,13 +111,19 @@
     Code
       cat_line(interactive)
     Output
-      Error: bar
+      Error: 
+        bar
+      Caused by error in `h()`: 
+        foo
       Run `rlang::last_error()` to see where the error occurred.
       Execution halted
     Code
       cat_line(non_interactive)
     Output
-      Error: bar
+      Error: 
+        bar
+      Caused by error in `h()`: 
+        foo
       Backtrace:
            x
         1. \-global::a()
@@ -200,8 +206,10 @@
       }
     Output
       <error/rlang_error>
-      Error: no wrapper
-      Caused by error in `failing()`: low-level
+      Error: 
+        no wrapper
+      Caused by error in `failing()`: 
+        low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -216,8 +224,10 @@
       }
     Output
       <error/rlang_error>
-      Error: wrapper
-      Caused by error in `failing()`: low-level
+      Error: 
+        wrapper
+      Caused by error in `failing()`: 
+        low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -232,8 +242,10 @@
       }
     Output
       <error/rlang_error>
-      Error: wrapper
-      Caused by error in `failing()`: low-level
+      Error: 
+        wrapper
+      Caused by error in `failing()`: 
+        low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang:::f()
@@ -244,8 +256,10 @@
       print(err_wch)
     Output
       <error/rlang_error>
-      Error: bar
-      Caused by error in `baz()`: foo
+      Error: 
+        bar
+      Caused by error in `baz()`: 
+        foo
       Backtrace:
         1. rlang:::catch_error(...)
        10. rlang:::foo()

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -4,8 +4,10 @@
       print(err)
     Output
       <error/rlang_error>
-      Error: High-level message
-      Caused by error in `h()`: Low-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
         1. base::identity(catch_error(a()))
        10. rlang:::a()
@@ -18,8 +20,10 @@
       summary(err)
     Output
       <error/rlang_error>
-      Error: High-level message
-      Caused by error in `h()`: Low-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
            x
         1. +-base::identity(catch_error(a()))

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -36,7 +36,10 @@
       print(err)
     Output
       <error/rlang_error>
-      Error: High-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang:::a()
@@ -52,7 +55,10 @@
       print(err, simplify = "none")
     Output
       <error/rlang_error>
-      Error: High-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -81,7 +87,10 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
       <error/rlang_error>
-      Error: High-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -107,7 +116,10 @@
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
       <error/rlang_error>
-      Error: High-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
@@ -123,7 +135,10 @@
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
       <error/rlang_error>
-      Error: High-level message
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang:::a()
@@ -139,9 +154,12 @@
       catch_error(high())
     Output
       <error/high>
-      Error: High-level
-      Caused by error: Mid-level
-      Caused by error in `low()`: Low-level
+      Error: 
+        High-level
+      Caused by error: 
+        Mid-level
+      Caused by error in `low()`: 
+        Low-level
 
 # summary.rlang_error() prints full backtrace
 
@@ -149,8 +167,10 @@
       summary(err)
     Output
       <error/rlang_error>
-      Error: The high-level error message
-      Caused by error in `h()`: The low-level error message
+      Error: 
+        The high-level error message
+      Caused by error in `h()`: 
+        The low-level error message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -189,7 +209,10 @@
       print(rlang_err)
     Output
       <error/bar>
-      Caused by error: foo
+      Error: 
+        baz
+      Caused by error: 
+        foo
 
 # errors are printed with call
 
@@ -205,12 +228,16 @@
       (expect_error(with_context(base_problem(), "step_dummy")))
     Output
       <error/rlang_error>
-      Error in `step_dummy()`: Problem while executing step.
-      Caused by error in `base_problem()`: oh no!
+      Error in `step_dummy()`: 
+        Problem while executing step.
+      Caused by error in `base_problem()`: 
+        oh no!
     Code
       (expect_error(with_context(rlang_problem(), "step_dummy")))
     Output
       <error/rlang_error>
-      Error in `step_dummy()`: Problem while executing step.
-      Caused by error in `rlang_problem()`: oh no!
+      Error in `step_dummy()`: 
+        Problem while executing step.
+      Caused by error in `rlang_problem()`: 
+        oh no!
 

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -44,7 +44,7 @@ test_that("rlang_error.print() calls conditionMessage() method", {
 test_that("error is printed with parent backtrace", {
   # Test low-level error can use conditionMessage()
   local_bindings(.env = global_env(),
-    conditionMessage.foobar = function(c) c$foobar_msg
+    cnd_header.foobar = function(c) c$foobar_msg
   )
 
   f <- function() g()
@@ -143,7 +143,7 @@ test_that("don't print message or backtrace fields if empty", {
 
 test_that("base parent errors are printed with rlang method", {
   base_err <- simpleError("foo")
-  rlang_err <- error_cnd("bar", message = "", parent = base_err)
+  rlang_err <- error_cnd("bar", message = "baz", parent = base_err)
   expect_snapshot(print(rlang_err))
 })
 


### PR DESCRIPTION
And indent error messages when printing a chain of errors.

The display is unchanged in the normal case:

```r
f <- function() g()
g <- function() h()
h <- function() rlang::abort("Low-level.")

f()
#> Error in `h()`: Low-level.

last_error()
#> <error/rlang_error>
#> Error in `h()`: Low-level.
#> Backtrace:
#>  1. global::f()
#>  2. global::g()
#>  3. global::h()
```

If the error is part of a chain, all parent causes are displayed with indentation:

```r
a <- function() b()
b <- function() c()
c <- function() {
  withCallingHandlers(
    error = function(cnd) {
      rlang::abort(
        "High-level",
        parent = cnd,
        call = env_parent()
      )
    },
    f()
  )
}

a()
#> Error in `c()`:
#>   High-level
#> Caused by error in `h()`:
#>   Low-level.

last_error()
#> <error/rlang_error>
#> Error in `c()`:
#>   High-level
#> Caused by error in `h()`:
#>   Low-level.
#> Backtrace:
#>  1. global::a()
#>  2. global::b()
#>  3. global::c()
#>  5. global::f()
#>  6. global::g()
#>  7. global::h()
```