### PR TITLE
More clearly cross-reference rlang_backtrace_on_error

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -797,63 +797,47 @@ trace_capture_depth <- function(trace) {
 #' @description
 #'
 #' Errors thrown with [abort()] automatically save a backtrace that
-#' can be inspected by calling [last_error()]. Optionally, you can
-#' also display the backtrace alongside the error message by setting
-#' the option `rlang_backtrace_on_error` to one of the following
-#' values:
+#' can be inspected by calling [last_error()]. You can control the default
+#' display of the backtrace by setting the option `rlang_backtrace_on_error`
+#' to one of the following values:
 #'
-#' * `"reminder"`: Display a reminder that the backtrace can be
-#'   inspected by calling [rlang::last_error()].
-#' * `"branch"`: Display a simplified backtrace.
-#' * `"collapse"`: Display a collapsed backtrace tree.
-#' * `"full"`: Display the full backtrace tree.
-#'
-#' If this option is not set, the default depends on whether the
-#' session is interactive as determined by [rlang::is_interactive()].
-#' In interactive sessions, the default is `"reminder"` so that the
-#' interested user is prompted to run `last_error()` to get more
-#' information. In non-interactive sessions, the default is `"full"`
-#' to provide users with as much debugging info as available.
-#'
+#' * `"none"` show nothing.
+#' * `"reminder"`, the default in interactive sessions, displays a reminder that
+#'   you can see the backtrace with [rlang::last_error()].
+#' * `"branch"` displays a simplified backtrace.
+#' * `"collapse"` displays a collapsed backtrace tree.
+#' * `"full"`, the default in non-interactive sessions, displays the full tree.
 #'
 #' @section Promote base errors to rlang errors:
 #'
-#' Call `options(error = rlang::entrace)` to instrument base
-#' errors with rlang features. This handler does two things:
+#' You can use `options(error = rlang::entrace)` to promote base errors to
+#' rlang errors. This does two things:
 #'
-#' * It saves the base error as an rlang object. This allows you to
-#'   call [last_error()] to print the backtrace or inspect its data.
+#' * It saves the base error as an rlang object so you can call [last_error()]
+#'   to print the backtrace or inspect its data.
 #'
 #' * It prints the backtrace for the current error according to the
 #'   `rlang_backtrace_on_error` option.
 #'
+#' @section Errors in RMarkdown:
 #'
-#' @section Unexpected errors in dynamic reports:
+#' There are two types of errors in Rmds: expected (i.e. `error = TRUE`)
+#' and unexpected.
 #'
-#' In dynamic reports (knitted Rmarkdown or RStudio notebooks), the
-#' relevant option is `rlang_backtrace_on_error_report`. The default
-#' is `"none"` in interactive sessions and `"branch"` in
-#' non-interactive sessions.
+#' * The display of unexpected errors is controlled by option
+#'   `rlang_backtrace_on_error_report` (note the `_report`). The
+#'   default is `"none"` in interactive sessions and `"branch"` in
+#'   non-interactive sessions.
 #'
-#'
-#' @section Expected errors in Rmarkdown documents:
-#'
-#' An `rlang_error` method for the `knitr::sew()` generic is
-#' registered to make it possible to display backtraces with captured
-#' errors (`error = TRUE` chunks).
-#'
-#' In `error = TRUE` chunks, the default value for
-#' `rlang_backtrace_on_error` is `"none"`. You can override it by
-#' setting this option in your document, e.g. to `"reminder"` or
-#' `"full"`.
+#' * The display of expected errors is controlled by option
+#'   `rlang_backtrace_on_error`. The default is `"none"`.
 #'
 #' When knitr is running (as determined by the `knitr.in.progress`
 #' global option), the default top environment for backtraces is set
 #' to the chunk environment `knitr::knit_global()`. This ensures that
 #' the part of the call stack belonging to knitr does not end up in
-#' backtraces. You can override this by setting the
-#' `rlang_trace_top_env` global option or by supplying the `top`
-#' argument to [trace_back()].
+#' backtraces. If needed, you can override this by setting the
+#' `rlang_trace_top_env` global option.
 #'
 #' @name rlang_backtrace_on_error
 #' @aliases add_backtrace

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -38,24 +38,10 @@
 #'
 #' @section Backtrace:
 #'
-#' Unlike `stop()` and `warning()`, these functions don't include call
-#' information by default. This saves you from typing `call. = FALSE`
-#' and produces cleaner error messages.
-#'
-#' A backtrace is always saved into error objects. You can print a
-#' simplified backtrace of the last error by calling [last_error()]
-#' and a full backtrace with `summary(last_error())`.
-#'
-#' You can also display a backtrace with the error message by setting
-#' the option [`rlang_backtrace_on_error`]. It supports the following
-#' values:
-#'
-#' * `"reminder"`: Invite users to call `rlang::last_error()` to see a
-#'   backtrace.
-#' * `"branch"`: Display a simplified backtrace.
-#' * `"collapse"`: Display a collapsed backtrace tree.
-#' * `"full"`: Display a full backtrace tree.
-#' * `"none"`: Display nothing.
+#' `abort()` always saves a backtrace. You can print a simplified backtrace of
+#' the last error by calling [last_error()] and a full backtrace with
+#' `summary(last_error())`. Control the default behaviour with
+#' [`rlang_backtrace_on_error`]
 #'
 #' @section Muffling and silencing conditions:
 #'
@@ -452,7 +438,7 @@ signal_abort <- function(cnd, file = NULL) {
 #' ```
 #' .__error_call__. <- "caller"
 #' ```
-#' 
+#'
 #' @examples
 #' # Set a context for error messages
 #' function() {
@@ -976,6 +962,8 @@ peek_backtrace_on_error <- function() {
 #'
 #' * `last_trace()` is a shortcut to return the backtrace stored in
 #'   the last error. This backtrace is printed in full form.
+#'
+#' See [`rlang_backtrace_on_error`] to control the default behaviour.
 #'
 #' @export
 last_error <- function() {

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -38,10 +38,10 @@
 #'
 #' @section Backtrace:
 #'
-#' `abort()` always saves a backtrace. You can print a simplified backtrace of
-#' the last error by calling [last_error()] and a full backtrace with
-#' `summary(last_error())`. Control the default behaviour with
-#' [`rlang_backtrace_on_error`]
+#' `abort()` always saves a backtrace. You can print a simplified
+#' backtrace of the last error by calling [last_error()] and a full
+#' backtrace with `summary(last_error())`. Learn how to control what is
+#' displayed when an error is thrown with [`rlang_backtrace_on_error`].
 #'
 #' @section Muffling and silencing conditions:
 #'
@@ -947,7 +947,8 @@ peek_backtrace_on_error <- function() {
 #' * `last_trace()` is a shortcut to return the backtrace stored in
 #'   the last error. This backtrace is printed in full form.
 #'
-#' See [`rlang_backtrace_on_error`] to control the default behaviour.
+#' Learn how to control what is displayed when an error is thrown with
+#' [`rlang_backtrace_on_error`].
 #'
 #' @export
 last_error <- function() {

--- a/R/trace.R
+++ b/R/trace.R
@@ -1,5 +1,6 @@
 #' Capture a backtrace
 #'
+#' @description
 #' A backtrace captures the sequence of calls that lead to the current
 #' function, sometimes called the call stack. Because of lazy
 #' evaluation, the call stack in R is actually a tree, which the

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -152,25 +152,10 @@ users. See the \code{call} argument of \code{abort()}.
 \section{Backtrace}{
 
 
-Unlike \code{stop()} and \code{warning()}, these functions don't include call
-information by default. This saves you from typing \code{call. = FALSE}
-and produces cleaner error messages.
-
-A backtrace is always saved into error objects. You can print a
-simplified backtrace of the last error by calling \code{\link[=last_error]{last_error()}}
-and a full backtrace with \code{summary(last_error())}.
-
-You can also display a backtrace with the error message by setting
-the option \code{\link{rlang_backtrace_on_error}}. It supports the following
-values:
-\itemize{
-\item \code{"reminder"}: Invite users to call \code{rlang::last_error()} to see a
-backtrace.
-\item \code{"branch"}: Display a simplified backtrace.
-\item \code{"collapse"}: Display a collapsed backtrace tree.
-\item \code{"full"}: Display a full backtrace tree.
-\item \code{"none"}: Display nothing.
-}
+\code{abort()} always saves a backtrace. You can print a simplified backtrace of
+the last error by calling \code{\link[=last_error]{last_error()}} and a full backtrace with
+\code{summary(last_error())}. Control the default behaviour with
+\code{\link{rlang_backtrace_on_error}}
 }
 
 \section{Muffling and silencing conditions}{

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -152,10 +152,10 @@ users. See the \code{call} argument of \code{abort()}.
 \section{Backtrace}{
 
 
-\code{abort()} always saves a backtrace. You can print a simplified backtrace of
-the last error by calling \code{\link[=last_error]{last_error()}} and a full backtrace with
-\code{summary(last_error())}. Control the default behaviour with
-\code{\link{rlang_backtrace_on_error}}
+\code{abort()} always saves a backtrace. You can print a simplified
+backtrace of the last error by calling \code{\link[=last_error]{last_error()}} and a full
+backtrace with \code{summary(last_error())}. Learn how to control what is
+displayed when an error is thrown with \code{\link{rlang_backtrace_on_error}}.
 }
 
 \section{Muffling and silencing conditions}{

--- a/man/last_error.Rd
+++ b/man/last_error.Rd
@@ -16,4 +16,6 @@ error is printed with a backtrace in simplified form.
 \item \code{last_trace()} is a shortcut to return the backtrace stored in
 the last error. This backtrace is printed in full form.
 }
+
+See \code{\link{rlang_backtrace_on_error}} to control the default behaviour.
 }

--- a/man/last_error.Rd
+++ b/man/last_error.Rd
@@ -17,5 +17,6 @@ error is printed with a backtrace in simplified form.
 the last error. This backtrace is printed in full form.
 }
 
-See \code{\link{rlang_backtrace_on_error}} to control the default behaviour.
+Learn how to control what is displayed when an error is thrown with
+\code{\link{rlang_backtrace_on_error}}.
 }

--- a/man/rlang_backtrace_on_error.Rd
+++ b/man/rlang_backtrace_on_error.Rd
@@ -6,66 +6,51 @@
 \title{Display backtrace on error}
 \description{
 Errors thrown with \code{\link[=abort]{abort()}} automatically save a backtrace that
-can be inspected by calling \code{\link[=last_error]{last_error()}}. Optionally, you can
-also display the backtrace alongside the error message by setting
-the option \code{rlang_backtrace_on_error} to one of the following
-values:
+can be inspected by calling \code{\link[=last_error]{last_error()}}. You can control the default
+display of the backtrace by setting the option \code{rlang_backtrace_on_error}
+to one of the following values:
 \itemize{
-\item \code{"reminder"}: Display a reminder that the backtrace can be
-inspected by calling \code{\link[=last_error]{last_error()}}.
-\item \code{"branch"}: Display a simplified backtrace.
-\item \code{"collapse"}: Display a collapsed backtrace tree.
-\item \code{"full"}: Display the full backtrace tree.
+\item \code{"none"} show nothing.
+\item \code{"reminder"}, the default in interactive sessions, displays a reminder that
+you can see the backtrace with \code{\link[=last_error]{last_error()}}.
+\item \code{"branch"} displays a simplified backtrace.
+\item \code{"collapse"} displays a collapsed backtrace tree.
+\item \code{"full"}, the default in non-interactive sessions, displays the full tree.
 }
-
-If this option is not set, the default depends on whether the
-session is interactive as determined by \code{\link[=is_interactive]{is_interactive()}}.
-In interactive sessions, the default is \code{"reminder"} so that the
-interested user is prompted to run \code{last_error()} to get more
-information. In non-interactive sessions, the default is \code{"full"}
-to provide users with as much debugging info as available.
 }
 \section{Promote base errors to rlang errors}{
 
 
-Call \code{options(error = rlang::entrace)} to instrument base
-errors with rlang features. This handler does two things:
+You can use \code{options(error = rlang::entrace)} to promote base errors to
+rlang errors. This does two things:
 \itemize{
-\item It saves the base error as an rlang object. This allows you to
-call \code{\link[=last_error]{last_error()}} to print the backtrace or inspect its data.
+\item It saves the base error as an rlang object so you can call \code{\link[=last_error]{last_error()}}
+to print the backtrace or inspect its data.
 \item It prints the backtrace for the current error according to the
 \code{rlang_backtrace_on_error} option.
 }
 }
 
-\section{Unexpected errors in dynamic reports}{
+\section{Errors in RMarkdown}{
 
 
-In dynamic reports (knitted Rmarkdown or RStudio notebooks), the
-relevant option is \code{rlang_backtrace_on_error_report}. The default
-is \code{"none"} in interactive sessions and \code{"branch"} in
+There are two types of errors in Rmds: expected (i.e. \code{error = TRUE})
+and unexpected.
+\itemize{
+\item The display of unexpected errors is controlled by option
+\code{rlang_backtrace_on_error_report} (note the \verb{_report}). The
+default is \code{"none"} in interactive sessions and \code{"branch"} in
 non-interactive sessions.
+\item The display of expected errors is controlled by option
+\code{rlang_backtrace_on_error}. The default is \code{"none"}.
 }
-
-\section{Expected errors in Rmarkdown documents}{
-
-
-An \code{rlang_error} method for the \code{knitr::sew()} generic is
-registered to make it possible to display backtraces with captured
-errors (\code{error = TRUE} chunks).
-
-In \code{error = TRUE} chunks, the default value for
-\code{rlang_backtrace_on_error} is \code{"none"}. You can override it by
-setting this option in your document, e.g. to \code{"reminder"} or
-\code{"full"}.
 
 When knitr is running (as determined by the \code{knitr.in.progress}
 global option), the default top environment for backtraces is set
 to the chunk environment \code{knitr::knit_global()}. This ensures that
 the part of the call stack belonging to knitr does not end up in
-backtraces. You can override this by setting the
-\code{rlang_trace_top_env} global option or by supplying the \code{top}
-argument to \code{\link[=trace_back]{trace_back()}}.
+backtraces. If needed, you can override this by setting the
+\code{rlang_trace_top_env} global option.
 }
 
 \examples{

--- a/man/trace_back.Rd
+++ b/man/trace_back.Rd
@@ -42,8 +42,7 @@ A backtrace captures the sequence of calls that lead to the current
 function, sometimes called the call stack. Because of lazy
 evaluation, the call stack in R is actually a tree, which the
 \code{print()} method for this object will reveal.
-}
-\details{
+
 \code{trace_length()} returns the number of frames in a backtrace.
 }
 \examples{


### PR DESCRIPTION
I couldn't re-build the docs because `load_all()` gives me:

```
Error in new_weakref(env, finalizer = ns_finalizer(dll_path)) : 
  object 'rlang_new_weakref' not found
Calls: suppressPackageStartupMessages ... load_code -> <Anonymous> -> load_dll -> new_weakref
Execution halted
```