### PR TITLE
Display external backtraces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 ## Features and bugfixes
 
+* External backtraces in error chains are now separately displayed (#1098).
+
 * Trace capture now better handles wrappers of calling handler in case
   of rethrown chained errors.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,9 @@
 
 ## Features and bugfixes
 
+* Trace capture now better handles wrappers of calling handler in case
+  of rethrown chained errors.
+
 * The `print()` method of rlang errors (commonly invoked with
   `last_error()`) has been improved:
     - Display calls if present.

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -792,6 +792,9 @@ trace_depth_wch <- function(trace) {
   if (!length(top)) {
     return(NULL)
   }
+  if (top <= 2) {
+    return(NULL)
+  }
 
   # withCallingHandlers()
   wch_calls <- calls[seq2(top - 2L, top - 0L)]

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -772,6 +772,15 @@ trace_capture_depth <- function(trace) {
   if (is_call(wch_calls[[1]], "signal_abort") &&
       is_call(wch_calls[[2]], "signalCondition") &&
       is_call(wch_calls[[3]]) && is_function(wch_calls[[3]][[1]])) {
+    # Check for with_abort()
+    with_abort_loc <- length(calls) - 4L - 2L
+    if (with_abort_loc > 0L) {
+      with_abort_call <- calls[[with_abort_loc]]
+      if (is_call(with_abort_call, ".handleSimpleError") &&
+            identical(with_abort_call[[2]], entrace)) {
+        return(with_abort_loc - 1L)
+      }
+    }
     return(length(calls) - 4L)
   }
 

--- a/R/cnd-error.R
+++ b/R/cnd-error.R
@@ -69,10 +69,6 @@ format.rlang_error <- function(x,
     x <- parent
     parent <- parent$parent
 
-    if (!is_null(x$trace)) {
-      trace <- x$trace
-    }
-
     message <- cnd_prefix_error_message(
       x,
       message = cnd_header(x),

--- a/R/trace.R
+++ b/R/trace.R
@@ -296,6 +296,32 @@ trace_slice <- function(trace, i) {
   out
 }
 
+trace_bind <- function(...) {
+  traces <- compact(list2(...))
+  n <- length(traces)
+
+  if (!every(traces, inherits, "rlang_trace")) {
+    abort("`...` must contain backtraces.")
+  }
+
+  if (n == 0L) {
+    return(new_trace(list(), int()))
+  }
+  if (n == 1L) {
+    return(traces[[1]])
+  }
+
+  out <- reduce(traces, function(x, y) {
+    if (identical(x$call, y$call)) {
+      return(x)
+    }
+    y$parent <- y$parent + nrow(x)
+    vec_rbind(as.data.frame(x), as.data.frame(y))
+  })
+
+  new_data_frame(out, .class = c("rlang_trace", "rlib_trace", "tbl"))
+}
+
 
 # Methods -----------------------------------------------------------------
 

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -344,3 +344,46 @@
       Error: `f` must be one of "foo", not "f".
       i Did you mean "foo"?
 
+# withCallingHandlers() wrappers don't throw off trace capture on rethrow
+
+    Code
+      print(err)
+    Output
+      <error/rlang_error>
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
+      Backtrace:
+        1. testthat::expect_error(foo())
+        7. rlang:::foo()
+        8. rlang:::bar()
+        9. rlang:::baz()
+       12. rlang:::f()
+       13. rlang:::g()
+       14. rlang:::h()
+    Code
+      summary(err)
+    Output
+      <error/rlang_error>
+      Error: 
+        High-level message
+      Caused by error in `h()`: 
+        Low-level message
+      Backtrace:
+           x
+        1. +-testthat::expect_error(foo())
+        2. | \-testthat:::expect_condition_matching(...)
+        3. |   \-testthat:::quasi_capture(...)
+        4. |     +-testthat:::.capture(...)
+        5. |     | \-base::withCallingHandlers(...)
+        6. |     \-rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
+        7. \-rlang:::foo()
+        8.   \-rlang:::bar()
+        9.     \-rlang:::baz()
+       10.       +-rlang:::wch(...)
+       11.       | \-base::withCallingHandlers(expr, ...)
+       12.       \-rlang:::f()
+       13.         \-rlang:::g()
+       14.           \-rlang:::h()
+

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -13,9 +13,9 @@
        10. rlang:::a()
        11. rlang:::b()
        12. rlang:::c()
-       19. rlang:::f()
-       20. rlang:::g()
-       21. rlang:::h()
+       16. rlang:::f()
+       17. rlang:::g()
+       18. rlang:::h()
     Code
       summary(err)
     Output
@@ -38,15 +38,12 @@
        10. \-rlang:::a()
        11.   \-rlang:::b()
        12.     \-rlang:::c()
-       13.       +-base::tryCatch(...)
-       14.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       15.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       16.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       17.       +-rlang::with_abort(f())
-       18.       | \-base::withCallingHandlers(...)
-       19.       \-rlang:::f()
-       20.         \-rlang:::g()
-       21.           \-rlang:::h()
+       13.       +-base::withCallingHandlers(...)
+       14.       +-rlang::with_abort(f())
+       15.       | \-base::withCallingHandlers(...)
+       16.       \-rlang:::f()
+       17.         \-rlang:::g()
+       18.           \-rlang:::h()
 
 # rlang and base errors are properly entraced
 

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -30,7 +30,7 @@
        10. rlang:::g()
        11. rlang:::h()
 
-# error is printed with parent backtrace
+# error is printed with youngest backtrace
 
     Code
       print(err)
@@ -45,9 +45,6 @@
         9. rlang:::a()
        10. rlang:::b()
        11. rlang:::c()
-       16. rlang:::f()
-       17. rlang:::g()
-       18. rlang:::h()
 
 ---
 
@@ -72,13 +69,6 @@
         9. \-rlang:::a()
        10.   \-rlang:::b()
        11.     \-rlang:::c()
-       12.       +-base::tryCatch(...)
-       13.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       14.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       15.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
 
 ---
 
@@ -104,13 +94,6 @@
         9. \-rlang:::a()
        10.   \-rlang:::b()
        11.     \-rlang:::c()
-       12.       +-base::tryCatch(...)
-       13.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       14.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       15.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
@@ -126,10 +109,6 @@
         9. \-rlang:::a()
        10.   \-rlang:::b()
        11.     \-rlang:::c()
-       12.       +-[ base::tryCatch(...) ] with 3 more calls
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
@@ -144,9 +123,6 @@
         9. rlang:::a()
        10. rlang:::b()
        11. rlang:::c()
-       16. rlang:::f()
-       17. rlang:::g()
-       18. rlang:::h()
 
 # 3-level ancestry works (#1248)
 
@@ -186,15 +162,12 @@
        11.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
        12.   \-rlang:::b()
        13.     \-rlang:::c()
-       14.       +-base::tryCatch(f(), error = handler)
-       15.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       16.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       17.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       18.       \-rlang:::f()
-       19.         +-base::tryCatch(g())
-       20.         | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       21.         \-rlang:::g()
-       22.           \-rlang:::h()
+       14.       +-base::withCallingHandlers(f(), error = handler)
+       15.       \-rlang:::f()
+       16.         +-base::tryCatch(g())
+       17.         | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+       18.         \-rlang:::g()
+       19.           \-rlang:::h()
 
 # don't print message or backtrace fields if empty
 

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -30,7 +30,7 @@
        10. rlang:::g()
        11. rlang:::h()
 
-# error is printed with youngest backtrace
+# Overlapping backtraces are printed separately
 
     Code
       print(err)
@@ -38,6 +38,11 @@
       <error/rlang_error>
       Error: 
         High-level message
+      Backtrace:
+        1. rlang:::catch_error(a())
+        9. rlang:::a()
+       10. rlang:::b()
+       11. rlang:::c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -45,6 +50,9 @@
         9. rlang:::a()
        10. rlang:::b()
        11. rlang:::c()
+       16. rlang:::f()
+       17. rlang:::g()
+       18. rlang:::h()
 
 ---
 
@@ -54,6 +62,19 @@
       <error/rlang_error>
       Error: 
         High-level message
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(a())
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang:::a()
+       10.   \-rlang:::b()
+       11.     \-rlang:::c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -69,6 +90,13 @@
         9. \-rlang:::a()
        10.   \-rlang:::b()
        11.     \-rlang:::c()
+       12.       +-base::tryCatch(...)
+       13.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+       14.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+       15.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+       16.       \-rlang:::f()
+       17.         \-rlang:::g()
+       18.           \-rlang:::h()
 
 ---
 
@@ -79,6 +107,19 @@
       <error/rlang_error>
       Error: 
         High-level message
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(a())
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang:::a()
+       10.   \-rlang:::b()
+       11.     \-rlang:::c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -94,6 +135,13 @@
         9. \-rlang:::a()
        10.   \-rlang:::b()
        11.     \-rlang:::c()
+       12.       +-base::tryCatch(...)
+       13.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+       14.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+       15.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+       16.       \-rlang:::f()
+       17.         \-rlang:::g()
+       18.           \-rlang:::h()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
@@ -101,6 +149,12 @@
       <error/rlang_error>
       Error: 
         High-level message
+      Backtrace:
+           x
+        1. +-[ rlang:::catch_error(...) ] with 7 more calls
+        9. \-rlang:::a()
+       10.   \-rlang:::b()
+       11.     \-rlang:::c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -109,6 +163,10 @@
         9. \-rlang:::a()
        10.   \-rlang:::b()
        11.     \-rlang:::c()
+       12.       +-[ base::tryCatch(...) ] with 3 more calls
+       16.       \-rlang:::f()
+       17.         \-rlang:::g()
+       18.           \-rlang:::h()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
@@ -116,6 +174,11 @@
       <error/rlang_error>
       Error: 
         High-level message
+      Backtrace:
+        1. rlang:::catch_error(a())
+        9. rlang:::a()
+       10. rlang:::b()
+       11. rlang:::c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -123,6 +186,9 @@
         9. rlang:::a()
        10. rlang:::b()
        11. rlang:::c()
+       16. rlang:::f()
+       17. rlang:::g()
+       18. rlang:::h()
 
 # 3-level ancestry works (#1248)
 
@@ -213,4 +279,54 @@
         Problem while executing step.
       Caused by error in `rlang_problem()`: 
         oh no!
+
+# external backtraces are displayed (#1098)
+
+    Code
+      print(err)
+    Output
+      <error/rlang_error>
+      Error: 
+        High-level message
+      Backtrace:
+        1. rlang::catch_cnd(foo(), "error")
+        8. rlang:::foo()
+        9. rlang:::bar()
+       10. rlang:::baz()
+       12. rlang:::f()
+       13. rlang:::g()
+       14. rlang:::h()
+      Caused by error in `h()`: 
+        Low-level message
+      Backtrace:
+       1. quux()
+       2. foofy()
+    Code
+      summary(err)
+    Output
+      <error/rlang_error>
+      Error: 
+        High-level message
+      Backtrace:
+           x
+        1. +-rlang::catch_cnd(foo(), "error")
+        2. | +-rlang::eval_bare(...)
+        3. | +-base::tryCatch(...)
+        4. | | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+        5. | |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        6. | |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+        7. | \-base::force(expr)
+        8. \-rlang:::foo()
+        9.   \-rlang:::bar()
+       10.     \-rlang:::baz()
+       11.       +-base::withCallingHandlers(...)
+       12.       \-rlang:::f()
+       13.         \-rlang:::g()
+       14.           \-rlang:::h()
+      Caused by error in `h()`: 
+        Low-level message
+      Backtrace:
+          x
+       1. \-quux()
+       2.   \-foofy()
 

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -330,3 +330,93 @@
        1. \-quux()
        2.   \-foofy()
 
+# rethrowing from an exiting handler
+
+    Code
+      # Full
+      print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
+    Output
+      <error/rlang_error>
+      Error: 
+        bar
+      Backtrace:
+           x
+        1. +-rlang::catch_cnd(foo(), "error")
+        2. | +-rlang::eval_bare(...)
+        3. | +-base::tryCatch(...)
+        4. | | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+        5. | |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        6. | |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+        7. | \-base::force(expr)
+        8. \-rlang:::foo()
+        9.   \-rlang:::bar()
+       10.     \-rlang:::baz()
+      Caused by error in `h()`: 
+        foo
+      Backtrace:
+           x
+        1. +-rlang::catch_cnd(foo(), "error")
+        2. | +-rlang::eval_bare(...)
+        3. | +-base::tryCatch(...)
+        4. | | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+        5. | |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        6. | |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+        7. | \-base::force(expr)
+        8. \-rlang:::foo()
+        9.   \-rlang:::bar()
+       10.     \-rlang:::baz()
+       11.       +-base::tryCatch(f(), error = function(err) abort("bar", parent = err))
+       12.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
+       13.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
+       14.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
+       15.       \-rlang:::f()
+       16.         \-rlang:::g()
+       17.           \-rlang:::h()
+    Code
+      # Collapsed
+      print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
+    Output
+      <error/rlang_error>
+      Error: 
+        bar
+      Backtrace:
+           x
+        1. +-[ rlang::catch_cnd(...) ] with 6 more calls
+        8. \-rlang:::foo()
+        9.   \-rlang:::bar()
+       10.     \-rlang:::baz()
+      Caused by error in `h()`: 
+        foo
+      Backtrace:
+           x
+        1. +-[ rlang::catch_cnd(...) ] with 6 more calls
+        8. \-rlang:::foo()
+        9.   \-rlang:::bar()
+       10.     \-rlang:::baz()
+       11.       +-[ base::tryCatch(...) ] with 3 more calls
+       15.       \-rlang:::f()
+       16.         \-rlang:::g()
+       17.           \-rlang:::h()
+    Code
+      # Branch
+      print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
+    Output
+      <error/rlang_error>
+      Error: 
+        bar
+      Backtrace:
+        1. rlang::catch_cnd(foo(), "error")
+        8. rlang:::foo()
+        9. rlang:::bar()
+       10. rlang:::baz()
+      Caused by error in `h()`: 
+        foo
+      Backtrace:
+        1. rlang::catch_cnd(foo(), "error")
+        8. rlang:::foo()
+        9. rlang:::bar()
+       10. rlang:::baz()
+       15. rlang:::f()
+       16. rlang:::g()
+       17. rlang:::h()
+

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -6,7 +6,7 @@ test_that("with_abort() promotes base errors to rlang errors", {
   a <- function() b()
   b <- function() c()
   c <- function() {
-    tryCatch(
+    withCallingHandlers(
       with_abort(f()),
       error = function(err) {
         abort("High-level message", parent = err)

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -41,7 +41,8 @@ test_that("rlang_error.print() calls conditionMessage() method", {
   expect_snapshot(print(err))
 })
 
-test_that("error is printed with youngest backtrace", {
+# tryCatch() instead of wCH() causes distinct overlapping traces
+test_that("Overlapping backtraces are printed separately", {
   # Test low-level error can use conditionMessage()
   local_bindings(.env = global_env(),
     cnd_header.foobar = function(c) c$foobar_msg
@@ -173,5 +174,36 @@ test_that("calls are consistently displayed on rethrow (#1240)", {
   expect_snapshot({
     (expect_error(with_context(base_problem(), "step_dummy")))
     (expect_error(with_context(rlang_problem(), "step_dummy")))
+  })
+})
+
+test_that("external backtraces are displayed (#1098)", {
+  local_options(
+    rlang_trace_top_env = current_env(),
+    rlang_trace_format_srcrefs = FALSE
+  )
+
+  ext_trace <- new_trace(alist(quux(), foofy()), base::c(0L, 1L))
+
+  f <- function() g()
+  g <- function() h()
+  h <- function() abort("Low-level message", trace = ext_trace)
+
+  foo <- function() bar()
+  bar <- function() baz()
+  baz <- function() {
+    withCallingHandlers(
+      f(),
+      error = function(err) {
+        abort("High-level message", parent = err)
+      }
+    )
+  }
+
+  err <- catch_cnd(foo(), "error")
+
+  expect_snapshot({
+    print(err)
+    summary(err)
   })
 })

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -41,7 +41,7 @@ test_that("rlang_error.print() calls conditionMessage() method", {
   expect_snapshot(print(err))
 })
 
-test_that("error is printed with parent backtrace", {
+test_that("error is printed with youngest backtrace", {
   # Test low-level error can use conditionMessage()
   local_bindings(.env = global_env(),
     cnd_header.foobar = function(c) c$foobar_msg
@@ -125,7 +125,7 @@ test_that("summary.rlang_error() prints full backtrace", {
 
   a <- function() tryCatch(b())
   b <- function() c()
-  c <- function() tryCatch(f(), error = handler)
+  c <- function() withCallingHandlers(f(), error = handler)
 
   err <- catch_error(a())
   expect_snapshot(summary(err))

--- a/tests/testthat/test-cnd-error.R
+++ b/tests/testthat/test-cnd-error.R
@@ -207,3 +207,26 @@ test_that("external backtraces are displayed (#1098)", {
     summary(err)
   })
 })
+
+test_that("rethrowing from an exiting handler", {
+  local_options(
+    rlang_trace_top_env = current_env(),
+    rlang_trace_format_srcrefs = FALSE
+  )
+
+  f <- function() g()
+  g <- function() h()
+  h <- function() abort("foo")
+
+  foo <- function() bar()
+  bar <- function() baz()
+  baz <- function() {
+    tryCatch(
+      f(),
+      error = function(err) abort("bar", parent = err)
+    )
+  }
+
+  err <- catch_cnd(foo(), "error")
+  expect_snapshot_trace(err)
+})

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -639,3 +639,23 @@ test_that("can slice backtrace", {
 test_that("backtraces carry `version` attribute", {
   expect_identical(attr(trace_back(), "version"), 2L)
 })
+
+test_that("can bind backtraces", {
+  trace1 <- new_trace(alist(a(), b(), c()), 0:2)
+
+  expect_equal(trace_bind(), new_trace(list(), int()))
+  expect_equal(trace_bind(trace1), trace1)
+  
+  trace2 <- new_trace(alist(foo(), bar(), baz()), c(0L, 1L, 1L))
+  out <- trace_bind(trace1, trace2)
+
+  expect_equal(
+    out$call,
+    alist(a(), b(), c(), foo(), bar(), baz())
+  )
+
+  expect_equal(
+    out$parent,
+    c(0:3, c(4L, 4L))
+  )
+})


### PR DESCRIPTION
And make trace capture in wrapped rethrowing handlers more robust.

Closes #1098.