### PR TITLE
Zap inline objects from backtraces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,9 @@
 
 ## Features and bugfixes
 
+* Backtraces no longer contain inlined objects to avoid performance
+  issues in edge cases (#1069, r-lib/testthat#1223).
+
 * Condition constructors now check for duplicate field names (#1268).
 
 * `as_label()` now better handles calls to infix operators (#956,

--- a/R/call.R
+++ b/R/call.R
@@ -1050,3 +1050,24 @@ call_type <- function(x) {
     abort("corrupt language object")
   }
 }
+
+call_zap_inline <- function(x) {
+  if (is_call(x)) {
+    if (is_call(x, "function")) {
+      if (!is_null(x[[2]])) {
+        x[[2]] <- as.pairlist(map(x[[2]], call_zap_inline))
+      }
+      x[[3]] <- call_zap_inline(x[[3]])
+    } else {
+      x[] <- map(x, call_zap_inline)
+    }
+    return(x)
+  }
+
+  if (is_symbol(x) || is_syntactic_literal(x)) {
+    x
+  } else {
+    name <- sprintf("<%s>", rlang_type_sum(x))
+    sym(name)
+  }
+}

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -956,7 +956,7 @@ trace_depth_wch <- function(trace) {
   if (with_abort_loc > 0L) {
     with_abort_call <- calls[[with_abort_loc]]
     if (is_call(with_abort_call, ".handleSimpleError") &&
-        identical(with_abort_call[[2]], entrace)) {
+        identical(with_abort_call[[2]], quote(`<fn>`))) {
       return(with_abort_loc - 1L)
     }
   }

--- a/R/trace.R
+++ b/R/trace.R
@@ -92,6 +92,7 @@ trace_back <- function(top = NULL, bottom = NULL) {
   calls <- as.list(sys.calls()[idx])
 
   calls <- map(calls, call_fix_car)
+  calls <- map(calls, call_zap_inline)
 
   context <- map2(calls, seq_along(calls), call_trace_context)
   context <- inject(vec_rbind(!!!context))

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -40,7 +40,7 @@
        12.     \-rlang:::c()
        13.       +-base::withCallingHandlers(...)
        14.       +-rlang::with_abort(f())
-       15.       | \-base::withCallingHandlers(...)
+       15.       | \-base::withCallingHandlers(expr, error = `<fn>`)
        16.       \-rlang:::f()
        17.         \-rlang:::g()
        18.           \-rlang:::h()

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1016,3 +1016,14 @@
           ##  2.   \-global::g()
           ##  3.     \-global::h()
 
+# backtraces don't contain inlined objects (#1069, r-lib/testthat#1223)
+
+    Code
+      summary(trace)
+    Output
+          x
+       1. +-rlang::inject(f(!!list()))
+       2. \-rlang:::f(`<list>`)
+       3.   \-rlang:::g()
+       4.     \-rlang:::h()
+

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1024,6 +1024,7 @@
           x
        1. +-rlang::inject(f(!!list()))
        2. \-rlang:::f(`<list>`)
-       3.   \-rlang:::g()
-       4.     \-rlang:::h()
+       3.   +-base::do.call("g", list(runif(1e+06) + 0))
+       4.   \-rlang:::g(`<dbl>`)
+       5.     \-rlang:::h()
 

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -550,3 +550,26 @@ test_that("is_call_infix() detects infix operators", {
   expect_true(is_call_infix(quote(a + b)))
   expect_false(is_call_infix(quote(+b)))
 })
+
+test_that("call_zap_inline() works", {
+  expect_equal(
+    call_zap_inline(quote(foo(1:2))),
+    quote(foo(1:2))
+  )
+  expect_equal(
+    call_zap_inline(expr(foo(!!(1:2)))),
+    quote(foo(`<int>`))
+  )
+
+  expect_equal(
+    call_zap_inline(quote(function() 1)),
+    quote(function() 1)
+  )
+
+  call <- expr(function(x = NULL) foo(!!(1:2)))
+  call[[2]]$x <- 1:2
+  expect_equal(
+    call_zap_inline(call),
+    quote(function(x = `<int>`) foo(`<int>`))
+  )
+})

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -661,6 +661,9 @@ test_that("can bind backtraces", {
 })
 
 test_that("backtraces don't contain inlined objects (#1069, r-lib/testthat#1223)", {
+  # !! deparsing in older R
+  skip_if_not_installed("base", "3.5.0")
+
   local_options(
     rlang_trace_format_srcrefs = FALSE
   )

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -667,10 +667,13 @@ test_that("backtraces don't contain inlined objects (#1069, r-lib/testthat#1223)
   local_options(
     rlang_trace_format_srcrefs = FALSE
   )
+
   e <- environment()
-  f <- function(...) g()
-  g <- function() h()
+  f <- function(...) do.call("g", list(runif(1e6) + 0))
+  g <- function(...) h()
   h <- function() trace_back(e)
   trace <- inject(f(!!list()))
+
   expect_snapshot(summary(trace))
+  expect_lt(object.size(trace$call), 50000)
 })

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -659,3 +659,15 @@ test_that("can bind backtraces", {
     c(0:3, c(4L, 4L))
   )
 })
+
+test_that("backtraces don't contain inlined objects (#1069, r-lib/testthat#1223)", {
+  local_options(
+    rlang_trace_format_srcrefs = FALSE
+  )
+  e <- environment()
+  f <- function(...) g()
+  g <- function() h()
+  h <- function() trace_back(e)
+  trace <- inject(f(!!list()))
+  expect_snapshot(summary(trace))
+})


### PR DESCRIPTION
Closes #1069.
Closes r-lib/testthat#1223.

Inline objects are replaced by their pillar type sum:

```r
call <- expr(foo(!!(1:2)))
call_zap_inline(call)
#> foo(`<int>`)
```