### PR TITLE
Don't use namespace operators invalidly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@
 
 ## Features and bugfixes
 
+* Functions defined in the global environments or in local execution
+  environments are now displayed with a space separator in backtraces
+  instead of `::` and `:::`. This avoids making it seem like these
+  frame calls are valid R code ready to be typed in (#902).
+
 * Backtraces no longer contain inlined objects to avoid performance
   issues in edge cases (#1069, r-lib/testthat#1223).
 

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -12,11 +12,11 @@
       Error in `h()`: Error message
       Backtrace:
           x
-       1. \-global::f()
-       2.   +-base::tryCatch(g())
-       3.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       4.   \-global::g()
-       5.     \-global::h()
+       1. \-global f()
+       2.   +-base::tryCatch(...)
+       3.   | \-base tryCatchList(...)
+       4.   \-global g()
+       5.     \-global h()
       Execution halted
     Code
       cat_line(reminder)
@@ -28,9 +28,9 @@
     Output
       Error in `h()`: Error message
       Backtrace:
-       1. global::f()
-       4. global::g()
-       5. global::h()
+       1. global f()
+       4. global g()
+       5. global h()
       Execution halted
     Code
       cat_line(collapse)
@@ -38,10 +38,10 @@
       Error in `h()`: Error message
       Backtrace:
           x
-       1. \-global::f()
+       1. \-global f()
        2.   +-[ base::tryCatch(...) ] with 1 more call
-       4.   \-global::g()
-       5.     \-global::h()
+       4.   \-global g()
+       5.     \-global h()
       Execution halted
     Code
       cat_line(full)
@@ -49,11 +49,11 @@
       Error in `h()`: Error message
       Backtrace:
           x
-       1. \-global::f()
-       2.   +-base::tryCatch(g())
-       3.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       4.   \-global::g()
-       5.     \-global::h()
+       1. \-global f()
+       2.   +-base::tryCatch(...)
+       3.   | \-base tryCatchList(...)
+       4.   \-global g()
+       5.     \-global h()
       Execution halted
     Code
       cat_line(rethrown_interactive)
@@ -67,15 +67,15 @@
       Error in `h()`: Error message
       Backtrace:
           x
-       1. +-base::tryCatch(f(), error = function(cnd) rlang::cnd_signal(cnd))
-       2. | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       3. |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       4. |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       5. \-global::f()
-       6.   +-base::tryCatch(g())
-       7.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       8.   \-global::g()
-       9.     \-global::h()
+       1. +-base::tryCatch(...)
+       2. | \-base tryCatchList(...)
+       3. |   \-base tryCatchOne(...)
+       4. |     \-base doTryCatch(...)
+       5. \-global f()
+       6.   +-base::tryCatch(...)
+       7.   | \-base tryCatchList(...)
+       8.   \-global g()
+       9.     \-global h()
       Execution halted
 
 # empty backtraces are not printed
@@ -95,7 +95,7 @@
     Output
       Error in `f()`: foo
       Backtrace:
-       1. global::f()
+       1. global f()
       Execution halted
     Code
       cat_line(full_depth_1)
@@ -103,7 +103,7 @@
       Error in `f()`: foo
       Backtrace:
           x
-       1. \-global::f()
+       1. \-global f()
       Execution halted
 
 # parent errors are not displayed in error message and backtrace
@@ -126,16 +126,16 @@
         foo
       Backtrace:
            x
-        1. \-global::a()
-        2.   \-global::b()
-        3.     \-global::c()
+        1. \-global a()
+        2.   \-global b()
+        3.     \-global c()
         4.       +-base::tryCatch(...)
-        5.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        6.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        7.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        8.       \-global::f()
-        9.         \-global::g()
-       10.           \-global::h()
+        5.       | \-base tryCatchList(...)
+        6.       |   \-base tryCatchOne(...)
+        7.       |     \-base doTryCatch(...)
+        8.       \-global f()
+        9.         \-global g()
+       10.           \-global h()
       Execution halted
 
 # backtrace reminder is displayed when called from `last_error()`
@@ -147,10 +147,10 @@
       <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
     Code
       # From `last_error()`
       print(last_error())
@@ -158,10 +158,10 @@
       <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
       Run `rlang::last_trace()` to see the full context.
     Code
       # Saved from `last_error()`
@@ -173,10 +173,10 @@
       <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
       Run `rlang::last_trace()` to see the full context.
     Code
       # Saved from `last_error()`, but no longer last
@@ -188,10 +188,10 @@
       <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
       Run `rlang::last_trace()` to see the full context.
 
 # capture context doesn't leak into low-level backtraces
@@ -211,10 +211,10 @@
       Caused by error in `failing()`: 
         low-level
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
     Code
       # Wrapped case
       {
@@ -229,10 +229,10 @@
       Caused by error in `failing()`: 
         low-level
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
     Code
       # FIXME?
       {
@@ -247,10 +247,10 @@
       Caused by error in `failing()`: 
         low-level
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
     Code
       # withCallingHandlers()
       print(err_wch)
@@ -262,9 +262,9 @@
         foo
       Backtrace:
         1. rlang:::catch_error(...)
-       10. rlang:::foo()
-       11. rlang:::bar(cnd)
-       12. rlang:::baz(cnd)
+       10. rlang foo()
+       11. rlang bar(...)
+       12. rlang baz(...)
 
 # abort() displays call in error prefix
 
@@ -355,13 +355,13 @@
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
-        1. testthat::expect_error(foo())
-        7. rlang:::foo()
-        8. rlang:::bar()
-        9. rlang:::baz()
-       12. rlang:::f()
-       13. rlang:::g()
-       14. rlang:::h()
+        1. testthat::expect_error(...)
+        7. rlang foo()
+        8. rlang bar()
+        9. rlang baz()
+       12. rlang f()
+       13. rlang g()
+       14. rlang h()
     Code
       summary(err)
     Output
@@ -372,20 +372,20 @@
         Low-level message
       Backtrace:
            x
-        1. +-testthat::expect_error(foo())
+        1. +-testthat::expect_error(...)
         2. | \-testthat:::expect_condition_matching(...)
         3. |   \-testthat:::quasi_capture(...)
-        4. |     +-testthat:::.capture(...)
+        4. |     +-testthat .capture(...)
         5. |     | \-base::withCallingHandlers(...)
-        6. |     \-rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
-        7. \-rlang:::foo()
-        8.   \-rlang:::bar()
-        9.     \-rlang:::baz()
-       10.       +-rlang:::wch(...)
-       11.       | \-base::withCallingHandlers(expr, ...)
-       12.       \-rlang:::f()
-       13.         \-rlang:::g()
-       14.           \-rlang:::h()
+        6. |     \-rlang::eval_bare(...)
+        7. \-rlang foo()
+        8.   \-rlang bar()
+        9.     \-rlang baz()
+       10.       +-rlang wch(...)
+       11.       | \-base::withCallingHandlers(...)
+       12.       \-rlang f()
+       13.         \-rlang g()
+       14.           \-rlang h()
 
 # `abort()` uses older bullets formatting by default
 

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -9,13 +9,13 @@
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
-        1. base::identity(catch_error(a()))
-       10. rlang:::a()
-       11. rlang:::b()
-       12. rlang:::c()
-       16. rlang:::f()
-       17. rlang:::g()
-       18. rlang:::h()
+        1. base::identity(...)
+       10. rlang a()
+       11. rlang b()
+       12. rlang c()
+       16. rlang f()
+       17. rlang g()
+       18. rlang h()
     Code
       summary(err)
     Output
@@ -26,24 +26,24 @@
         Low-level message
       Backtrace:
            x
-        1. +-base::identity(catch_error(a()))
-        2. +-rlang:::catch_error(a())
-        3. | \-rlang::catch_cnd(expr, "error")
+        1. +-base::identity(...)
+        2. +-rlang:::catch_error(...)
+        3. | \-rlang::catch_cnd(...)
         4. |   +-rlang::eval_bare(...)
         5. |   +-base::tryCatch(...)
-        6. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        7. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        8. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        9. |   \-base::force(expr)
-       10. \-rlang:::a()
-       11.   \-rlang:::b()
-       12.     \-rlang:::c()
+        6. |   | \-base tryCatchList(...)
+        7. |   |   \-base tryCatchOne(...)
+        8. |   |     \-base doTryCatch(...)
+        9. |   \-base::force(...)
+       10. \-rlang a()
+       11.   \-rlang b()
+       12.     \-rlang c()
        13.       +-base::withCallingHandlers(...)
-       14.       +-rlang::with_abort(f())
-       15.       | \-base::withCallingHandlers(expr, error = `<fn>`)
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
+       14.       +-rlang::with_abort(...)
+       15.       | \-base::withCallingHandlers(...)
+       16.       \-rlang f()
+       17.         \-rlang g()
+       18.           \-rlang h()
 
 # rlang and base errors are properly entraced
 
@@ -56,17 +56,17 @@
       <error/rlang_error>
       Error: foo
       Backtrace:
-       1. global::f()
-       2. global::g()
-       3. global::h()
+       1. global f()
+       2. global g()
+       3. global h()
       Run `rlang::last_trace()` to see the full context.
       <error/rlang_error>
       Error: foo
       Backtrace:
           x
-       1. \-global::f()
-       2.   \-global::g()
-       3.     \-global::h()
+       1. \-global f()
+       2.   \-global g()
+       3.     \-global h()
     Code
       cat_line(rlang)
     Output
@@ -75,15 +75,15 @@
       <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
-       1. global::f()
-       2. global::g()
-       3. global::h()
+       1. global f()
+       2. global g()
+       3. global h()
       Run `rlang::last_trace()` to see the full context.
       <error/rlang_error>
       Error in `h()`: foo
       Backtrace:
           x
-       1. \-global::f()
-       2.   \-global::g()
-       3.     \-global::h()
+       1. \-global f()
+       2.   \-global g()
+       3.     \-global h()
 

--- a/tests/testthat/_snaps/cnd-error.md
+++ b/tests/testthat/_snaps/cnd-error.md
@@ -12,9 +12,9 @@
       Error in `h()`: dispatched!
       Backtrace:
           x
-       1. \-global::f()
-       2.   \-global::g()
-       3.     \-global::h()
+       1. \-global f()
+       2.   \-global g()
+       3.     \-global h()
       Execution halted
 
 # rlang_error.print() calls cnd_message() methods
@@ -25,10 +25,10 @@
       <error/foobar>
       Error in `h()`: Low-level message
       Backtrace:
-        1. rlang:::catch_error(f())
-        9. rlang:::f()
-       10. rlang:::g()
-       11. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang f()
+       10. rlang g()
+       11. rlang h()
 
 # Overlapping backtraces are printed separately
 
@@ -39,20 +39,20 @@
       Error: 
         High-level message
       Backtrace:
-        1. rlang:::catch_error(a())
-        9. rlang:::a()
-       10. rlang:::b()
-       11. rlang:::c()
+        1. rlang:::catch_error(...)
+        9. rlang a()
+       10. rlang b()
+       11. rlang c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
-        1. rlang:::catch_error(a())
-        9. rlang:::a()
-       10. rlang:::b()
-       11. rlang:::c()
-       16. rlang:::f()
-       17. rlang:::g()
-       18. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang a()
+       10. rlang b()
+       11. rlang c()
+       16. rlang f()
+       17. rlang g()
+       18. rlang h()
 
 ---
 
@@ -64,39 +64,39 @@
         High-level message
       Backtrace:
            x
-        1. +-rlang:::catch_error(a())
-        2. | \-rlang::catch_cnd(expr, "error")
+        1. +-rlang:::catch_error(...)
+        2. | \-rlang::catch_cnd(...)
         3. |   +-rlang::eval_bare(...)
         4. |   +-base::tryCatch(...)
-        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        8. |   \-base::force(expr)
-        9. \-rlang:::a()
-       10.   \-rlang:::b()
-       11.     \-rlang:::c()
+        5. |   | \-base tryCatchList(...)
+        6. |   |   \-base tryCatchOne(...)
+        7. |   |     \-base doTryCatch(...)
+        8. |   \-base::force(...)
+        9. \-rlang a()
+       10.   \-rlang b()
+       11.     \-rlang c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
            x
-        1. +-rlang:::catch_error(a())
-        2. | \-rlang::catch_cnd(expr, "error")
+        1. +-rlang:::catch_error(...)
+        2. | \-rlang::catch_cnd(...)
         3. |   +-rlang::eval_bare(...)
         4. |   +-base::tryCatch(...)
-        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        8. |   \-base::force(expr)
-        9. \-rlang:::a()
-       10.   \-rlang:::b()
-       11.     \-rlang:::c()
+        5. |   | \-base tryCatchList(...)
+        6. |   |   \-base tryCatchOne(...)
+        7. |   |     \-base doTryCatch(...)
+        8. |   \-base::force(...)
+        9. \-rlang a()
+       10.   \-rlang b()
+       11.     \-rlang c()
        12.       +-base::tryCatch(...)
-       13.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       14.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       15.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
+       13.       | \-base tryCatchList(...)
+       14.       |   \-base tryCatchOne(...)
+       15.       |     \-base doTryCatch(...)
+       16.       \-rlang f()
+       17.         \-rlang g()
+       18.           \-rlang h()
 
 ---
 
@@ -109,39 +109,39 @@
         High-level message
       Backtrace:
            x
-        1. +-rlang:::catch_error(a())
-        2. | \-rlang::catch_cnd(expr, "error")
+        1. +-rlang:::catch_error(...)
+        2. | \-rlang::catch_cnd(...)
         3. |   +-rlang::eval_bare(...)
         4. |   +-base::tryCatch(...)
-        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        8. |   \-base::force(expr)
-        9. \-rlang:::a()
-       10.   \-rlang:::b()
-       11.     \-rlang:::c()
+        5. |   | \-base tryCatchList(...)
+        6. |   |   \-base tryCatchOne(...)
+        7. |   |     \-base doTryCatch(...)
+        8. |   \-base::force(...)
+        9. \-rlang a()
+       10.   \-rlang b()
+       11.     \-rlang c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
            x
-        1. +-rlang:::catch_error(a())
-        2. | \-rlang::catch_cnd(expr, "error")
+        1. +-rlang:::catch_error(...)
+        2. | \-rlang::catch_cnd(...)
         3. |   +-rlang::eval_bare(...)
         4. |   +-base::tryCatch(...)
-        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        8. |   \-base::force(expr)
-        9. \-rlang:::a()
-       10.   \-rlang:::b()
-       11.     \-rlang:::c()
+        5. |   | \-base tryCatchList(...)
+        6. |   |   \-base tryCatchOne(...)
+        7. |   |     \-base doTryCatch(...)
+        8. |   \-base::force(...)
+        9. \-rlang a()
+       10.   \-rlang b()
+       11.     \-rlang c()
        12.       +-base::tryCatch(...)
-       13.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       14.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       15.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
+       13.       | \-base tryCatchList(...)
+       14.       |   \-base tryCatchOne(...)
+       15.       |     \-base doTryCatch(...)
+       16.       \-rlang f()
+       17.         \-rlang g()
+       18.           \-rlang h()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
@@ -152,21 +152,21 @@
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
-        9. \-rlang:::a()
-       10.   \-rlang:::b()
-       11.     \-rlang:::c()
+        9. \-rlang a()
+       10.   \-rlang b()
+       11.     \-rlang c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
-        9. \-rlang:::a()
-       10.   \-rlang:::b()
-       11.     \-rlang:::c()
+        9. \-rlang a()
+       10.   \-rlang b()
+       11.     \-rlang c()
        12.       +-[ base::tryCatch(...) ] with 3 more calls
-       16.       \-rlang:::f()
-       17.         \-rlang:::g()
-       18.           \-rlang:::h()
+       16.       \-rlang f()
+       17.         \-rlang g()
+       18.           \-rlang h()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
@@ -175,20 +175,20 @@
       Error: 
         High-level message
       Backtrace:
-        1. rlang:::catch_error(a())
-        9. rlang:::a()
-       10. rlang:::b()
-       11. rlang:::c()
+        1. rlang:::catch_error(...)
+        9. rlang a()
+       10. rlang b()
+       11. rlang c()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
-        1. rlang:::catch_error(a())
-        9. rlang:::a()
-       10. rlang:::b()
-       11. rlang:::c()
-       16. rlang:::f()
-       17. rlang:::g()
-       18. rlang:::h()
+        1. rlang:::catch_error(...)
+        9. rlang a()
+       10. rlang b()
+       11. rlang c()
+       16. rlang f()
+       17. rlang g()
+       18. rlang h()
 
 # 3-level ancestry works (#1248)
 
@@ -215,25 +215,25 @@
         The low-level error message
       Backtrace:
            x
-        1. +-rlang:::catch_error(a())
-        2. | \-rlang::catch_cnd(expr, "error")
+        1. +-rlang:::catch_error(...)
+        2. | \-rlang::catch_cnd(...)
         3. |   +-rlang::eval_bare(...)
         4. |   +-base::tryCatch(...)
-        5. |   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        6. |   |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        7. |   |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        8. |   \-base::force(expr)
-        9. \-rlang:::a()
-       10.   +-base::tryCatch(b())
-       11.   | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       12.   \-rlang:::b()
-       13.     \-rlang:::c()
-       14.       +-base::withCallingHandlers(f(), error = handler)
-       15.       \-rlang:::f()
-       16.         +-base::tryCatch(g())
-       17.         | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       18.         \-rlang:::g()
-       19.           \-rlang:::h()
+        5. |   | \-base tryCatchList(...)
+        6. |   |   \-base tryCatchOne(...)
+        7. |   |     \-base doTryCatch(...)
+        8. |   \-base::force(...)
+        9. \-rlang a()
+       10.   +-base::tryCatch(...)
+       11.   | \-base tryCatchList(...)
+       12.   \-rlang b()
+       13.     \-rlang c()
+       14.       +-base::withCallingHandlers(...)
+       15.       \-rlang f()
+       16.         +-base::tryCatch(...)
+       17.         | \-base tryCatchList(...)
+       18.         \-rlang g()
+       19.           \-rlang h()
 
 # don't print message or backtrace fields if empty
 
@@ -289,13 +289,13 @@
       Error: 
         High-level message
       Backtrace:
-        1. rlang::catch_cnd(foo(), "error")
-        8. rlang:::foo()
-        9. rlang:::bar()
-       10. rlang:::baz()
-       12. rlang:::f()
-       13. rlang:::g()
-       14. rlang:::h()
+        1. rlang::catch_cnd(...)
+        8. rlang foo()
+        9. rlang bar()
+       10. rlang baz()
+       12. rlang f()
+       13. rlang g()
+       14. rlang h()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -309,20 +309,20 @@
         High-level message
       Backtrace:
            x
-        1. +-rlang::catch_cnd(foo(), "error")
+        1. +-rlang::catch_cnd(...)
         2. | +-rlang::eval_bare(...)
         3. | +-base::tryCatch(...)
-        4. | | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        5. | |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        6. | |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        7. | \-base::force(expr)
-        8. \-rlang:::foo()
-        9.   \-rlang:::bar()
-       10.     \-rlang:::baz()
+        4. | | \-base tryCatchList(...)
+        5. | |   \-base tryCatchOne(...)
+        6. | |     \-base doTryCatch(...)
+        7. | \-base::force(...)
+        8. \-rlang foo()
+        9.   \-rlang bar()
+       10.     \-rlang baz()
        11.       +-base::withCallingHandlers(...)
-       12.       \-rlang:::f()
-       13.         \-rlang:::g()
-       14.           \-rlang:::h()
+       12.       \-rlang f()
+       13.         \-rlang g()
+       14.           \-rlang h()
       Caused by error in `h()`: 
         Low-level message
       Backtrace:
@@ -341,37 +341,37 @@
         bar
       Backtrace:
            x
-        1. +-rlang::catch_cnd(foo(), "error")
+        1. +-rlang::catch_cnd(...)
         2. | +-rlang::eval_bare(...)
         3. | +-base::tryCatch(...)
-        4. | | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        5. | |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        6. | |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        7. | \-base::force(expr)
-        8. \-rlang:::foo()
-        9.   \-rlang:::bar()
-       10.     \-rlang:::baz()
+        4. | | \-base tryCatchList(...)
+        5. | |   \-base tryCatchOne(...)
+        6. | |     \-base doTryCatch(...)
+        7. | \-base::force(...)
+        8. \-rlang foo()
+        9.   \-rlang bar()
+       10.     \-rlang baz()
       Caused by error in `h()`: 
         foo
       Backtrace:
            x
-        1. +-rlang::catch_cnd(foo(), "error")
+        1. +-rlang::catch_cnd(...)
         2. | +-rlang::eval_bare(...)
         3. | +-base::tryCatch(...)
-        4. | | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        5. | |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        6. | |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        7. | \-base::force(expr)
-        8. \-rlang:::foo()
-        9.   \-rlang:::bar()
-       10.     \-rlang:::baz()
-       11.       +-base::tryCatch(f(), error = function(err) abort("bar", parent = err))
-       12.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       13.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       14.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       15.       \-rlang:::f()
-       16.         \-rlang:::g()
-       17.           \-rlang:::h()
+        4. | | \-base tryCatchList(...)
+        5. | |   \-base tryCatchOne(...)
+        6. | |     \-base doTryCatch(...)
+        7. | \-base::force(...)
+        8. \-rlang foo()
+        9.   \-rlang bar()
+       10.     \-rlang baz()
+       11.       +-base::tryCatch(...)
+       12.       | \-base tryCatchList(...)
+       13.       |   \-base tryCatchOne(...)
+       14.       |     \-base doTryCatch(...)
+       15.       \-rlang f()
+       16.         \-rlang g()
+       17.           \-rlang h()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
@@ -382,21 +382,21 @@
       Backtrace:
            x
         1. +-[ rlang::catch_cnd(...) ] with 6 more calls
-        8. \-rlang:::foo()
-        9.   \-rlang:::bar()
-       10.     \-rlang:::baz()
+        8. \-rlang foo()
+        9.   \-rlang bar()
+       10.     \-rlang baz()
       Caused by error in `h()`: 
         foo
       Backtrace:
            x
         1. +-[ rlang::catch_cnd(...) ] with 6 more calls
-        8. \-rlang:::foo()
-        9.   \-rlang:::bar()
-       10.     \-rlang:::baz()
+        8. \-rlang foo()
+        9.   \-rlang bar()
+       10.     \-rlang baz()
        11.       +-[ base::tryCatch(...) ] with 3 more calls
-       15.       \-rlang:::f()
-       16.         \-rlang:::g()
-       17.           \-rlang:::h()
+       15.       \-rlang f()
+       16.         \-rlang g()
+       17.           \-rlang h()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
@@ -405,18 +405,18 @@
       Error: 
         bar
       Backtrace:
-        1. rlang::catch_cnd(foo(), "error")
-        8. rlang:::foo()
-        9. rlang:::bar()
-       10. rlang:::baz()
+        1. rlang::catch_cnd(...)
+        8. rlang foo()
+        9. rlang bar()
+       10. rlang baz()
       Caused by error in `h()`: 
         foo
       Backtrace:
-        1. rlang::catch_cnd(foo(), "error")
-        8. rlang:::foo()
-        9. rlang:::bar()
-       10. rlang:::baz()
-       15. rlang:::f()
-       16. rlang:::g()
-       17. rlang:::h()
+        1. rlang::catch_cnd(...)
+        8. rlang foo()
+        9. rlang bar()
+       10. rlang baz()
+       15. rlang f()
+       16. rlang g()
+       17. rlang h()
 

--- a/tests/testthat/_snaps/cnd-signal.md
+++ b/tests/testthat/_snaps/cnd-signal.md
@@ -5,10 +5,10 @@
     Output
       <error/rlang_error_foobar>
       Backtrace:
-        1. rlang::catch_cnd(f())
-        8. rlang:::f()
-        9. rlang:::g()
-       10. rlang:::h()
+        1. rlang::catch_cnd(...)
+        8. rlang f()
+        9. rlang g()
+       10. rlang h()
 
 # `inform()` and `warn()` with recurrent footer handle newlines correctly
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -4,10 +4,10 @@
       print(trace, dir = dir)
     Output
           x
-       1. \-rlang:::i() at test-trace.R:25:2
-       2.   \-rlang:::j(i) at test-trace.R:18:7
-       3.     \-rlang:::k(i) at test-trace.R:19:21
-       4.       \-rlang:::l(i) at test-trace.R:22:4
+       1. \-rlang i() at test-trace.R:25:2
+       2.   \-rlang j(...) at test-trace.R:18:7
+       3.     \-rlang k(...) at test-trace.R:19:21
+       4.       \-rlang l(...) at test-trace.R:22:4
     Code
       cat("\n")
     Output
@@ -24,47 +24,47 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
            x
-        1. \-rlang:::f()
-        2.   \-rlang:::g() at test-trace.R:49:20
-        3.     +-base::tryCatch(h(), foo = identity, bar = identity) at test-trace.R:50:20
-        4.     | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        5.     |   +-base:::tryCatchOne(...)
-        6.     |   | \-base:::doTryCatch(return(expr), name, parentenv, handler)
-        7.     |   \-base:::tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
-        8.     |     \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        9.     |       \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       10.     \-rlang:::h()
-       11.       +-base::tryCatch(i(), baz = identity) at test-trace.R:51:20
-       12.       | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       13.       |   \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       14.       |     \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       15.       \-rlang:::i()
-       16.         +-base::tryCatch(trace_back(e, bottom = 0)) at test-trace.R:52:20
-       17.         | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-       18.         \-rlang::trace_back(e, bottom = 0)
+        1. \-rlang f()
+        2.   \-rlang g() at test-trace.R:49:20
+        3.     +-base::tryCatch(...) at test-trace.R:50:20
+        4.     | \-base tryCatchList(...)
+        5.     |   +-base tryCatchOne(...)
+        6.     |   | \-base doTryCatch(...)
+        7.     |   \-base tryCatchList(...)
+        8.     |     \-base tryCatchOne(...)
+        9.     |       \-base doTryCatch(...)
+       10.     \-rlang h()
+       11.       +-base::tryCatch(...) at test-trace.R:51:20
+       12.       | \-base tryCatchList(...)
+       13.       |   \-base tryCatchOne(...)
+       14.       |     \-base doTryCatch(...)
+       15.       \-rlang i()
+       16.         +-base::tryCatch(...) at test-trace.R:52:20
+       17.         | \-base tryCatchList(...)
+       18.         \-rlang::trace_back(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
            x
-        1. \-rlang:::f()
-        2.   \-rlang:::g() at test-trace.R:49:20
+        1. \-rlang f()
+        2.   \-rlang g() at test-trace.R:49:20
         3.     +-[ base::tryCatch(...) ] with 6 more calls at test-trace.R:50:20
-       10.     \-rlang:::h()
+       10.     \-rlang h()
        11.       +-[ base::tryCatch(...) ] with 3 more calls at test-trace.R:51:20
-       15.       \-rlang:::i()
+       15.       \-rlang i()
        16.         +-[ base::tryCatch(...) ] with 1 more call at test-trace.R:52:20
-       18.         \-rlang::trace_back(e, bottom = 0)
+       18.         \-rlang::trace_back(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-        1. rlang:::f()
-        2. rlang:::g()
+        1. rlang f()
+        2. rlang g()
            at test-trace.R:49:20
-       10. rlang:::h()
-       15. rlang:::i()
-       18. rlang::trace_back(e, bottom = 0)
+       10. rlang h()
+       15. rlang i()
+       18. rlang::trace_back(...)
 
 ---
 
@@ -73,48 +73,48 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
            x
-        1. \-rlang:::f()
-        2.   +-base::eval(quote(eval(quote(g())))) at test-trace.R:61:7
-        3.   | \-base::eval(quote(eval(quote(g()))))
-        4.   +-base::eval(quote(g()))
-        5.   | \-base::eval(quote(g()))
-        6.   \-rlang:::g()
-        7.     +-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) at test-trace.R:62:7
-        8.     | \-base:::tryCatchList(expr, classes, parentenv, handlers)
-        9.     |   +-base:::tryCatchOne(...)
-       10.     |   | \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       11.     |   \-base:::tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
-       12.     |     \-base:::tryCatchOne(expr, names, parentenv, handlers[[1L]])
-       13.     |       \-base:::doTryCatch(return(expr), name, parentenv, handler)
-       14.     +-base::eval(quote(h()))
-       15.     | \-base::eval(quote(h()))
-       16.     \-rlang:::h()
+        1. \-rlang f()
+        2.   +-base::eval(...) at test-trace.R:61:7
+        3.   | \-base::eval(...)
+        4.   +-base::eval(...)
+        5.   | \-base::eval(...)
+        6.   \-rlang g()
+        7.     +-base::tryCatch(...) at test-trace.R:62:7
+        8.     | \-base tryCatchList(...)
+        9.     |   +-base tryCatchOne(...)
+       10.     |   | \-base doTryCatch(...)
+       11.     |   \-base tryCatchList(...)
+       12.     |     \-base tryCatchOne(...)
+       13.     |       \-base doTryCatch(...)
+       14.     +-base::eval(...)
+       15.     | \-base::eval(...)
+       16.     \-rlang h()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
            x
-        1. \-rlang:::f()
+        1. \-rlang f()
         2.   +-[ base::eval(...) ] with 1 more call at test-trace.R:61:7
         4.   +-[ base::eval(...) ] with 1 more call
-        6.   \-rlang:::g()
+        6.   \-rlang g()
         7.     +-[ base::tryCatch(...) ] with 6 more calls at test-trace.R:62:7
        14.     +-[ base::eval(...) ] with 1 more call
-       16.     \-rlang:::h()
+       16.     \-rlang h()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-        1. rlang:::f()
-        6. rlang:::g()
-       16. rlang:::h()
+        1. rlang f()
+        6. rlang g()
+       16. rlang h()
 
 # cli_branch() handles edge case
 
     Code
       cli_branch(tree[-1, ])
     Output
-      [1] " 1. rlang:::f()"
+      [1] " 1. rlang f()"
 
 # collapsed formatting doesn't collapse single frame siblings
 
@@ -122,16 +122,16 @@
       print(trace, simplify = "none", srcrefs = FALSE)
     Output
           x
-       1. \-rlang:::f()
-       2.   +-rlang::eval_bare(quote(g()))
-       3.   \-rlang:::g()
+       1. \-rlang f()
+       2.   +-rlang::eval_bare(...)
+       3.   \-rlang g()
     Code
       print(trace, simplify = "collapse", srcrefs = FALSE)
     Output
           x
-       1. \-rlang:::f()
-       2.   +-rlang::eval_bare(quote(g()))
-       3.   \-rlang:::g()
+       1. \-rlang f()
+       2.   +-rlang::eval_bare(...)
+       3.   \-rlang g()
 
 # recursive frames are rewired to the global env
 
@@ -140,24 +140,24 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang::eval_tidy(quo(f()))
-       2. \-rlang:::f()
-       3.   \-rlang:::g()
+       1. +-rlang::eval_tidy(...)
+       2. \-rlang f()
+       3.   \-rlang g()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang::eval_tidy(quo(f()))
-       2. \-rlang:::f()
-       3.   \-rlang:::g()
+       1. +-rlang::eval_tidy(...)
+       2. \-rlang f()
+       3.   \-rlang g()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang::eval_tidy(quo(f()))
-       2. rlang:::f()
-       3. rlang:::g()
+       1. rlang::eval_tidy(...)
+       2. rlang f()
+       3. rlang g()
 
 # long backtrace branches are truncated
 
@@ -168,17 +168,17 @@
     Code
       print(trace, simplify = "branch", srcrefs = FALSE)
     Output
-        1. rlang:::f(10)
-        2. rlang:::f(n - 1)
-        3. rlang:::f(n - 1)
-        4. rlang:::f(n - 1)
-        5. rlang:::f(n - 1)
-        6. rlang:::f(n - 1)
-        7. rlang:::f(n - 1)
-        8. rlang:::f(n - 1)
-        9. rlang:::f(n - 1)
-       10. rlang:::f(n - 1)
-       11. rlang:::f(n - 1)
+        1. rlang f(...)
+        2. rlang f(...)
+        3. rlang f(...)
+        4. rlang f(...)
+        5. rlang f(...)
+        6. rlang f(...)
+        7. rlang f(...)
+        8. rlang f(...)
+        9. rlang f(...)
+       10. rlang f(...)
+       11. rlang f(...)
     Code
       cat("\n5 frames:\n")
     Output
@@ -187,12 +187,12 @@
     Code
       print(trace, simplify = "branch", max_frames = 5, srcrefs = FALSE)
     Output
-        1. rlang:::f(10)
-        2. rlang:::f(n - 1)
-        3. rlang:::f(n - 1)
+        1. rlang f(...)
+        2. rlang f(...)
+        3. rlang f(...)
            ...
-       10. rlang:::f(n - 1)
-       11. rlang:::f(n - 1)
+       10. rlang f(...)
+       11. rlang f(...)
     Code
       cat("\n2 frames:\n")
     Output
@@ -201,9 +201,9 @@
     Code
       print(trace, simplify = "branch", max_frames = 2, srcrefs = FALSE)
     Output
-        1. rlang:::f(10)
+        1. rlang f(...)
            ...
-       11. rlang:::f(n - 1)
+       11. rlang f(...)
     Code
       cat("\n1 frame:\n")
     Output
@@ -212,7 +212,7 @@
     Code
       print(trace, simplify = "branch", max_frames = 1, srcrefs = FALSE)
     Output
-        1. rlang:::f(10)
+        1. rlang f(...)
            ...
 
 # eval() frames are collapsed
@@ -222,30 +222,30 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::f()
-       2.   +-base::eval(quote(g()))
-       3.   | \-base::eval(quote(g()))
-       4.   \-rlang:::g()
-       5.     +-base::eval(quote(trace_back(e, bottom = 0)))
-       6.     | \-base::eval(quote(trace_back(e, bottom = 0)))
-       7.     \-rlang::trace_back(e, bottom = 0)
+       1. \-rlang f()
+       2.   +-base::eval(...)
+       3.   | \-base::eval(...)
+       4.   \-rlang g()
+       5.     +-base::eval(...)
+       6.     | \-base::eval(...)
+       7.     \-rlang::trace_back(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::f()
+       1. \-rlang f()
        2.   +-[ base::eval(...) ] with 1 more call
-       4.   \-rlang:::g()
+       4.   \-rlang g()
        5.     +-[ base::eval(...) ] with 1 more call
-       7.     \-rlang::trace_back(e, bottom = 0)
+       7.     \-rlang::trace_back(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::f()
-       4. rlang:::g()
-       7. rlang::trace_back(e, bottom = 0)
+       1. rlang f()
+       4. rlang g()
+       7. rlang::trace_back(...)
 
 ---
 
@@ -254,30 +254,30 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::f()
-       2.   +-base::evalq(g())
-       3.   | \-base::evalq(g())
-       4.   \-rlang:::g()
-       5.     +-base::evalq(trace_back(e, bottom = 0))
-       6.     | \-base::evalq(trace_back(e, bottom = 0))
-       7.     \-rlang::trace_back(e, bottom = 0)
+       1. \-rlang f()
+       2.   +-base::evalq(...)
+       3.   | \-base::evalq(...)
+       4.   \-rlang g()
+       5.     +-base::evalq(...)
+       6.     | \-base::evalq(...)
+       7.     \-rlang::trace_back(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::f()
+       1. \-rlang f()
        2.   +-[ base::evalq(...) ] with 1 more call
-       4.   \-rlang:::g()
+       4.   \-rlang g()
        5.     +-[ base::evalq(...) ] with 1 more call
-       7.     \-rlang::trace_back(e, bottom = 0)
+       7.     \-rlang::trace_back(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::f()
-       4. rlang:::g()
-       7. rlang::trace_back(e, bottom = 0)
+       1. rlang f()
+       4. rlang g()
+       7. rlang::trace_back(...)
 
 # %>% frames are collapsed
 
@@ -287,20 +287,20 @@
     Output
           x
        1. +-NULL %>% f() %>% g(1, 2) %>% h(3, ., 4)
-       2. \-rlang:::h(3, ., 4)
+       2. \-rlang h(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-NULL %>% f() %>% g(1, 2) %>% h(3, ., 4)
-       2. \-rlang:::h(3, ., 4)
+       2. \-rlang h(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. NULL %>% f() %>% g(1, 2) %>% h(3, ., 4)
-       2. rlang:::h(3, ., 4)
+       2. rlang h(...)
 
 ---
 
@@ -310,20 +310,20 @@
     Output
           x
        1. +-f(NULL) %>% g(list(.)) %>% h(3, ., list(.))
-       2. \-rlang:::h(3, ., list(.))
+       2. \-rlang h(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-f(NULL) %>% g(list(.)) %>% h(3, ., list(.))
-       2. \-rlang:::h(3, ., list(.))
+       2. \-rlang h(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. f(NULL) %>% g(list(.)) %>% h(3, ., list(.))
-       2. rlang:::h(3, ., list(.))
+       2. rlang h(...)
 
 ---
 
@@ -332,23 +332,23 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::f(g(NULL %>% f()) %>% h())
+       1. +-rlang f(...)
        2. +-g(NULL %>% f()) %>% h()
-       3. \-rlang:::h(.)
+       3. \-rlang h(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::f(g(NULL %>% f()) %>% h())
+       1. +-rlang f(...)
        2. +-g(NULL %>% f()) %>% h()
-       3. \-rlang:::h(.)
+       3. \-rlang h(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::f(g(NULL %>% f()) %>% h())
-       3. rlang:::h(.)
+       1. rlang f(...)
+       3. rlang h(...)
 
 # children of collapsed %>% frames have correct parent
 
@@ -358,26 +358,26 @@
     Output
           x
        1. +-NA %>% F() %>% G() %>% H()
-       2. \-rlang:::H(.)
-       3.   \-rlang:::f()
-       4.     \-rlang:::h()
+       2. \-rlang H(...)
+       3.   \-rlang f()
+       4.     \-rlang h()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-NA %>% F() %>% G() %>% H()
-       2. \-rlang:::H(.)
-       3.   \-rlang:::f()
-       4.     \-rlang:::h()
+       2. \-rlang H(...)
+       3.   \-rlang f()
+       4.     \-rlang h()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. NA %>% F() %>% G() %>% H()
-       2. rlang:::H(.)
-       3. rlang:::f()
-       4. rlang:::h()
+       2. rlang H(...)
+       3. rlang f()
+       4. rlang h()
 
 # children of collapsed frames are rechained to correct parent
 
@@ -389,10 +389,10 @@
       print(trace, simplify = "none", srcrefs = FALSE)
     Output
           x
-       1. \-rlang:::f()
-       2.   \-base::eval(quote(g()), env())
-       3.     \-base::eval(quote(g()), env())
-       4.       \-rlang:::g()
+       1. \-rlang f()
+       2.   \-base::eval(...)
+       3.     \-base::eval(...)
+       4.       \-rlang g()
     Code
       cat("\nCollapsed:\n")
     Output
@@ -402,9 +402,9 @@
       print(trace, simplify = "collapse", srcrefs = FALSE)
     Output
           x
-       1. \-rlang:::f()
+       1. \-rlang f()
        2.   \-[ base::eval(...) ] with 1 more call
-       4.     \-rlang:::g()
+       4.     \-rlang g()
     Code
       cat("\nBranch:\n")
     Output
@@ -413,9 +413,9 @@
     Code
       print(trace, simplify = "branch", srcrefs = FALSE)
     Output
-       1. rlang:::f()
+       1. rlang f()
        2. [ base::eval(...) ] with 1 more call
-       4. rlang:::g()
+       4. rlang g()
 
 # combinations of incomplete and leading pipes collapse properly
 
@@ -425,24 +425,24 @@
     Output
           x
        1. +-NA %>% F() %>% T() %>% F() %>% F()
-       2. +-rlang:::F(.)
-       3. +-rlang:::F(.)
-       4. \-rlang:::T(.)
+       2. +-rlang F(...)
+       3. +-rlang F(...)
+       4. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-NA %>% F() %>% T() %>% F() %>% F()
-       2. +-rlang:::F(.)
-       3. +-rlang:::F(.)
-       4. \-rlang:::T(.)
+       2. +-rlang F(...)
+       3. +-rlang F(...)
+       4. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. NA %>% F() %>% T() %>% F() %>% F()
-       4. rlang:::T(.)
+       4. rlang T(...)
 
 ---
 
@@ -452,22 +452,22 @@
     Output
           x
        1. +-T(NA) %>% F()
-       2. +-rlang:::F(.)
-       3. \-rlang:::T(NA)
+       2. +-rlang F(...)
+       3. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-T(NA) %>% F()
-       2. +-rlang:::F(.)
-       3. \-rlang:::T(NA)
+       2. +-rlang F(...)
+       3. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. T(NA) %>% F()
-       3. rlang:::T(NA)
+       3. rlang T(...)
 
 ---
 
@@ -477,24 +477,24 @@
     Output
           x
        1. +-F(NA) %>% F() %>% T() %>% F() %>% F()
-       2. +-rlang:::F(.)
-       3. +-rlang:::F(.)
-       4. \-rlang:::T(.)
+       2. +-rlang F(...)
+       3. +-rlang F(...)
+       4. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-F(NA) %>% F() %>% T() %>% F() %>% F()
-       2. +-rlang:::F(.)
-       3. +-rlang:::F(.)
-       4. \-rlang:::T(.)
+       2. +-rlang F(...)
+       3. +-rlang F(...)
+       4. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. F(NA) %>% F() %>% T() %>% F() %>% F()
-       4. rlang:::T(.)
+       4. rlang T(...)
 
 ---
 
@@ -504,20 +504,20 @@
     Output
           x
        1. +-NA %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-NA %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. NA %>% T()
-       2. rlang:::T(.)
+       2. rlang T(...)
 
 ---
 
@@ -527,20 +527,20 @@
     Output
           x
        1. +-NA %>% F() %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-NA %>% F() %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. NA %>% F() %>% T()
-       2. rlang:::T(.)
+       2. rlang T(...)
 
 ---
 
@@ -550,20 +550,20 @@
     Output
           x
        1. +-F(NA) %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-F(NA) %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. F(NA) %>% T()
-       2. rlang:::T(.)
+       2. rlang T(...)
 
 ---
 
@@ -573,20 +573,20 @@
     Output
           x
        1. +-F(NA) %>% F() %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-F(NA) %>% F() %>% T()
-       2. \-rlang:::T(.)
+       2. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. F(NA) %>% F() %>% T()
-       2. rlang:::T(.)
+       2. rlang T(...)
 
 # calls before and after pipe are preserved
 
@@ -595,23 +595,23 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::F(NA %>% T())
+       1. +-rlang F(...)
        2. +-NA %>% T()
-       3. \-rlang:::T(.)
+       3. \-rlang T(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::F(NA %>% T())
+       1. +-rlang F(...)
        2. +-NA %>% T()
-       3. \-rlang:::T(.)
+       3. \-rlang T(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::F(NA %>% T())
-       3. rlang:::T(.)
+       1. rlang F(...)
+       3. rlang T(...)
 
 ---
 
@@ -621,23 +621,23 @@
     Output
           x
        1. +-NA %>% C()
-       2. \-rlang:::C(.)
-       3.   \-rlang:::f()
+       2. \-rlang C(...)
+       3.   \-rlang f()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
        1. +-NA %>% C()
-       2. \-rlang:::C(.)
-       3.   \-rlang:::f()
+       2. \-rlang C(...)
+       3.   \-rlang f()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. NA %>% C()
-       2. rlang:::C(.)
-       3. rlang:::f()
+       2. rlang C(...)
+       3. rlang f()
 
 ---
 
@@ -646,26 +646,26 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::F(NA %>% C())
+       1. +-rlang F(...)
        2. +-NA %>% C()
-       3. \-rlang:::C(.)
-       4.   \-rlang:::f()
+       3. \-rlang C(...)
+       4.   \-rlang f()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::F(NA %>% C())
+       1. +-rlang F(...)
        2. +-NA %>% C()
-       3. \-rlang:::C(.)
-       4.   \-rlang:::f()
+       3. \-rlang C(...)
+       4.   \-rlang f()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::F(NA %>% C())
-       3. rlang:::C(.)
-       4. rlang:::f()
+       1. rlang F(...)
+       3. rlang C(...)
+       4. rlang f()
 
 # always keep very first frame as part of backtrace branch
 
@@ -674,21 +674,21 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::gen()
-       2. \-rlang:::gen.default()
+       1. +-rlang gen()
+       2. \-rlang gen.default()
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-rlang:::gen()
-       2. \-rlang:::gen.default()
+       1. +-rlang gen()
+       2. \-rlang gen.default()
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::gen()
-       2. rlang:::gen.default()
+       1. rlang gen()
+       2. rlang gen.default()
 
 # anonymous calls are stripped from backtraces
 
@@ -719,7 +719,7 @@
           x
        1. +-base::eval()
        2. \-base::.handleSimpleError(...)
-       3.   \-rlang:::h(simpleError(msg, call))
+       3.   \-rlang h(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
@@ -727,14 +727,14 @@
           x
        1. +-base::eval()
        2. \-base::.handleSimpleError(...)
-       3.   \-rlang:::h(simpleError(msg, call))
+       3.   \-rlang h(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. base::eval()
        2. base::.handleSimpleError(...)
-       3. rlang:::h(simpleError(msg, call))
+       3. rlang h(...)
 
 # can print degenerate backtraces
 
@@ -803,21 +803,21 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-base::print(foo)
-       2. \-rlang:::print.foo(foo)
+       1. +-base::print(...)
+       2. \-rlang print.foo(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. +-base::print(foo)
-       2. \-rlang:::print.foo(foo)
+       1. +-base::print(...)
+       2. \-rlang print.foo(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. base::print(foo)
-       2. rlang:::print.foo(foo)
+       1. base::print(...)
+       2. rlang print.foo(...)
 
 # dangling srcrefs are not printed
 
@@ -826,21 +826,21 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::f(current_env())
-       2.   \-rlang:::g(e) at fixtures/trace-srcref2.R:2:2
+       1. \-rlang f(...)
+       2.   \-rlang g(...) at fixtures/trace-srcref2.R:2:2
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::f(current_env())
-       2.   \-rlang:::g(e) at fixtures/trace-srcref2.R:2:2
+       1. \-rlang f(...)
+       2.   \-rlang g(...) at fixtures/trace-srcref2.R:2:2
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::f(current_env())
-       2. rlang:::g(e)
+       1. rlang f(...)
+       2. rlang g(...)
           at fixtures/trace-srcref2.R:2:2
 
 # summary.rlang_trace() prints the full tree
@@ -849,9 +849,9 @@
       summary(trace, srcrefs = FALSE)
     Output
           x
-       1. \-rlang:::f()
-       2.   \-rlang:::g()
-       3.     \-rlang:::h()
+       1. \-rlang f()
+       2.   \-rlang g()
+       3.     \-rlang h()
 
 # global functions have `global::` prefix
 
@@ -860,21 +860,21 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::g(current_env())
-       2.   \-global::f(e)
+       1. \-rlang g(...)
+       2.   \-global f(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::g(current_env())
-       2.   \-global::f(e)
+       1. \-rlang g(...)
+       2.   \-global f(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::g(current_env())
-       2. global::f(e)
+       1. rlang g(...)
+       2. global f(...)
 
 # local functions inheriting from global do not have `global::` prefix
 
@@ -883,21 +883,21 @@
       print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::g(current_env())
-       2.   \-f(e)
+       1. \-rlang g(...)
+       2.   \-f(...)
     Code
       # Collapsed
       print(trace, simplify = "collapse", dir = dir, srcrefs = srcrefs)
     Output
           x
-       1. \-rlang:::g(current_env())
-       2.   \-f(e)
+       1. \-rlang g(...)
+       2.   \-f(...)
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
-       1. rlang:::g(current_env())
-       2. f(e)
+       1. rlang g(...)
+       2. f(...)
 
 # can trim layers of backtraces
 
@@ -910,16 +910,16 @@
       summary(trace0)
     Output
            x
-        1. \-rlang:::f(0) at test-trace.R:456:2
-        2.   +-base::identity(identity(g(n))) at test-trace.R:452:7
-        3.   +-base::identity(g(n))
-        4.   \-rlang:::g(n)
-        5.     +-base::identity(identity(h(n))) at test-trace.R:453:7
-        6.     +-base::identity(h(n))
-        7.     \-rlang:::h(n)
-        8.       +-base::identity(identity(trace_back(e, bottom = n))) at test-trace.R:454:7
-        9.       +-base::identity(trace_back(e, bottom = n))
-       10.       \-rlang::trace_back(e, bottom = n)
+        1. \-rlang f(...) at test-trace.R:456:2
+        2.   +-base::identity(...) at test-trace.R:452:7
+        3.   +-base::identity(...)
+        4.   \-rlang g(...)
+        5.     +-base::identity(...) at test-trace.R:453:7
+        6.     +-base::identity(...)
+        7.     \-rlang h(...)
+        8.       +-base::identity(...) at test-trace.R:454:7
+        9.       +-base::identity(...)
+       10.       \-rlang::trace_back(...)
     Code
       cat_line("", "", "One layer (the default):")
     Output
@@ -930,13 +930,13 @@
       summary(trace1)
     Output
           x
-       1. \-rlang:::f(1) at test-trace.R:457:2
-       2.   +-base::identity(identity(g(n))) at test-trace.R:452:7
-       3.   +-base::identity(g(n))
-       4.   \-rlang:::g(n)
-       5.     +-base::identity(identity(h(n))) at test-trace.R:453:7
-       6.     +-base::identity(h(n))
-       7.     \-rlang:::h(n)
+       1. \-rlang f(...) at test-trace.R:457:2
+       2.   +-base::identity(...) at test-trace.R:452:7
+       3.   +-base::identity(...)
+       4.   \-rlang g(...)
+       5.     +-base::identity(...) at test-trace.R:453:7
+       6.     +-base::identity(...)
+       7.     \-rlang h(...)
     Code
       cat_line("", "", "Two layers:")
     Output
@@ -947,10 +947,10 @@
       summary(trace2)
     Output
           x
-       1. \-rlang:::f(2) at test-trace.R:458:2
-       2.   +-base::identity(identity(g(n))) at test-trace.R:452:7
-       3.   +-base::identity(g(n))
-       4.   \-rlang:::g(n)
+       1. \-rlang f(...) at test-trace.R:458:2
+       2.   +-base::identity(...) at test-trace.R:452:7
+       3.   +-base::identity(...)
+       4.   \-rlang g(...)
     Code
       cat_line("", "", "Three layers:")
     Output
@@ -961,7 +961,7 @@
       summary(trace3)
     Output
           x
-       1. \-rlang:::f(3) at test-trace.R:459:2
+       1. \-rlang f(...) at test-trace.R:459:2
 
 # caught error does not display backtrace in knitted files
 
@@ -985,9 +985,9 @@
           ## <error/rlang_error>
           ## Error in `h()`: foo
           ## Backtrace:
-          ##  1. global::f()
-          ##  2. global::g()
-          ##  3. global::h()
+          ##  1. global f()
+          ##  2. global g()
+          ##  3. global h()
           ## Run `rlang::last_trace()` to see the full context.
       
           last_trace()
@@ -996,9 +996,9 @@
           ## Error in `h()`: foo
           ## Backtrace:
           ##     x
-          ##  1. \-global::f()
-          ##  2.   \-global::g()
-          ##  3.     \-global::h()
+          ##  1. \-global f()
+          ##  2.   \-global g()
+          ##  3.     \-global h()
       
           options(rlang_backtrace_on_error_report = "reminder")
           f()
@@ -1012,9 +1012,9 @@
           ## Error: foo
           ## Backtrace:
           ##     x
-          ##  1. \-global::f()
-          ##  2.   \-global::g()
-          ##  3.     \-global::h()
+          ##  1. \-global f()
+          ##  2.   \-global g()
+          ##  3.     \-global h()
 
 # backtraces don't contain inlined objects (#1069, r-lib/testthat#1223)
 
@@ -1022,9 +1022,9 @@
       summary(trace)
     Output
           x
-       1. +-rlang::inject(f(!!list()))
-       2. \-rlang:::f(`<list>`)
-       3.   +-base::do.call("g", list(runif(1e+06) + 0))
-       4.   \-rlang:::g(`<dbl>`)
-       5.     \-rlang:::h()
+       1. +-rlang::inject(...)
+       2. \-rlang f(...)
+       3.   +-base::do.call(...)
+       4.   \-rlang g(...)
+       5.     \-rlang h()
 


### PR DESCRIPTION
@jimhester makes a good point that it's confusing to display namespaced calls in the backtrace that don't work in the console. This PR leverages the new metadata recorded in backtraces to replace namespace operators with a simple space. Closes #902.

Local functions are no longer qualified with `:::`

```r
as.Date("foo")
#> Error in charToDate(x) :
#>   character string is not in a standard unambiguous format

# Before
last_error()
#> <error/rlang_error>
#> Error: character string is not in a standard unambiguous format
#> Backtrace:
#>  1. base::as.Date(...)
#>  2. base::as.Date.character(...)
#>  3. base:::charToDate(...)

# After
last_error()
#> <error/rlang_error>
#> Error: character string is not in a standard unambiguous format
#> Backtrace:
#>  1. base::as.Date(...)
#>  2. base::as.Date.character(...)
#>  3. base charToDate(...)
```

Global functions are no longer qualified with `::`

```r
f <- function() g()
g <- function() h()
h <- function() abort("foo")
f()
#> Error in `h()`: foo

# Before
last_error()
#> <error/rlang_error>
#> Error in `h()`: foo
#> Backtrace:
#>  1. global::f()
#>  2. global::g()
#>  3. global::h()

# After
last_error()
#> <error/rlang_error>
#> Error in `h()`: foo
#> Backtrace:
#>  1. global f()
#>  2. global g()
#>  3. global h()
```