### PR TITLE
Fix C++11 detection in `use_rlang_c_library()`

### DIFF
--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -67,7 +67,7 @@ use_rlang_c_library <- function() {
     usethis::ui_todo("Add to `src/Makvars`:")
     usethis::ui_code_block("PKG_CPPFLAGS = -I./rlang")
   }
-  if (!has_cpp11_sysreq(src_path)) {
+  if (!has_cpp11_sysreq(proj_path)) {
     usethis::ui_todo("Add to `DESCRIPTION`:")
     usethis::ui_code_block("SystemRequirements: C++11")
   }
@@ -124,9 +124,9 @@ has_include_directive <- function(src_path) {
   any(grepl("PKG_CPPFLAGS.*-I.*rlang", makevars_lines))
 }
 
-has_cpp11_sysreq <- function(src_path) {
-  desc_lines <- readLines(fs::path(src_path, "DESCRIPTION"))
-  any(grepl("C++11", desc_lines))
+has_cpp11_sysreq <- function(proj_path) {
+  desc_lines <- readLines(fs::path(proj_path, "DESCRIPTION"))
+  any(grepl("C++11", desc_lines, fixed = TRUE))
 }
 
 detect_rlang_lib_usage <- function(src_path) {
@@ -315,7 +315,7 @@ list_compact <- function(x) {
 }
 
 vec_resize <- function(x, n) {
-  .Call(ffi_vec_resize, x, n) 
+  .Call(ffi_vec_resize, x, n)
 }
 
 


### PR DESCRIPTION
I'm pretty sure we need to pass through the project path in `has_cpp11_sysreq()`.

Also, `grep()` doesn't like the `++` in the `"C++11"` pattern and returns this without `fixed = TRUE`:

```r
Error in grepl("C++11", desc_lines, fixed = F) : 
  invalid regular expression 'C++11', reason 'Invalid use of repetition operators'
```