### PR TITLE
Replace `action = signaller` arguments by `error = handler`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,10 @@
 
 * `friendly_type()` is deprecated and `as_pairlist()` is defunct.
 
+* The `action` argument of `check_dots_used()`, `check_dots_unnamed()`,
+  and `check_dots_empty()` is deprecated in favour of the new `error`
+  argument which takes an error handler.
+
 
 ## Features and bugfixes
 

--- a/man/check_dots_empty.Rd
+++ b/man/check_dots_empty.Rd
@@ -4,18 +4,25 @@
 \alias{check_dots_empty}
 \title{Check that dots are empty}
 \usage{
-check_dots_empty(env = caller_env(), call = caller_env(), action = abort)
+check_dots_empty(
+  env = caller_env(),
+  error = NULL,
+  call = caller_env(),
+  action = abort
+)
 }
 \arguments{
 \item{env}{Environment in which to look for \code{...}.}
+
+\item{error}{An optional error handler passed to \code{\link[=try_catch]{try_catch()}}. Use
+this e.g. to demote an error into a warning.}
 
 \item{call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[=abort]{abort()}} for more information.}
 
-\item{action}{The action to take when the dots have not been used. One of
-\code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}} or \code{\link[=signal]{signal()}}.}
+\item{action}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}.}
 }
 \description{
 Sometimes you just want to use \code{...} to force your users to fully name

--- a/man/check_dots_unnamed.Rd
+++ b/man/check_dots_unnamed.Rd
@@ -4,18 +4,25 @@
 \alias{check_dots_unnamed}
 \title{Check that all dots are unnamed}
 \usage{
-check_dots_unnamed(env = caller_env(), call = caller_env(), action = abort)
+check_dots_unnamed(
+  env = caller_env(),
+  error = NULL,
+  call = caller_env(),
+  action = abort
+)
 }
 \arguments{
 \item{env}{Environment in which to look for \code{...}.}
+
+\item{error}{An optional error handler passed to \code{\link[=try_catch]{try_catch()}}. Use
+this e.g. to demote an error into a warning.}
 
 \item{call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[=abort]{abort()}} for more information.}
 
-\item{action}{The action to take when the dots have not been used. One of
-\code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}} or \code{\link[=signal]{signal()}}.}
+\item{action}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}.}
 }
 \description{
 In functions like \code{paste()}, named arguments in \code{...} are often a

--- a/man/check_dots_used.Rd
+++ b/man/check_dots_used.Rd
@@ -4,7 +4,12 @@
 \alias{check_dots_used}
 \title{Check that all dots have been used}
 \usage{
-check_dots_used(env = caller_env(), call = caller_env(), action = abort)
+check_dots_used(
+  env = caller_env(),
+  call = caller_env(),
+  error = NULL,
+  action = deprecated()
+)
 }
 \arguments{
 \item{env}{Environment in which to look for \code{...} and to set up handler.}
@@ -14,8 +19,10 @@ running function, e.g. \code{caller_env()}. The function will be
 mentioned in error messages as the source of the error. See the
 \code{call} argument of \code{\link[=abort]{abort()}} for more information.}
 
-\item{action}{The action to take when the dots have not been used. One of
-\code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, \code{\link[=inform]{inform()}} or \code{\link[=signal]{signal()}}.}
+\item{error}{An optional error handler passed to \code{\link[=try_catch]{try_catch()}}. Use
+this e.g. to demote an error into a warning.}
+
+\item{action}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}.}
 }
 \description{
 Automatically sets exit handler to run when function terminates, checking

--- a/tests/testthat/test-dots-ellipsis.R
+++ b/tests/testthat/test-dots-ellipsis.R
@@ -56,7 +56,7 @@ test_that("error if if dots not empty", {
   })
 })
 
-test_that("can control the action", {
+test_that("can control the action (deprecated)", {
   f <- function(action, check, ..., xyz = 1) {
     check(action = action)
   }
@@ -85,4 +85,21 @@ test_that("warn if unused dots", {
   expect_error(safe_median(1:10), NA)
   expect_error(safe_median(1:10, na.rm = TRUE), NA)
   expect_error(safe_median(1:10, y = 1), class = "rlib_error_dots_unused")
+})
+
+test_that("can supply `error` handler", {
+  hnd <- function(cnd) warning(cnd)
+
+  f <- function(...) check_dots_empty(error = hnd)
+  expect_silent(f())
+  expect_warning(f(foo), class = "rlib_error_dots_nonempty")
+
+  f <- function(...) check_dots_used(error = hnd)
+  expect_silent(f())
+  expect_warning(f(foo), class = "rlib_error_dots_unused")
+
+
+  f <- function(...) check_dots_unnamed(error = hnd)
+  expect_silent(f(foo))
+  expect_warning(f(foo = foo), class = "rlib_error_dots_named")
 })


### PR DESCRIPTION
To avoid tying the ellipsis functions to a fuzzy signaller interface (e.g. does the signaller support `call` arguments?).

Also more consistent with general condition handling idioms.