### PR TITLE
Typo fix (and, apparently, some whitespace)

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -49,7 +49,7 @@ navbar:
       - text: Metaprogramming
       - text: Taking multiple columns without `...`
         href: reference/topic-multiple-columns.html
-    
+
     notes:
       text: Notes
       menu:
@@ -87,7 +87,7 @@ reference:
 
   - title: Tidy evaluation
     desc: >
-      The programmable data-masking framework developped for the
+      The programmable data-masking framework developed for the
       tidyverse.
   - subtitle: Tools
     contents:


### PR DESCRIPTION
The new reference index looks great! I noticed this while there.