### PR TITLE
Fix comment in test following #1299

### DIFF
--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -638,8 +638,8 @@ test_that("infix operators are labelled (#956, r-lib/testthat#1432)", {
     "nchar(chr, type = \"bytes\", allowNA = TRUE) == 1"
   )
 
-  # This fits into 60 characters if we truncate just the left side,
-  # so we don't need to shorten the right
+  # This fits into 60 characters if we truncate either side,
+  # so we don't need to shorten both of them
   expect_equal(
     as_label(quote(very_long_expression[with(subsetting), -1] -
                      another_very_long_expression[with(subsetting), -1]


### PR DESCRIPTION
In my original attempt at #1299, I truncated the left side before checking the right, but before merging @lionel- improved that to keep the left side intact if possible. That meant that the comment I left describing one of the tests wasn't accurate anymore. 