### PR TITLE
Include parent messages in `cnd_message()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,9 @@
   a full prefix, including `call` field if present and parent messages
   if the condition is chained.
 
+* `cnd_message()` gains an `inherit` argument to control whether to
+  print the messages of parent errors.
+
 * `env_has()` and the corresponding C-level function no longer force
   active bindings (#1292).
 

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -462,7 +462,7 @@ signal_abort <- function(cnd, file = NULL) {
   # Print the error manually. This allows us to use our own style,
   # include parent errors, and work around limitations on the length
   # of error messages (#856).
-  msg <- cnd_build_error_message(cnd)
+  msg <- cnd_message_reduce(cnd)
   msg <- cnd_unhandled_message(cnd, message = msg)
 
   cat_line(msg, file = file %||% default_message_file())

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -462,7 +462,7 @@ signal_abort <- function(cnd, file = NULL) {
   # Print the error manually. This allows us to use our own style,
   # include parent errors, and work around limitations on the length
   # of error messages (#856).
-  msg <- cnd_message_reduce(cnd)
+  msg <- cnd_message(cnd, inherit = TRUE, prefix = TRUE)
   msg <- cnd_unhandled_message(cnd, message = msg)
 
   cat_line(msg, file = file %||% default_message_file())

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -59,8 +59,7 @@ cnd_message <- function(cnd, ..., prefix = FALSE) {
   if (prefix) {
     cnd_message_reduce(cnd, ...)
   } else {
-    cnd_format <- cnd_formatter(cnd)
-    cnd_format(cnd_message_lines(cnd, ...))
+    cnd_message_format(cnd, ...)
   }
 }
 cnd_message_lines <- function(cnd, ...) {
@@ -71,16 +70,16 @@ cnd_message_lines <- function(cnd, ...) {
   )
 }
 
-cnd_formatter <- function(cnd) {
+cnd_message_format <- function(cnd, ..., indent = FALSE) {
+  lines <- cnd_message_lines(cnd, ...)
+
   if (!is_true(cnd$use_cli_format)) {
-    return(function(x, indent = FALSE) {
-      x <- paste_line(x)
-      if (indent) {
-        x <- paste0("  ", x)
-        x <- gsub("\n", "\n  ", x, fixed = TRUE)
-      }
-      x
-    })
+    out <- paste_line(lines)
+    if (indent) {
+      out <- paste0("  ", out)
+      out <- gsub("\n", "\n  ", out, fixed = TRUE)
+    }
+    return(out)
   }
 
   # FIXME! Use `format_message()` instead of `format_error()` until
@@ -92,12 +91,10 @@ cnd_formatter <- function(cnd) {
     cli::format_message
   )
 
-  function(x, indent = FALSE) {
-    if (indent) {
-      local_cli_indent()
-    }
-    cli_format(glue_escape(x), .envir = emptyenv())
+  if (indent) {
+    local_cli_indent()
   }
+  cli_format(glue_escape(lines), .envir = emptyenv())
 }
 
 local_cli_indent <- function(frame = caller_env()) {
@@ -180,10 +177,7 @@ cnd_prefixed_message <- function(cnd, ..., parent = FALSE) {
   }
 
   if (is_true(cnd$use_cli_format)) {
-    message <- cnd_message_lines(cnd, ...)
-
-    cnd_format <- cnd_formatter(cnd)
-    message <- cnd_format(message, indent = indent)
+    message <- cnd_message_format(cnd, ..., indent = indent)
   } else {
     message <- conditionMessage(cnd)
     if (indent) {

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -67,7 +67,15 @@ cnd_message <- function(cnd, ..., inherit = TRUE, prefix = FALSE) {
   if (prefix) {
     msg <- cnd_message_format_prefixed(cnd, ..., parent = FALSE)
   } else {
-    msg <- cnd_message_format(cnd, ...)
+    indent <- is_condition(cnd$parent)
+    msg <- cnd_message_format(cnd, ..., indent = indent)
+
+    # Remove leading indent but leave bullets indent if we are not in
+    # charge of formatting the error prefix. This makes the output of
+    # `conditionMessage()` as consistent as possible.
+    if (indent && !prefix) {
+      msg <- substr(msg, 3, nchar(msg))
+    }
   }
 
   # Parent messages are always prefixed

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -155,17 +155,17 @@ cnd_footer.default <- function(cnd, ...) {
 }
 
 cnd_message_reduce <- function(cnd, ...) {
-  msg <- cnd_prefixed_message(cnd, ..., parent = FALSE)
+  msg <- cnd_message_format_prefixed(cnd, ..., parent = FALSE)
 
   while (is_error(cnd <- cnd$parent)) {
-    parent_msg <- cnd_prefixed_message(cnd, parent = TRUE)
+    parent_msg <- cnd_message_format_prefixed(cnd, parent = TRUE)
     msg <- paste_line(msg, parent_msg)
   }
 
   msg
 }
 
-cnd_prefixed_message <- function(cnd, ..., parent = FALSE) {
+cnd_message_format_prefixed <- function(cnd, ..., parent = FALSE) {
   type <- cnd_type(cnd)
 
   if (parent) {

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -57,7 +57,7 @@
 #' @export
 cnd_message <- function(cnd, ..., prefix = FALSE) {
   if (prefix) {
-    cnd_build_error_message(cnd, ...)
+    cnd_message_reduce(cnd, ...)
   } else {
     cnd_format <- cnd_formatter(cnd)
     cnd_format(cnd_message_lines(cnd, ...))
@@ -157,7 +157,7 @@ cnd_footer.default <- function(cnd, ...) {
   cnd$footer %||% chr()
 }
 
-cnd_build_error_message <- function(cnd, ...) {
+cnd_message_reduce <- function(cnd, ...) {
   msg <- cnd_prefixed_message(cnd, ..., parent = FALSE)
 
   while (is_error(cnd <- cnd$parent)) {

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -232,7 +232,7 @@ cnd_format <- function(x,
   style <- cli_box_chars()
 
   header <- cnd_type_header(x)
-  message <- cnd_prefixed_message(x)
+  message <- cnd_message_format_prefixed(x)
 
   out <- paste_line(
     header,
@@ -252,7 +252,7 @@ cnd_format <- function(x,
       trace <- chained_trace
     }
 
-    message <- cnd_prefixed_message(x, parent = TRUE)
+    message <- cnd_message_format_prefixed(x, parent = TRUE)
     out <- paste_line(out, message)
   }
 

--- a/man/cnd_message.Rd
+++ b/man/cnd_message.Rd
@@ -7,7 +7,7 @@
 \alias{cnd_footer}
 \title{Build an error message from parts}
 \usage{
-cnd_message(cnd, ..., prefix = FALSE)
+cnd_message(cnd, ..., inherit = TRUE, prefix = FALSE)
 
 cnd_header(cnd, ...)
 
@@ -19,6 +19,10 @@ cnd_footer(cnd, ...)
 \item{cnd}{A condition object.}
 
 \item{...}{Arguments passed to methods.}
+
+\item{inherit}{Wether to include parent messages. Parent messages
+are printed with a "Caused by error:" prefix, even if \code{prefix} is
+\code{FALSE}.}
 
 \item{prefix}{Whether to print the full message, including the
 condition prefix (\verb{Error:}, \verb{Warning:}, \verb{Message:}, or

--- a/man/topic-data-mask-programming.Rd
+++ b/man/topic-data-mask-programming.Rd
@@ -180,9 +180,9 @@ my_mean(mtcars, tolower("CYL"))
 \subsection{Character vector of names}{
 
 The \code{.data} pronoun can only be subsetted with single column names. It doesn't support single-bracket indexing:\if{html}{\out{<div class="sourceCode r">}}\preformatted{mtcars \%>\% dplyr::summarise(.data[c("cyl", "am")])
-#> Error: Problem with `summarise()` input `..1`.
-#> i `..1 = .data[c("cyl", "am")]`.
-#> x `[` is not supported by the `.data` pronoun, use `[[` or $ instead.
+#> Error: Problem while computing `..1 = .data[c("cyl", "am")]`.
+#> Caused by error in `.data[c("cyl", "am")]`:
+#>   `[` is not supported by the `.data` pronoun, use `[[` or $ instead.
 }\if{html}{\out{</div>}}
 
 There is no plural variant of \code{.data} built in tidy eval. Instead, we'll used the \code{all_of()} operator available in tidy selections to supply character vectors. This is straightforward in functions that take tidy selections, like \code{tidyr::pivot_longer()}:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vars <- c("cyl", "am")

--- a/man/topic-data-mask.Rd
+++ b/man/topic-data-mask.Rd
@@ -27,9 +27,9 @@ Let's see what happens when we pass arguments to a data-masking function like \c
 \}
 
 my_mean(mtcars, cyl, am)
-#> Error: Problem with `summarise()` input `..1`.
-#> i `..1 = mean(var1 + var2)`.
-#> x object 'cyl' not found
+#> Error: Problem while computing `..1 = mean(var1 + var2)`.
+#> Caused by error in `mean()`:
+#>   object 'cyl' not found
 }\if{html}{\out{</div>}}
 
 The problem here is that \code{summarise()} defuses the R code it was supplied, i.e. \code{mean(var1 + var2)}.  Instead we want it to see \code{mean(cyl + am)}. This is why we need injection, we need to modify that piece of code by injecting the code supplied to the function in place of \code{var1} and \code{var2}.

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -479,8 +479,8 @@
           f()
       
           ## Error: Message.
-          ## x Bullet A
-          ## i Bullet B.
+          ##   x Bullet A
+          ##   i Bullet B.
           ## Caused by error:
           ##   Parent message.
           ##   * Bullet 1.

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -462,3 +462,27 @@
       <error/rlang_error>
       Error in `f4()`: foo
 
+# errors are displayed with parent messages in knitted files
+
+    Code
+      writeLines(render_md("test-parent-errors.Rmd"))
+    Output
+          foo <- error_cnd(
+            "foo",
+            message = "Parent message.",
+            body = c("*" = "Bullet 1.", "*" = "Bullet 2."),
+            use_cli_format = TRUE
+          )
+      
+          f <- function() abort(c("Message.", "x" = "Bullet A", "i" = "Bullet B."), parent = foo)
+      
+          f()
+      
+          ## Error: Message.
+          ## x Bullet A
+          ## i Bullet B.
+          ## Caused by error:
+          ##   Parent message.
+          ##   * Bullet 1.
+          ##   * Bullet 2.
+

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -183,17 +183,74 @@
         Header
         i Bullet
 
-# can print message with prefix
+# can print message with and without prefix
 
     Code
+      foo <- error_cnd("foo", message = "Parent message.", body = c(`*` = "Bullet 1.",
+        `*` = "Bullet 2."), use_cli_format = TRUE)
+      bar <- error_cnd("bar", message = "Message.", body = c(`*` = "Bullet A.", `*` = "Bullet B."),
+      parent = foo, use_cli_format = TRUE)
       writeLines(cnd_message(foo, prefix = TRUE))
     Output
-      Error: Foo
+      Error: Parent message.
+      * Bullet 1.
+      * Bullet 2.
     Code
       writeLines(cnd_message(bar, prefix = TRUE))
     Output
       Error:
-        Bar
+        Message.
+        * Bullet A.
+        * Bullet B.
       Caused by error:
-        Foo
+        Parent message.
+        * Bullet 1.
+        * Bullet 2.
+    Code
+      writeLines(cnd_message(foo, prefix = FALSE))
+    Output
+      Parent message.
+      * Bullet 1.
+      * Bullet 2.
+    Code
+      writeLines(cnd_message(bar, prefix = FALSE))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
+      Caused by error:
+        Parent message.
+        * Bullet 1.
+        * Bullet 2.
+
+# can print message without inheritance
+
+    Code
+      foo <- error_cnd("foo", message = "Parent message.", body = c(`*` = "Bullet 1.",
+        `*` = "Bullet 2."), use_cli_format = TRUE)
+      bar <- error_cnd("bar", message = "Message.", body = c(`*` = "Bullet A.", `*` = "Bullet B."),
+      parent = foo, use_cli_format = TRUE)
+      writeLines(cnd_message(foo, inherit = FALSE, prefix = TRUE))
+    Output
+      Error: Parent message.
+      * Bullet 1.
+      * Bullet 2.
+    Code
+      writeLines(cnd_message(bar, inherit = FALSE, prefix = TRUE))
+    Output
+      Error: Message.
+      * Bullet A.
+      * Bullet B.
+    Code
+      writeLines(cnd_message(foo, inherit = FALSE, prefix = FALSE))
+    Output
+      Parent message.
+      * Bullet 1.
+      * Bullet 2.
+    Code
+      writeLines(cnd_message(bar, inherit = FALSE, prefix = FALSE))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
 

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -216,8 +216,8 @@
       writeLines(cnd_message(bar, prefix = FALSE))
     Output
       Message.
-      * Bullet A.
-      * Bullet B.
+        * Bullet A.
+        * Bullet B.
       Caused by error:
         Parent message.
         * Bullet 1.

--- a/tests/testthat/fixtures/error-backtrace-conditionMessage.R
+++ b/tests/testthat/fixtures/error-backtrace-conditionMessage.R
@@ -9,7 +9,7 @@ if (nzchar(Sys.getenv("rlang_interactive"))) {
 }
 options(rlang_trace_format_srcrefs = FALSE)
 
-conditionMessage.foobar_error <- function(c) {
+cnd_header.foobar_error <- function(c) {
   "dispatched!"
 }
 

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -520,3 +520,13 @@ test_that("generic call is picked up in methods", {
     err(f4(NULL))
   })
 })
+
+test_that("errors are displayed with parent messages in knitted files", {
+  skip_if_not_installed("knitr")
+  skip_if_not_installed("rmarkdown")
+  skip_if(!rmarkdown::pandoc_available())
+
+  expect_snapshot({
+    writeLines(render_md("test-parent-errors.Rmd"))
+  })
+})

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -221,15 +221,15 @@ cli::test_that_cli(configs = c("plain", "fancy"), "can use cli syntax in `cnd_me
 
 test_that("prefix takes call into account", {
   err <- error_cnd(message = "msg", call = quote(foo(bar = TRUE)))
-  expect_equal(cnd_prefixed_message(err), "Error in `foo()`: msg")
+  expect_equal(cnd_message_format_prefixed(err), "Error in `foo()`: msg")
 
   # Inlined objects disable context deparsing
   err1 <- error_cnd(message = "msg", call = expr(foo(bar = !!(1:3))))
   err2 <- error_cnd(message = "msg", call = quote(foo$bar()))
   err3 <- error_cnd(message = "msg", call = call2(identity))
-  expect_equal(cnd_prefixed_message(err1), "Error in `foo()`: msg")
-  expect_equal(cnd_prefixed_message(err2), "Error: msg")
-  expect_equal(cnd_prefixed_message(err3), "Error: msg")
+  expect_equal(cnd_message_format_prefixed(err1), "Error in `foo()`: msg")
+  expect_equal(cnd_message_format_prefixed(err2), "Error: msg")
+  expect_equal(cnd_message_format_prefixed(err3), "Error: msg")
 })
 
 test_that("long prefixes cause a line break", {

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -333,11 +333,50 @@ test_that("special syntax calls handle edge cases", {
   expect_equal(error_call_as_string(quote(base::`+`(1, 2))), "+")
 })
 
-test_that("can print message with prefix", {
-  foo <- error_cnd("foo", message = "Foo")
-  bar <- error_cnd("bar", message = "Bar", parent = foo)
-  expect_snapshot({
+test_that("can print message with and without prefix", {
+  expect_snapshot(cran = TRUE, {
+    foo <- error_cnd(
+      "foo",
+      message = "Parent message.",
+      body = c("*" = "Bullet 1.", "*" = "Bullet 2."),
+      use_cli_format = TRUE
+    )
+    bar <- error_cnd(
+      "bar",
+      message = "Message.",
+      body = c("*" = "Bullet A.", "*" = "Bullet B."),
+      parent = foo,
+      use_cli_format = TRUE
+    )
+
     writeLines(cnd_message(foo, prefix = TRUE))
     writeLines(cnd_message(bar, prefix = TRUE))
+
+    writeLines(cnd_message(foo, prefix = FALSE))
+    writeLines(cnd_message(bar, prefix = FALSE))
+  })
+})
+
+test_that("can print message without inheritance", {
+  expect_snapshot(cran = TRUE, {
+    foo <- error_cnd(
+      "foo",
+      message = "Parent message.",
+      body = c("*" = "Bullet 1.", "*" = "Bullet 2."),
+      use_cli_format = TRUE
+    )
+    bar <- error_cnd(
+      "bar",
+      message = "Message.",
+      body = c("*" = "Bullet A.", "*" = "Bullet B."),
+      parent = foo,
+      use_cli_format = TRUE
+    )
+
+    writeLines(cnd_message(foo, inherit = FALSE, prefix = TRUE))
+    writeLines(cnd_message(bar, inherit = FALSE, prefix = TRUE))
+
+    writeLines(cnd_message(foo, inherit = FALSE, prefix = FALSE))
+    writeLines(cnd_message(bar, inherit = FALSE, prefix = FALSE))
   })
 })

--- a/tests/testthat/test-parent-errors.Rmd
+++ b/tests/testthat/test-parent-errors.Rmd
@@ -1,0 +1,14 @@
+```{r}
+foo <- error_cnd(
+  "foo",
+  message = "Parent message.",
+  body = c("*" = "Bullet 1.", "*" = "Bullet 2."),
+  use_cli_format = TRUE
+)
+
+f <- function() abort(c("Message.", "x" = "Bullet A", "i" = "Bullet B."), parent = foo)
+```
+
+```{r, error = TRUE}
+f()
+```


### PR DESCRIPTION
Part of r-lib/testthat#1493. Since the parent messages are included, it is now possible to match them.

Also fixes chained error messages in knitr/rmarkdown. The output is not optimal but much better and good enough as a stopgap until knitr is able to use `cnd_message()` or equivalent.