### PR TITLE
Fully preserve operators in error calls

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -818,7 +818,7 @@ error_call_as_string <- function(call) {
 
   # Preserve operator calls, even if multiline
   if (!is_string(call_parse_type(call), "")) {
-    return(paste(expr_deparse(call), collapse = "\n"))
+    return(paste(error_call_deparse(call), collapse = "\n"))
   }
 
   # FIXME! Deparse with arguments?
@@ -829,6 +829,15 @@ error_call_as_string <- function(call) {
   # Remove distracting arguments from the call and restore namespace
   call[[1]] <- old
   as_label(call[1])
+}
+
+# Add indent to ulterior lines
+error_call_deparse <- function(call) {
+  out <- expr_deparse(call)
+  if (length(out) > 1) {
+    out[-1] <- paste0("  ", out[-1])
+  }
+  out
 }
 
 error_call <- function(call) {

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -762,7 +762,11 @@ format_error_call <- function(call) {
     return(NULL)
   }
 
-  format_code(label)
+  if (grepl("\n", label)) {
+    cli_with_whiteline_escapes(label, format_code)
+  } else {
+    format_code(label)
+  }
 }
 
 error_call_as_string <- function(call) {
@@ -804,20 +808,20 @@ error_call_as_string <- function(call) {
   old <- call[[1]]
   call[[1]] <- sym(call_name(call))
 
-  # Deal with special-syntax calls. `if` carries useful information in
-  # its call. For other operators we just return their name because
-  # the functional form may be confusing.
+  # Deal with `if` bombs. Keep the condition as it is informative but
+  # drop the uninformative branches to avoid multiline calls. See
+  # https://github.com/r-lib/testthat/issues/1429
   if (is_call(call, "if")) {
-    # Deal with `if` bombs. Keep the condition as it is informative but
-    # drop the branches to avoid multiline calls. See
-    # https://github.com/r-lib/testthat/issues/1429
     call[[3]] <- quote(...)
     return(as_label(call[1:3]))
   }
+
+  # Preserve operator calls, even if multiline
   if (!is_string(call_parse_type(call), "")) {
-    return(as_string(call[[1]]))
+    return(paste(expr_deparse(call), collapse = "\n"))
   }
 
+  # FIXME! Deparse with arguments?
   if (is_symbol(call[[1]]) && needs_backticks(call[[1]])) {
     return(as_string(call[[1]]))
   }

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -371,12 +371,22 @@ tight_op_deparse <- function(x, lines = new_lines()) {
 }
 
 unary_op_deparse <- function(x, lines = new_lines()) {
+  # Constructed call without argument
+  if (is_null(node_cdr(x))) {
+    return(call_deparse(x, lines))
+  }
+
   op <- as_string(node_car(x))
   lines$push(op)
   lines$deparse(node_cadr(x))
   lines$get_lines()
 }
 unary_f_deparse <- function(x, lines = new_lines()) {
+  # Constructed call without argument
+  if (is_null(node_cdr(x))) {
+    return(call_deparse(x, lines))
+  }
+
   lines$push("~")
 
   rhs <- node_cadr(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -419,3 +419,12 @@ capitalise <- function(x) {
 testing <- function() {
   nzchar(Sys.getenv("TESTTHAT"))
 }
+
+cli_with_whiteline_escapes <- function(x, fn) {
+  x <- gsub("\n", "__NEW_LINE__", x, fixed = TRUE)
+  x <- gsub(" ", "__SPACE__", x, fixed = TRUE)
+  x <- fn(x)
+  x <- gsub("__SPACE__", " ", x, fixed = TRUE)
+  x <- gsub("__NEW_LINE__", "\n", x, fixed = TRUE)
+  x
+}

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -373,6 +373,34 @@
       Error: `"f"` must be one of "foo", not "f".
       i Did you mean "foo"?
 
+# error_call() and format_error_call() preserve special syntax ops
+
+    Code
+      format_error_call(quote(1 + 2))
+    Output
+      [1] "`1 + 2`"
+
+---
+
+    Code
+      format_error_call(quote(for (x in y) NULL))
+    Output
+      [1] "`for (x in y) NULL`"
+
+---
+
+    Code
+      format_error_call(quote(a %||% b))
+    Output
+      [1] "`a %||% b`"
+
+---
+
+    Code
+      format_error_call(quote(`%||%`()))
+    Output
+      [1] "``%||%`()`"
+
 # withCallingHandlers() wrappers don't throw off trace capture on rethrow
 
     Code

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -49,7 +49,7 @@
       print(err)
     Output
       <error/rlang_error>
-      Error in `+`:
+      Error in `1 + ""`:
       non-numeric argument to binary operator
       Backtrace:
         1. rlang::catch_cnd(...)
@@ -60,7 +60,7 @@
 
 # can set `entrace()` as a global handler
 
-    Error in `+`:
+    Error in `1 + ""`:
     non-numeric argument to binary operator
     Backtrace:
         x
@@ -71,7 +71,7 @@
 
 ---
 
-    Error in `+`:
+    Error in `1 + ""`:
     non-numeric argument to binary operator
     Backtrace:
         x

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -217,6 +217,17 @@
         Header
         i Bullet
 
+# special syntax calls handle edge cases
+
+    Code
+      error_call_as_string(quote(+NULL))
+    Output
+      [1] "+NULL"
+    Code
+      error_call_as_string(quote(base::`+`(1, 2)))
+    Output
+      [1] "1 + 2"
+
 # can print message with and without prefix
 
     Code
@@ -342,4 +353,32 @@
         Parent message.
         * Bullet 1.
         * Bullet 2.
+
+# multiline operator calls are preserved
+
+    <error/rlang_error>
+    Error in `1 + ("veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long" +
+      "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long")`:
+    This is the error message.
+
+---
+
+    <error/rlang_error>
+    Error in `{
+      1
+      2
+    } + {
+      2
+      3
+    }`:
+    This is the error message.
+
+---
+
+    <error/rlang_error>
+    Error in `x[{
+      1
+      2
+    }]`:
+    This is the error message.
 

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -358,27 +358,27 @@
 
     <error/rlang_error>
     Error in `1 + ("veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long" +
-      "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long")`:
+        "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long")`:
     This is the error message.
 
 ---
 
     <error/rlang_error>
     Error in `{
-      1
-      2
-    } + {
-      2
-      3
-    }`:
+        1
+        2
+      } + {
+        2
+        3
+      }`:
     This is the error message.
 
 ---
 
     <error/rlang_error>
     Error in `x[{
-      1
-      2
-    }]`:
+        1
+        2
+      }]`:
     This is the error message.
 

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -220,9 +220,9 @@
 # special syntax calls handle edge cases
 
     Code
-      error_call_as_string(quote(+NULL))
+      error_call_as_string(quote(`+`()))
     Output
-      [1] "+NULL"
+      [1] "`+`()"
     Code
       error_call_as_string(quote(base::`+`(1, 2)))
     Output

--- a/tests/testthat/_snaps/operators.md
+++ b/tests/testthat/_snaps/operators.md
@@ -4,25 +4,25 @@
       (expect_error(c(1L, NA) %|% 2))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `c(1L, NA) %|% 2`:
       Replacement values must have type integer, not type double
     Code
       (expect_error(c(1, NA) %|% ""))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `c(1, NA) %|% ""`:
       Replacement values must have type double, not type character
     Code
       (expect_error(c(1, NA) %|% call("fn")))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `c(1, NA) %|% call("fn")`:
       Replacement values must have type double, not type language
     Code
       (expect_error(call("fn") %|% 1))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `call("fn") %|% 1`:
       Cannot replace missing values in an object of type language
 
 # %|% fails with wrong length
@@ -31,18 +31,18 @@
       (expect_error(c(1L, NA) %|% 1:3))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `c(1L, NA) %|% 1:3`:
       The replacement values must have size 1 or 2, not 3
     Code
       (expect_error(1:10 %|% 1:4))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `1:10 %|% 1:4`:
       The replacement values must have size 1 or 10, not 4
     Code
       (expect_error(1L %|% 1:4))
     Output
       <error/rlang_error>
-      Error in `%|%`:
+      Error in `1L %|% 1:4`:
       The replacement values must have size 1, not 4
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1041,7 +1041,7 @@
       print(err)
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
-      [1m[33mError[39m in [1m[1m[30m[47m`+`[49m[39m:[22m
+      [1m[33mError[39m in [1m[1m[30m[47m`1 + ""`[49m[39m:[22m
       non-numeric argument to binary operator
       [1mBacktrace:[22m
       [90m  1. [39m[1mrlang[22m::catch_cnd(withCallingHandlers(f(), error = entrace), "error")
@@ -1053,7 +1053,7 @@
       summary(err)
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
-      [1m[33mError[39m in [1m[1m[30m[47m`+`[49m[39m:[22m
+      [1m[33mError[39m in [1m[1m[30m[47m`1 + ""`[49m[39m:[22m
       non-numeric argument to binary operator
       [1mBacktrace:[22m
       [90m     [39mx

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -349,28 +349,16 @@ test_that("error_call() and format_error_call() preserve special syntax ops", {
     error_call(quote(1 + 2)),
     quote(1 + 2)
   )
-  expect_equal(
-    format_error_call(quote(1 + 2)),
-    "`+`"
-  )
+  expect_snapshot(format_error_call(quote(1 + 2)))
 
   expect_equal(
     error_call(quote(for (x in y) NULL)),
     quote(for (x in y) NULL)
   )
-  expect_equal(
-    format_error_call(quote(for (x in y) NULL)),
-    "`for`"
-  )
+  expect_snapshot(format_error_call(quote(for (x in y) NULL)))
 
-  expect_equal(
-    format_error_call(quote(a %||% b)),
-    "`%||%`"
-  )
-  expect_equal(
-    format_error_call(quote(`%||%`())),
-    "`%||%`"
-  )
+  expect_snapshot(format_error_call(quote(a %||% b)))
+  expect_snapshot(format_error_call(quote(`%||%`())))  # Suboptimal
 })
 
 test_that("error_call() preserves srcrefs", {

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -360,8 +360,10 @@ test_that("qualified calls are included in error prefix (#1315)", {
 })
 
 test_that("special syntax calls handle edge cases", {
-  expect_equal(error_call_as_string(quote(`+`())), "+")
-  expect_equal(error_call_as_string(quote(base::`+`(1, 2))), "+")
+  expect_snapshot({
+    error_call_as_string(quote(`+`()))
+    error_call_as_string(quote(base::`+`(1, 2)))
+  })
 })
 
 test_that("can print message with and without prefix", {
@@ -471,4 +473,12 @@ test_that("as.character() methods for errors, warnings, and messages", {
     cat(as.character(cnd_with(warning_cnd, parent = TRUE)))
     cat(as.character(cnd_with(message_cnd, parent = TRUE)))
   })
+})
+
+test_that("multiline operator calls are preserved", {
+  err <- function(expr) error_cnd(message = "This is the error message.", call = enexpr(expr))
+
+  expect_snapshot_output(err(1 + ("veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long" + "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long")))
+  expect_snapshot_output(err({ 1; 2 } + { 2; 3 }))
+  expect_snapshot_output(err(x[{ 1; 2 }]))
 })

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -677,3 +677,18 @@ test_that("infix operators are labelled (#956, r-lib/testthat#1432)", {
     "... + ..."
   )
 })
+
+test_that("binary op without arguments", {
+  expect_equal(
+    expr_deparse(quote(`+`())),
+    "`+`()"
+  )
+  expect_equal(
+    expr_deparse(quote(`$`())),
+    "`$`()"
+  )
+  expect_equal(
+    expr_deparse(quote(`~`())),
+    "`~`()"
+  )
+})


### PR DESCRIPTION
```r
1 + ""
#> Error in `1 + ""`:
#> non-numeric argument to binary operator
```

Multiline operators are printed with indentation:

```r
err <- function(expr) error_cnd(message = "This is the error message.", call = enexpr(expr))

err(1 + ("veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long" + "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long"))
#> <error/rlang_error>
#> Error in `1 + ("veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long" +
#>     "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long")`:
#> This is the error message.

err({ 1; 2 } + { 2; 3 })
#> <error/rlang_error>
#> Error in `{
#>     1
#>     2
#>   } + {
#>     2
#>     3
#>   }`:
#> This is the error message.

err(x[{ 1; 2 }])
#> <error/rlang_error>
#> Error in `x[{
#>     1
#>     2
#>   }]`:
#> This is the error message.
```