### PR TITLE
Improve ellipsis errors

### DIFF
--- a/R/dots-ellipsis.R
+++ b/R/dots-ellipsis.R
@@ -104,7 +104,7 @@ check_dots_unnamed <- function(env = caller_env(),
   action_dots(
     error = error,
     action = action,
-    message = "Arguments in `...` can't be named.",
+    message = "Arguments in `...` must be passed by position, not name.",
     dots_i = named,
     class = "rlib_error_dots_named",
     call = call,

--- a/R/dots-ellipsis.R
+++ b/R/dots-ellipsis.R
@@ -90,12 +90,12 @@ check_dots_unnamed <- function(env = caller_env(),
                                error = NULL,
                                call = caller_env(),
                                action = abort) {
-  proms <- ellipsis_dots(env, auto_name = FALSE)
+  proms <- ellipsis_dots(env)
   if (length(proms) == 0) {
     return()
   }
 
-  unnamed <- is.na(names(proms))
+  unnamed <- names2(proms) == ""
   if (all(unnamed)) {
     return(invisible())
   }
@@ -154,10 +154,17 @@ check_dots_empty <- function(env = caller_env(),
     return()
   }
 
+  if (!is_named(dots)) {
+    note <- c("i" = "Did you forget to name an argument?")
+  } else {
+    note <- NULL
+  }
+
   action_dots(
     error = error,
     action = action,
     message = "`...` must be empty.",
+    note = note,
     dots_i = TRUE,
     class = "rlib_error_dots_nonempty",
     call = call,
@@ -187,6 +194,7 @@ action_dots <- function(error,
                         dots_i,
                         env,
                         class = NULL,
+                        note = NULL,
                         ...) {
   if (is_missing(action)) {
     action <- abort
@@ -223,7 +231,7 @@ action_dots <- function(error,
   }
 
   try_dots(action(
-    c(message, "x" = bullet_header, set_names(bullets, "*")),
+    c(message, "x" = bullet_header, set_names(bullets, "*"), note),
     class = c(class, "rlib_error_dots"),
     ...
   ))
@@ -232,8 +240,8 @@ action_dots <- function(error,
 promise_forced <- function(x) {
   .Call(ffi_ellipsis_promise_forced, x)
 }
-ellipsis_dots <- function(env = caller_env(), auto_name = TRUE) {
-  .Call(ffi_ellipsis_dots, env, auto_name)
+ellipsis_dots <- function(env = caller_env()) {
+  .Call(ffi_ellipsis_dots, env)
 }
 
 #' Helper for consistent documentation of empty dots

--- a/R/dots-ellipsis.R
+++ b/R/dots-ellipsis.R
@@ -61,7 +61,10 @@ check_dots <- function(env = caller_env(), error, action, call) {
   action_dots(
     error = error,
     action = action,
-    message = paste0(length(unused), " arguments in `...` were not used."),
+    message = c(
+      "Arguments in `...` must be used.",
+      "x" = "Problematic arguments:"
+    ),
     dot_names = unused,
     class = "rlib_error_dots_unused",
     call = call
@@ -104,7 +107,10 @@ check_dots_unnamed <- function(env = caller_env(),
   action_dots(
     error = error,
     action = action,
-    message = paste0(length(named), " arguments in `...` had unexpected names."),
+    message = c(
+      "Arguments in `...` can't be named.",
+      "x" = "Problematic arguments:"
+    ),
     dot_names = named,
     class = "rlib_error_dots_named",
     call = call
@@ -156,9 +162,11 @@ check_dots_empty <- function(env = caller_env(),
   action_dots(
     error = error,
     action = action,
-    message = "`...` is not empty.",
+    message = c(
+      "`...` must be empty.",
+      "x" = "Problematic arguments:"
+    ),
     dot_names = names(dots),
-    note = "These dots only exist to allow future extensions and should be empty.",
     class = "rlib_error_dots_nonempty",
     call = call
   )
@@ -180,7 +188,7 @@ check_dots_empty0 <- function(..., call = caller_env()) {
   }
 }
 
-action_dots <- function(error, action, message, dot_names, note = NULL, class = NULL, ...) {
+action_dots <- function(error, action, message, dot_names, class = NULL, ...) {
   if (is_missing(action)) {
     action <- abort
   } else  {
@@ -199,10 +207,7 @@ action_dots <- function(error, action, message, dot_names, note = NULL, class = 
 
   message <- c(
     message,
-    i = note,
-    x = "We detected these problematic arguments:",
-    set_names(chr_quoted(dot_names), "*"),
-    i = "Did you misspecify an argument?"
+    set_names(chr_quoted(dot_names), "*")
   )
 
   try_dots(action(message, class = c(class, "rlib_error_dots"), ...))

--- a/src/internal/dots-ellipsis.c
+++ b/src/internal/dots-ellipsis.c
@@ -15,7 +15,7 @@ r_obj* ffi_ellipsis_find_dots(r_obj* env) {
   return dots;
 }
 
-r_obj* ffi_ellipsis_dots(r_obj* env, r_obj* auto_name) {
+r_obj* ffi_ellipsis_dots(r_obj* env) {
   r_obj* dots = ffi_ellipsis_find_dots(env);
 
   // Empty dots
@@ -24,8 +24,6 @@ r_obj* ffi_ellipsis_dots(r_obj* env, r_obj* auto_name) {
   }
 
   KEEP(dots);
-
-  bool c_auto_name = r_arg_as_bool(auto_name, "auto_name");
 
   int n = r_length(dots);
   r_obj* out = KEEP(r_alloc_list(n));
@@ -40,13 +38,7 @@ r_obj* ffi_ellipsis_dots(r_obj* env, r_obj* auto_name) {
     if (r_typeof(name) == R_TYPE_symbol) {
       r_chr_poke(names, i, r_sym_string(name));
     } else {
-      if (c_auto_name) {
-        char buffer[20];
-        snprintf(buffer, 20, "..%i", i + 1);
-        r_chr_poke(names, i, r_str(buffer));
-      } else {
-        r_chr_poke(names, i, r_globals.na_str);
-      }
+      r_chr_poke(names, i, r_strs.empty);
     }
 
     dots = r_node_cdr(dots);

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -42,7 +42,7 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_dots_list",                    (DL_FUNC) &ffi_dots_list, 7},
   {"ffi_dots_pairlist",                (DL_FUNC) &ffi_dots_pairlist, 7},
   {"ffi_duplicate",                    (DL_FUNC) &ffi_duplicate, 2},
-  {"ffi_ellipsis_dots",                (DL_FUNC) &ffi_ellipsis_dots, 2},
+  {"ffi_ellipsis_dots",                (DL_FUNC) &ffi_ellipsis_dots, 1},
   {"ffi_ellipsis_dots_used",           (DL_FUNC) &ffi_ellipsis_dots_used, 1},
   {"ffi_ellipsis_promise_forced",      (DL_FUNC) &ffi_ellipsis_promise_forced, 1},
   {"ffi_enexpr",                       (DL_FUNC) &ffi_enexpr, 2},

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -10,11 +10,10 @@
     Output
       <error/rlib_error_dots_named>
       Error in `f()`:
-      2 arguments in `...` had unexpected names.
-      x We detected these problematic arguments:
+      Arguments in `...` can't be named.
+      x Problematic arguments:
       * `xy`
       * `x`
-      i Did you misspecify an argument?
 
 # error if if dots not empty
 
@@ -23,19 +22,15 @@
     Output
       <error/rlib_error_dots_nonempty>
       Error in `f()`:
-      `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
+      `...` must be empty.
+      x Problematic arguments:
       * `xy`
-      i Did you misspecify an argument?
     Code
       (expect_error(f0(xy = 4), class = "rlib_error_dots_nonempty"))
     Output
       <error/rlib_error_dots_nonempty>
       Error in `f0()`:
-      `...` is not empty.
-      i These dots only exist to allow future extensions and should be empty.
-      x We detected these problematic arguments:
+      `...` must be empty.
+      x Problematic arguments:
       * `xy`
-      i Did you misspecify an argument?
 

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -42,18 +42,21 @@
       `...` must be empty.
       x Problematic argument:
       * ..1 = "foo"
+      i Did you forget to name an argument?
     Code
       f(foo)
     Error <rlib_error_dots_nonempty>
       `...` must be empty.
       x Problematic argument:
       * ..1 = foo
+      i Did you forget to name an argument?
     Code
       inject(f(!!letters))
     Error <rlib_error_dots_nonempty>
       `...` must be empty.
       x Problematic argument:
       * ..1 = <chr>
+      i Did you forget to name an argument?
     Code
       f(a = {
         1
@@ -69,4 +72,28 @@
       `...` must be empty.
       x Problematic argument:
       * a = toupper(letters)
+
+# empty dots error mentions info bullets if any unnamed element
+
+    Code
+      f(1)
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * ..1 = 1
+      i Did you forget to name an argument?
+    Code
+      f(a = 1)
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * a = 1
+    Code
+      f(a = 1, 2)
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic arguments:
+      * a = 1
+      * ..2 = 2
+      i Did you forget to name an argument?
 

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -10,7 +10,7 @@
     Output
       <error/rlib_error_dots_named>
       Error in `f()`:
-      Arguments in `...` can't be named.
+      Arguments in `...` must be passed by position, not name.
       x Problematic arguments:
       * xy = 4
       * x = 5

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -12,8 +12,8 @@
       Error in `f()`:
       Arguments in `...` can't be named.
       x Problematic arguments:
-      * `xy`
-      * `x`
+      * xy = 4
+      * x = 5
 
 # error if if dots not empty
 
@@ -23,14 +23,50 @@
       <error/rlib_error_dots_nonempty>
       Error in `f()`:
       `...` must be empty.
-      x Problematic arguments:
-      * `xy`
+      x Problematic argument:
+      * xy = 4
     Code
       (expect_error(f0(xy = 4), class = "rlib_error_dots_nonempty"))
     Output
       <error/rlib_error_dots_nonempty>
       Error in `f0()`:
       `...` must be empty.
-      x Problematic arguments:
-      * `xy`
+      x Problematic argument:
+      * xy = 4
+
+# expression contents are mentioned
+
+    Code
+      f("foo")
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * ..1 = "foo"
+    Code
+      f(foo)
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * ..1 = foo
+    Code
+      inject(f(!!letters))
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * ..1 = <chr>
+    Code
+      f(a = {
+        1
+        2
+      })
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * a = { ... }
+    Code
+      f(a = toupper(letters))
+    Error <rlib_error_dots_nonempty>
+      `...` must be empty.
+      x Problematic argument:
+      * a = toupper(letters)
 

--- a/tests/testthat/test-dots-ellipsis.R
+++ b/tests/testthat/test-dots-ellipsis.R
@@ -103,3 +103,15 @@ test_that("can supply `error` handler", {
   expect_silent(f(foo))
   expect_warning(f(foo = foo), class = "rlib_error_dots_named")
 })
+
+test_that("expression contents are mentioned", {
+  f <- function(...) check_dots_empty()
+
+  expect_snapshot(error = TRUE, {
+    f("foo")
+    f(foo)
+    inject(f(!!letters))
+    f(a = { 1; 2 })
+    f(a = toupper(letters))
+  })
+})

--- a/tests/testthat/test-dots-ellipsis.R
+++ b/tests/testthat/test-dots-ellipsis.R
@@ -115,3 +115,12 @@ test_that("expression contents are mentioned", {
     f(a = toupper(letters))
   })
 })
+
+test_that("empty dots error mentions info bullets if any unnamed element", {
+  f <- function(...) check_dots_empty()
+  expect_snapshot(error = TRUE, {
+    f(1)
+    f(a = 1)
+    f(a = 1, 2)
+  })
+})


### PR DESCRIPTION
Closes #1319.

In all ellipsis errors:

* Show the value of the arguments.
* Try to reduce text density.
* Use conventional "must be" or "can't" phrasing.

In empty dots errors:

* Don't mention "future extensions", just that no arguments are expected in `...`.
* Suggest user has probably forgotten to give a name to an argument when unnamed dots are supplied and dots should be empty.

Before:

```r
is_installed("rlang", "0.99.0.9001")
#> Error in `is_installed()`: `...` is not empty.
#> i These dots only exist to allow future extensions and should be empty.
#> x We detected these problematic arguments:
#> * `..1`
#> i Did you misspecify an argument?
```

After:

```r
is_installed("rlang", "0.99.0.9001")
#> Error in `is_installed()`:
#> `...` must be empty.
#> x Problematic argument:
#> * ..1 = "0.99.0.9001"
#> i Did you forget to name an argument?
```