### PR TITLE
Improve version requirements in `is_installed()` and `check_installed()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rlang
-Version: 0.99.0.9002
+Version: 0.99.0.9003
 Title: Functions for Base Types and Core R and 'Tidyverse' Features
 Description: A toolbox for working with base types, core R features
   like the condition system, and core 'Tidyverse' features like tidy

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,11 @@
 
 ## Features and bugfixes
 
+* `is_installed()` and `check_installed()` now support
+  DESCRIPTION-style version requirements like `"rlang (>= 1.0)"`.
+  They also gain `version` and `op` arguments to supply requirements
+  programmatically.
+
 * `abort()`, `warn()`, and `inform()` gain a `body` argument to supply
   additional bullets in the error message.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,8 +77,8 @@
   They also gain `version` and `compare` arguments to supply requirements
   programmatically.
 
-* `check_installed()` gains a `src` argument to specificy pak-style
-  sources.
+* `check_installed()` gains an `action` argument that is called when
+  the user chooses to install and update missing and outdated packages.
 
 * `abort()`, `warn()`, and `inform()` gain a `body` argument to supply
   additional bullets in the error message.

--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,9 @@
   They also gain `version` and `compare` arguments to supply requirements
   programmatically.
 
+* `check_installed()` gains a `src` argument to specificy pak-style
+  sources.
+
 * `abort()`, `warn()`, and `inform()` gain a `body` argument to supply
   additional bullets in the error message.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -74,7 +74,7 @@
 
 * `is_installed()` and `check_installed()` now support
   DESCRIPTION-style version requirements like `"rlang (>= 1.0)"`.
-  They also gain `version` and `op` arguments to supply requirements
+  They also gain `version` and `compare` arguments to supply requirements
   programmatically.
 
 * `abort()`, `warn()`, and `inform()` gain a `body` argument to supply

--- a/R/compat-purrr.R
+++ b/R/compat-purrr.R
@@ -14,6 +14,9 @@
 #
 # 2021-05-21:
 # * Fixed "object `x` not found" error in `imap()` (@mgirlich)
+#
+# 2021-12-15:
+# * `transpose()` now supports empty lists.
 
 map <- function(.x, .f, ...) {
   .f <- as_function(.f, env = global_env())
@@ -115,6 +118,9 @@ compact <- function(.x) {
 }
 
 transpose <- function(.l) {
+  if (!length(.l)) {
+    return(.l)
+  }
   inner_names <- names(.l[[1]])
   if (is.null(inner_names)) {
     fields <- seq_along(.l[[1]])

--- a/R/session.R
+++ b/R/session.R
@@ -20,7 +20,8 @@
 #'  `rlib_restart_package_not_found` global option to `FALSE`. In that
 #'  case, missing packages always cause an error.
 #'
-#' @param pkg The package names.
+#' @param pkg The package names. Can include version requirements,
+#'   e.g. `"pkg (>= 1.0.0)"`.
 #' @param reason Optional string indicating why is `pkg` needed.
 #'   Appears in error messages (if non-interactive) and user prompts
 #'   (if interactive).

--- a/R/session.R
+++ b/R/session.R
@@ -56,6 +56,7 @@
 #' is_installed(c("base", "ggplot5"), version = c(NA, "5.1.0"))
 is_installed <- function(pkg, ..., version = NULL) {
   check_dots_empty0(...)
+  check_pkg_version(pkg, version)
 
   # Internal mechanism for unit tests
   hook <- peek_option("rlang:::is_installed_hook")
@@ -68,10 +69,6 @@ is_installed <- function(pkg, ..., version = NULL) {
   }
   if (is_null(version)) {
     return(TRUE)
-  }
-
-  if (!is_character(version, n = length(pkg))) {
-    abort("`version` must be a character vector the same length as `pkg`.")
   }
 
   all(map2_lgl(pkg, version, function(p, v) {
@@ -87,17 +84,11 @@ check_installed <- function(pkg,
                             version = NULL,
                             call = caller_env()) {
   check_dots_empty0(...)
-
-  if (!is_character(pkg)) {
-    abort("`pkg` must be a package name or a vector of package names.", call = call)
-  }
+  check_pkg_version(pkg, version)
 
   if (is_null(version)) {
     needs_install <- !map_lgl(pkg, is_installed)
   } else {
-    if (!is_character(version, n = length(pkg))) {
-      abort("`version` must be a character vector the same length as `pkg`.")
-    }
     needs_install <- !map2_lgl(pkg, version, function(p, v) is_installed(p, version = v))
   }
 
@@ -155,6 +146,29 @@ check_installed <- function(pkg,
     pkg_install(missing_pkgs, ask = FALSE)
   } else {
     utils::install.packages(missing_pkgs)
+  }
+}
+
+check_pkg_version <- function(pkg, version, call = caller_env()) {
+  if (!is_character(pkg, missing = FALSE, empty = FALSE)) {
+    abort(
+      sprintf(
+        "%s must be a package name or a vector of package names.",
+        format_arg("pkg")
+      ),
+      call = call
+    )
+  }
+
+  if (!is_null(version) && !is_character(version, n = length(pkg), empty = FALSE)) {
+    abort(
+      sprintf(
+        "%s must be `NULL` or a vector of versions the same length as %s.",
+        format_arg("version"),
+        format_arg("pkg")
+      ),
+      call = call
+    )
   }
 }
 

--- a/R/session.R
+++ b/R/session.R
@@ -166,10 +166,6 @@ as_version_info <- function(pkg, call = caller_env()) {
 }
 
 #' @rdname is_installed
-#' @param src A [pak
-#'   source](https://pak.r-lib.org/reference/pak_package_sources.html)
-#'   specification passed to `pak::pkg_install()` when `pkg` needs to
-#'   be installed or reinstalled.
 #' @inheritParams args_error_context
 #' @export
 check_installed <- function(pkg,
@@ -177,7 +173,6 @@ check_installed <- function(pkg,
                             ...,
                             version = NULL,
                             compare = NULL,
-                            src = NULL,
                             call = caller_env()) {
   check_dots_empty0(...)
 
@@ -188,21 +183,13 @@ check_installed <- function(pkg,
   version <- info$ver
   compare <- info$cmp
 
-  if (!any(needs_install)) {
-    return(invisible(NULL))
-  }
-
-  check_src(src, pkg)
-  if (is_null(src)) {
-    missing_srcs <- NULL
-  } else {
-    src <- ifelse(detect_na(src), pkg, src)
-    missing_srcs <- src[needs_install]
-  }
-
   missing_pkgs <- pkg[needs_install]
   missing_vers <- version[needs_install]
   missing_cmps <- compare[needs_install]
+
+  if (!length(missing_pkgs)) {
+    return(invisible(NULL))
+  }
 
   cnd <- new_error_package_not_found(
     missing_pkgs,
@@ -215,12 +202,6 @@ check_installed <- function(pkg,
   restart <- peek_option("rlib_restart_package_not_found") %||% TRUE
   if (!is_bool(restart)) {
     abort("`rlib_restart_package_not_found` must be a logical value.")
-  }
-
-  # Can't install packages if remotes are supplied and pak is not installed
-  has_pak <- is_installed("pak")
-  if (!has_pak && !is_null(missing_srcs)) {
-    restart <- FALSE
   }
 
   if (!is_interactive() || !restart || any(missing_cmps %in% c("<", "<="))) {
@@ -255,9 +236,9 @@ check_installed <- function(pkg,
     # Pass condition in case caller sets up an `abort` restart
     invokeRestart("abort", cnd)
   }
-  if (has_pak) {
+  if (is_installed("pak")) {
     pkg_install <- env_get(ns_env("pak"), "pkg_install")
-    pkg_install(missing_srcs %||% missing_pkgs, ask = FALSE)
+    pkg_install(missing_pkgs, ask = FALSE)
   } else {
     utils::install.packages(missing_pkgs)
   }
@@ -294,18 +275,6 @@ check_pkg_version <- function(pkg,
         "%s must be supplied when %s is supplied.",
         format_arg("version"),
         format_arg("compare")
-      )
-      abort(msg, call = call)
-    }
-  }
-}
-check_src <- function(src, pkg, call = caller_env()) {
-  if (!is_null(src)) {
-    if (!is_character(src, n = length(pkg), empty = FALSE)) {
-      msg <- sprintf(
-        "%s must be a character vector as long as %s.",
-        format_arg("src"),
-        format_arg("pkg")
       )
       abort(msg, call = call)
     }

--- a/R/session.R
+++ b/R/session.R
@@ -75,6 +75,43 @@ is_installed <- function(pkg, ..., version = NULL) {
     is_na(v) || utils::packageVersion(p) >= v
   }))
 }
+
+pkg_version_info <- function(pkg, version, call = caller_env()) {
+  matches <- grepl(version_regex, pkg)
+
+  info <- data_frame(pkg = pkg, op = na_chr, ver = na_chr)
+  info <- vec_assign(info, matches, new_version_info(pkg[matches]))
+
+  if (!is_null(version)) {
+    abort("TODO")
+    info <- vec_assign(info, !matches)
+  }
+
+  info
+}
+
+version_regex <- "(.*) \\((.*)\\)$"
+
+new_version_info <- function(pkg) {
+  ver <- sub(version_regex, "\\2", pkg)
+  ver <- strsplit(ver, " ")
+
+  if (!every(ver, is_character, n = 2, missing = FALSE, empty = FALSE)) {
+    abort(
+      sprintf("Can't parse version in %s.", format_arg("pkg")),
+      call = call
+    )
+  }
+
+  info <- set_names(transpose(ver), c("op", "ver"))
+  info <- map(info, flatten_chr)
+
+  pkg <- sub(version_regex, "\\1", pkg)
+  info <- c(list(pkg = pkg), info)
+
+  new_data_frame(info, .class = "tbl")
+}
+
 #' @rdname is_installed
 #' @inheritParams args_error_context
 #' @export

--- a/R/session.R
+++ b/R/session.R
@@ -195,7 +195,8 @@ check_installed <- function(pkg,
     missing_pkgs,
     missing_vers,
     missing_cmps,
-    reason = reason
+    reason = reason,
+    call = call
   )
 
   restart <- peek_option("rlib_restart_package_not_found") %||% TRUE
@@ -204,7 +205,7 @@ check_installed <- function(pkg,
   }
 
   if (!is_interactive() || !restart || any(missing_cmps %in% c("<", "<="))) {
-    abort(cnd_header(cnd), call = call)
+    stop(cnd)
   }
 
   if (signal_package_not_found(cnd)) {
@@ -232,7 +233,8 @@ check_installed <- function(pkg,
   ))
 
   if (utils::menu(c("Yes", "No")) != 1) {
-    invokeRestart("abort")
+    # Pass condition in case caller sets up an `abort` restart
+    invokeRestart("abort", cnd)
   }
   if (is_installed("pak")) {
     pkg_install <- env_get(ns_env("pak"), "pkg_install")

--- a/R/session.R
+++ b/R/session.R
@@ -149,7 +149,7 @@ as_version_info <- function(pkg, call = caller_env()) {
   ver <- sub(version_regex, "\\2", pkg)
   ver <- strsplit(ver, " ")
 
-  if (!every(ver, is_character, n = 2, missing = FALSE, empty = FALSE)) {
+  if (!every(ver, is_character2, n = 2, missing = FALSE, empty = FALSE)) {
     abort(
       sprintf("Can't parse version in %s.", format_arg("pkg")),
       call = call
@@ -257,7 +257,7 @@ check_pkg_version <- function(pkg,
                               version,
                               compare,
                               call = caller_env()) {
-  if (!is_character(pkg, missing = FALSE, empty = FALSE)) {
+  if (!is_character2(pkg, missing = FALSE, empty = FALSE)) {
     abort(
       sprintf(
         "%s must be a package name or a vector of package names.",
@@ -267,7 +267,7 @@ check_pkg_version <- function(pkg,
     )
   }
 
-  if (!is_null(version) && !is_character(version, n = length(pkg), empty = FALSE)) {
+  if (!is_null(version) && !is_character2(version, n = length(pkg), empty = FALSE)) {
     abort(
       sprintf(
         "%s must be `NULL` or a vector of versions the same length as %s.",

--- a/R/vec-na.R
+++ b/R/vec-na.R
@@ -121,6 +121,8 @@ is_na <- function(x) {
   is_scalar_vector(x) && is.na(x)
 }
 
+detect_na <- are_na
+
 #' @rdname are_na
 #' @export
 is_lgl_na <- function(x) {

--- a/man/is_installed.Rd
+++ b/man/is_installed.Rd
@@ -7,10 +7,18 @@
 \usage{
 is_installed(pkg, ..., version = NULL, op = NULL)
 
-check_installed(pkg, reason = NULL, ..., version = NULL, call = caller_env())
+check_installed(
+  pkg,
+  reason = NULL,
+  ...,
+  version = NULL,
+  op = NULL,
+  call = caller_env()
+)
 }
 \arguments{
-\item{pkg}{The package names.}
+\item{pkg}{The package names. Can include version requirements,
+e.g. \code{"pkg (>= 1.0.0)"}.}
 
 \item{...}{These dots must be empty.}
 

--- a/man/is_installed.Rd
+++ b/man/is_installed.Rd
@@ -13,6 +13,7 @@ check_installed(
   ...,
   version = NULL,
   compare = NULL,
+  action = NULL,
   call = caller_env()
 )
 }
@@ -34,6 +35,11 @@ default.}
 \item{reason}{Optional string indicating why is \code{pkg} needed.
 Appears in error messages (if non-interactive) and user prompts
 (if interactive).}
+
+\item{action}{An optional function taking \code{pkg} and \code{...}
+arguments. It is called by \code{check_installed()} when the user
+chooses to update outdated packages. The function is passed the
+missing and outdated packages as a character vector of names.}
 
 \item{call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/man/is_installed.Rd
+++ b/man/is_installed.Rd
@@ -5,14 +5,14 @@
 \alias{check_installed}
 \title{Are packages installed in any of the libraries?}
 \usage{
-is_installed(pkg, ..., version = NULL, op = NULL)
+is_installed(pkg, ..., version = NULL, compare = NULL)
 
 check_installed(
   pkg,
   reason = NULL,
   ...,
   version = NULL,
-  op = NULL,
+  compare = NULL,
   call = caller_env()
 )
 }
@@ -25,10 +25,11 @@ e.g. \code{"pkg (>= 1.0.0)"}.}
 \item{version}{Minimum versions for \code{pkg}. If supplied, must be the
 same length as \code{pkg}. \code{NA} elements stand for any versions.}
 
-\item{op}{A character vector of comparison operators to use for
-\code{version}. If supplied, must be the same length as \code{version}. If
-\code{NULL}, \code{>=} is used as default for all elements. \code{NA} elements
-in \code{op} are also set to \code{>=} by default.}
+\item{compare}{A character vector of comparison operators to use
+for \code{version}. If supplied, must be the same length as
+\code{version}. If \code{NULL}, \code{>=} is used as default for all
+elements. \code{NA} elements in \code{compare} are also set to \code{>=} by
+default.}
 
 \item{reason}{Optional string indicating why is \code{pkg} needed.
 Appears in error messages (if non-interactive) and user prompts

--- a/man/is_installed.Rd
+++ b/man/is_installed.Rd
@@ -13,7 +13,6 @@ check_installed(
   ...,
   version = NULL,
   compare = NULL,
-  src = NULL,
   call = caller_env()
 )
 }
@@ -35,10 +34,6 @@ default.}
 \item{reason}{Optional string indicating why is \code{pkg} needed.
 Appears in error messages (if non-interactive) and user prompts
 (if interactive).}
-
-\item{src}{A \href{https://pak.r-lib.org/reference/pak_package_sources.html}{pak source}
-specification passed to \code{pak::pkg_install()} when \code{pkg} needs to
-be installed or reinstalled.}
 
 \item{call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/man/is_installed.Rd
+++ b/man/is_installed.Rd
@@ -5,7 +5,7 @@
 \alias{check_installed}
 \title{Are packages installed in any of the libraries?}
 \usage{
-is_installed(pkg, ..., version = NULL)
+is_installed(pkg, ..., version = NULL, op = NULL)
 
 check_installed(pkg, reason = NULL, ..., version = NULL, call = caller_env())
 }
@@ -16,6 +16,11 @@ check_installed(pkg, reason = NULL, ..., version = NULL, call = caller_env())
 
 \item{version}{Minimum versions for \code{pkg}. If supplied, must be the
 same length as \code{pkg}. \code{NA} elements stand for any versions.}
+
+\item{op}{A character vector of comparison operators to use for
+\code{version}. If supplied, must be the same length as \code{version}. If
+\code{NULL}, \code{>=} is used as default for all elements. \code{NA} elements
+in \code{op} are also set to \code{>=} by default.}
 
 \item{reason}{Optional string indicating why is \code{pkg} needed.
 Appears in error messages (if non-interactive) and user prompts

--- a/man/is_installed.Rd
+++ b/man/is_installed.Rd
@@ -13,6 +13,7 @@ check_installed(
   ...,
   version = NULL,
   compare = NULL,
+  src = NULL,
   call = caller_env()
 )
 }
@@ -34,6 +35,10 @@ default.}
 \item{reason}{Optional string indicating why is \code{pkg} needed.
 Appears in error messages (if non-interactive) and user prompts
 (if interactive).}
+
+\item{src}{A \href{https://pak.r-lib.org/reference/pak_package_sources.html}{pak source}
+specification passed to \code{pak::pkg_install()} when \code{pkg} needs to
+be installed or reinstalled.}
 
 \item{call}{The execution environment of a currently
 running function, e.g. \code{caller_env()}. The function will be

--- a/src/version.c
+++ b/src/version.c
@@ -1,7 +1,7 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 
-const char* rlang_version = "0.99.0.9002";
+const char* rlang_version = "0.99.0.9003";
 
 /**
  * This file records the expected package version in the shared

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -77,3 +77,25 @@
       <error/rlang_error>
       Error in `check_installed()`: `version` must be `NULL` or a vector of versions the same length as `pkg`.
 
+# pkg_version_info() parses info
+
+    Code
+      (expect_error(pkg_version_info("foo 1.0"), "valid"))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: Must supply valid package names.
+      x Problematic names:
+      * "foo 1.0"
+    Code
+      (expect_error(pkg_version_info("foo (1.0)"), "parse"))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: Can't parse version in `pkg`.
+    Code
+      (expect_error(pkg_version_info("foo (>= 1.0)", "1.0"), "both"))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: Can't supply version in both `pkg` and `version`.
+      x Redundant versions:
+      * "foo (>= 1.0)"
+

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -23,7 +23,7 @@
       "the same length"))
     Output
       <error/rlang_error>
-      Error in `is_installed()`: `version` must be a character vector the same length as `pkg`.
+      Error in `is_installed()`: `version` must be `NULL` or a vector of versions the same length as `pkg`.
 
 # check_installed() checks minimal versions
 
@@ -31,7 +31,7 @@
       (expect_error(check_installed(c("rlang", "testthat"), version = "0.1")))
     Output
       <error/rlang_error>
-      Error in `check_installed()`: `version` must be a character vector the same length as `pkg`.
+      Error in `check_installed()`: `version` must be `NULL` or a vector of versions the same length as `pkg`.
     Code
       (expect_error(check_installed("_foo", version = "1.0")))
     Output
@@ -53,4 +53,27 @@
     Output
       <error/rlang_error>
       Error in `foo()`: The packages `_foo` (>= 1.0) and `_bar` (>= 2.0) are required to proceed.
+
+# `pkg` is type-checked
+
+    Code
+      (expect_error(is_installed(1)))
+    Output
+      <error/rlang_error>
+      Error in `is_installed()`: `pkg` must be a package name or a vector of package names.
+    Code
+      (expect_error(is_installed(na_chr)))
+    Output
+      <error/rlang_error>
+      Error in `is_installed()`: `pkg` must be a package name or a vector of package names.
+    Code
+      (expect_error(check_installed(c("foo", ""))))
+    Output
+      <error/rlang_error>
+      Error in `check_installed()`: `pkg` must be a package name or a vector of package names.
+    Code
+      (expect_error(check_installed(c("foo", "bar"), version = c("1", ""))))
+    Output
+      <error/rlang_error>
+      Error in `check_installed()`: `version` must be `NULL` or a vector of versions the same length as `pkg`.
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -1,20 +1,20 @@
 # check_installed() fails if packages are not installed
 
     Code
-      (expect_error(check_installed("_foo")))
+      (expect_error(check_installed("rlangFoo")))
     Output
       <error/rlang_error>
-      Error in `foo()`: The package `_foo` is required.
+      Error in `foo()`: The package `rlangFoo` is required.
     Code
-      (expect_error(check_installed(c("_foo", "_bar"))))
+      (expect_error(check_installed(c("rlangFoo", "rlangBar"))))
     Output
       <error/rlang_error>
-      Error in `foo()`: The packages `_foo` and `_bar` are required.
+      Error in `foo()`: The packages `rlangFoo` and `rlangBar` are required.
     Code
-      (expect_error(check_installed(c("_foo", "_bar"), "to proceed.")))
+      (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.")))
     Output
       <error/rlang_error>
-      Error in `foo()`: The packages `_foo` and `_bar` are required to proceed.
+      Error in `foo()`: The packages `rlangFoo` and `rlangBar` are required to proceed.
 
 # is_installed() checks minimal versions
 
@@ -33,26 +33,34 @@
       <error/rlang_error>
       Error in `check_installed()`: `version` must be `NULL` or a vector of versions the same length as `pkg`.
     Code
-      (expect_error(check_installed("_foo", version = "1.0")))
+      (expect_error(check_installed("rlangFoo", version = "1.0")))
     Output
       <error/rlang_error>
-      Error in `foo()`: The package `_foo` (>= 1.0) is required.
+      Error in `foo()`: The package `rlangFoo` (>= 1.0) is required.
     Code
-      (expect_error(check_installed(c("_foo", "_bar"), version = c("1.0", NA))))
+      (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA)))
+      )
     Output
       <error/rlang_error>
-      Error in `foo()`: The packages `_foo` (>= 1.0) and `_bar` are required.
+      Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` are required.
     Code
-      (expect_error(check_installed(c("_foo", "_bar"), version = c(NA, "2.0"))))
+      (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0")))
+      )
     Output
       <error/rlang_error>
-      Error in `foo()`: The packages `_foo` and `_bar` (>= 2.0) are required.
+      Error in `foo()`: The packages `rlangFoo` and `rlangBar` (>= 2.0) are required.
     Code
-      (expect_error(check_installed(c("_foo", "_bar"), "to proceed.", version = c(
-        "1.0", "2.0"))))
+      (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.",
+      version = c("1.0", "2.0"))))
     Output
       <error/rlang_error>
-      Error in `foo()`: The packages `_foo` (>= 1.0) and `_bar` (>= 2.0) are required to proceed.
+      Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` (>= 2.0) are required to proceed.
+    Code
+      (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (>= 2.0)"),
+      "to proceed.")))
+    Output
+      <error/rlang_error>
+      Error in `foo()`: The packages `rlangFoo (>= 1.0)` and `rlangBar (>= 2.0)` are required to proceed.
 
 # `pkg` is type-checked
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -145,3 +145,16 @@
       <error/rlang_error>
       Error in `caller()`: `compare` must be one of ">", ">=", "<", or "<=".
 
+# `src` is checked
+
+    Code
+      err(check_installed("foo", src = c("a", "b")))
+    Output
+      <error/rlang_error>
+      Error in `check_installed()`: `src` must be a character vector as long as `pkg`.
+    Code
+      err(check_installed("foo", src = 1))
+    Output
+      <error/rlang_error>
+      Error in `check_installed()`: `src` must be a character vector as long as `pkg`.
+

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -145,3 +145,16 @@
       <error/rlang_error>
       Error in `caller()`: `compare` must be one of ">", ">=", "<", or "<=".
 
+# `action` is checked
+
+    Code
+      err(check_installed("foo", action = "identity"))
+    Output
+      <error/rlang_error>
+      Error in `check_installed()`: `action` must `NULL` or a function.
+    Code
+      err(check_installed("foo", action = identity))
+    Output
+      <error/rlang_error>
+      Error in `check_installed()`: `action` must take a `...` argument.
+

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -98,4 +98,34 @@
       Error in `caller()`: Can't supply version in both `pkg` and `version`.
       x Redundant versions:
       * "foo (>= 1.0)"
+    Code
+      (expect_error(pkg_version_info(c("foo (!= 1.0)"))))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: `op` must be one of ">", ">=", "<", or "<=".
+
+# pkg_version_info() supports `op`
+
+    Code
+      err(pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">=")))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: `version` must be supplied when `op` is supplied.
+    Code
+      err(pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">=")))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: `version` must be supplied when `op` is supplied.
+    Code
+      err(pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">=")))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: Can't supply version in both `pkg` and `version`.
+      x Redundant versions:
+      * "bar (>= 2.0)"
+    Code
+      err(pkg_version_info("foo", "1.0", "!="))
+    Output
+      <error/rlang_error>
+      Error in `caller()`: `op` must be one of ">", ">=", "<", or "<=".
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -118,20 +118,20 @@
       (expect_error(pkg_version_info(c("foo (!= 1.0)"))))
     Output
       <error/rlang_error>
-      Error in `caller()`: `op` must be one of ">", ">=", "<", or "<=".
+      Error in `caller()`: `compare` must be one of ">", ">=", "<", or "<=".
 
-# pkg_version_info() supports `op`
+# pkg_version_info() supports `cmp`
 
     Code
       err(pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">=")))
     Output
       <error/rlang_error>
-      Error in `caller()`: `version` must be supplied when `op` is supplied.
+      Error in `caller()`: `version` must be supplied when `compare` is supplied.
     Code
       err(pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">=")))
     Output
       <error/rlang_error>
-      Error in `caller()`: `version` must be supplied when `op` is supplied.
+      Error in `caller()`: `version` must be supplied when `compare` is supplied.
     Code
       err(pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">=")))
     Output
@@ -143,5 +143,5 @@
       err(pkg_version_info("foo", "1.0", "!="))
     Output
       <error/rlang_error>
-      Error in `caller()`: `op` must be one of ">", ">=", "<", or "<=".
+      Error in `caller()`: `compare` must be one of ">", ">=", "<", or "<=".
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -56,11 +56,19 @@
       <error/rlang_error>
       Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` (>= 2.0) are required to proceed.
     Code
-      (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (>= 2.0)"),
+      (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"),
       "to proceed.")))
     Output
       <error/rlang_error>
-      Error in `foo()`: The packages `rlangFoo (>= 1.0)` and `rlangBar (>= 2.0)` are required to proceed.
+      Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` (> 2.0) are required to proceed.
+
+# < requirements can't be recovered with restart
+
+    Code
+      (expect_error(check_installed("rlang (< 0.1)")))
+    Output
+      <error/rlang_error>
+      Error in `foo()`: The package `rlang` (< 0.1) is required.
 
 # `pkg` is type-checked
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -3,17 +3,17 @@
     Code
       (expect_error(check_installed("rlangFoo")))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The package `rlangFoo` is required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"))))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The packages `rlangFoo` and `rlangBar` are required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.")))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The packages `rlangFoo` and `rlangBar` are required to proceed.
 
 # is_installed() checks minimal versions
@@ -35,31 +35,31 @@
     Code
       (expect_error(check_installed("rlangFoo", version = "1.0")))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The package `rlangFoo` (>= 1.0) is required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA)))
       )
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` are required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0")))
       )
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The packages `rlangFoo` and `rlangBar` (>= 2.0) are required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.",
       version = c("1.0", "2.0"))))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` (>= 2.0) are required to proceed.
     Code
       (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"),
       "to proceed.")))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The packages `rlangFoo` (>= 1.0) and `rlangBar` (> 2.0) are required to proceed.
 
 # < requirements can't be recovered with restart
@@ -67,7 +67,7 @@
     Code
       (expect_error(check_installed("rlang (< 0.1)")))
     Output
-      <error/rlang_error>
+      <error/rlib_error_package_not_found>
       Error in `foo()`: The package `rlang` (< 0.1) is required.
 
 # `pkg` is type-checked

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -145,16 +145,3 @@
       <error/rlang_error>
       Error in `caller()`: `compare` must be one of ">", ">=", "<", or "<=".
 
-# `src` is checked
-
-    Code
-      err(check_installed("foo", src = c("a", "b")))
-    Output
-      <error/rlang_error>
-      Error in `check_installed()`: `src` must be a character vector as long as `pkg`.
-    Code
-      err(check_installed("foo", src = 1))
-    Output
-      <error/rlang_error>
-      Error in `check_installed()`: `src` must be a character vector as long as `pkg`.
-

--- a/tests/testthat/test-compat-purrr.R
+++ b/tests/testthat/test-compat-purrr.R
@@ -49,5 +49,8 @@ test_that("reduce/accumulate work", {
 
   expect_equal(accumulate(x, `+`), c(1, 3, 6))
   expect_equal(accumulate_right(x, `+`), c(6, 5, 3))
+})
 
+test_that("transpose() handles empty list", {
+  expect_equal(transpose(list()), list())
 })

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -118,3 +118,14 @@ test_that("`pkg` is type-checked", {
     (expect_error(check_installed(c("foo", "bar"), version = c("1", ""))))
   })
 })
+
+test_that("pkg_version_info() parses info", {
+  pkg <- c("foo (>= 0.99)", "bar", "baz (> 0.1)")
+  out <- pkg_version_info(pkg, NULL)
+
+  expect_equal(out, data_frame(
+    pkg = c("foo", "bar", "baz"),
+    op = c(">=", NA, ">"),
+    ver = c("0.99", NA, "0.1")
+  ))
+})

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -45,11 +45,23 @@ test_that("check_installed() checks minimal versions", {
     (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA))))
     (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0"))))
     (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.", version = c("1.0", "2.0"))))
-    (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (>= 2.0)"), "to proceed.")))
+    (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"), "to proceed.")))
+  })
+})
+
+test_that("< requirements can't be recovered with restart", {
+  local_options(rlang_interactive = TRUE)
+  local_error_call(call("foo"))
+  expect_snapshot({
+    (expect_error(check_installed("rlang (< 0.1)")))
   })
 })
 
 test_that("pnf error is validated", {
+  # No need to revalidate unless we export it
+  expect_true(TRUE)
+  return()
+
   expect_pnf <- function(out, pkg, ver) {
     expect_s3_class(out, "rlib_error_package_not_found")
     expect_equal(out$pkg, pkg)
@@ -74,13 +86,13 @@ test_that("can handle check-installed", {
 
   # Override `is_installed()` results
   override <- NULL
-  is_installed_hook <- function(pkg, ver) {
+  is_installed_hook <- function(pkg, ver, op) {
     if (is_bool(override)) {
       rep_along(pkg, override)
     } else {
       with_options(
         "rlang:::is_installed_hook" = NULL,
-        is_installed(pkg, version = ver)
+        is_installed(pkg, version = ver, op = op)
       )
     }
   }

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -86,13 +86,13 @@ test_that("can handle check-installed", {
 
   # Override `is_installed()` results
   override <- NULL
-  is_installed_hook <- function(pkg, ver, op) {
+  is_installed_hook <- function(pkg, ver, cmp) {
     if (is_bool(override)) {
       rep_along(pkg, override)
     } else {
       with_options(
         "rlang:::is_installed_hook" = NULL,
-        is_installed(pkg, version = ver, op = op)
+        is_installed(pkg, version = ver, compare = cmp)
       )
     }
   }
@@ -146,7 +146,7 @@ test_that("pkg_version_info() parses info", {
 
   expect_equal(out, data_frame(
     pkg = c("foo", "bar", "baz"),
-    op = c(">=", NA, ">"),
+    cmp = c(">=", NA, ">"),
     ver = c("1.0", NA, "3.0")
   ))
 
@@ -155,7 +155,7 @@ test_that("pkg_version_info() parses info", {
 
   expect_equal(out, data_frame(
     pkg = c("foo", "bar", "baz", "quux"),
-    op = c(">=", ">=", ">", NA),
+    cmp = c(">=", ">=", ">", NA),
     ver = c("1.0", "2.0", "3.0", NA)
   ))
 
@@ -164,7 +164,7 @@ test_that("pkg_version_info() parses info", {
 
   expect_equal(out, data_frame(
     pkg = c("foo", "bar", "baz", "quux"),
-    op = c(">=", ">=", ">", ">="),
+    cmp = c(">=", ">=", ">", ">="),
     ver = c("1.0", "2.0", "3.0", "4.0")
   ))
 
@@ -176,7 +176,7 @@ test_that("pkg_version_info() parses info", {
   })
 })
 
-test_that("pkg_version_info() supports `op`", {
+test_that("pkg_version_info() supports `cmp`", {
   local_error_call(call("caller"))
 
   pkg <- c("foo", "bar", "baz")
@@ -184,7 +184,7 @@ test_that("pkg_version_info() supports `op`", {
 
   expect_equal(out, data_frame(
     pkg = c("foo", "bar", "baz"),
-    op = c(">=", ">=", "<"),
+    cmp = c(">=", ">=", "<"),
     ver = c("1.0", "2.0", "3.0")
   ))
 

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -153,5 +153,26 @@ test_that("pkg_version_info() parses info", {
     (expect_error(pkg_version_info("foo 1.0"), "valid"))
     (expect_error(pkg_version_info("foo (1.0)"), "parse"))
     (expect_error(pkg_version_info("foo (>= 1.0)", "1.0"), "both"))
+    (expect_error(pkg_version_info(c("foo (!= 1.0)"))))
+  })
+})
+
+test_that("pkg_version_info() supports `op`", {
+  local_error_call(call("caller"))
+
+  pkg <- c("foo", "bar", "baz")
+  out <- pkg_version_info(pkg, c("1.0", "2.0", "3.0"), c(NA, NA, "<"))
+
+  expect_equal(out, data_frame(
+    pkg = c("foo", "bar", "baz"),
+    op = c(">=", ">=", "<"),
+    ver = c("1.0", "2.0", "3.0")
+  ))
+
+  expect_snapshot({
+    err(pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">=")))
+    err(pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">=")))
+    err(pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">=")))
+    err(pkg_version_info("foo", "1.0", "!="))
   })
 })

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -197,13 +197,3 @@ test_that("pkg_version_info() supports `cmp`", {
     err(pkg_version_info("foo", "1.0", "!="))
   })
 })
-
-test_that("`src` is checked", {
-  expect_null(check_src(c("a", "b"), c("c", "d")))
-  expect_null(check_src(NULL, c("c", "d")))
-
-  expect_snapshot({
-    err(check_installed("foo", src = c("a", "b")))
-    err(check_installed("foo", src = 1))
-  })
-})

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -7,9 +7,9 @@ test_that("check_installed() fails if packages are not installed", {
   local_error_call(call("foo"))
 
   expect_snapshot({
-    (expect_error(check_installed("_foo")))
-    (expect_error(check_installed(c("_foo", "_bar"))))
-    (expect_error(check_installed(c("_foo", "_bar"), "to proceed.")))
+    (expect_error(check_installed("rlangFoo")))
+    (expect_error(check_installed(c("rlangFoo", "rlangBar"))))
+    (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.")))
   })
 })
 
@@ -27,18 +27,25 @@ test_that("is_installed() checks minimal versions", {
 
   expect_true(is_installed(c("rlang", "testthat"), version = chr(NA, NA)))
   expect_false(is_installed(c("rlang", "testthat"), version = c(NA, "100")))
+
+  expect_true(is_installed(c("rlang (>= 0.1)", "testthat (>= 0.1)")))
+  expect_false(is_installed(c("rlang (>= 100.1)", "testthat (>= 0.1)")))
+  expect_false(is_installed(c("rlang (<= 0.4.0)", "testthat (>= 0.1)")))
 })
 
 test_that("check_installed() checks minimal versions", {
   local_options(rlang_interactive = FALSE)
   local_error_call(call("foo"))
 
+  expect_null(check_installed(c("rlang (>= 0.1)", "testthat (>= 0.1)")))
+
   expect_snapshot({
     (expect_error(check_installed(c("rlang", "testthat"), version = "0.1")))
-    (expect_error(check_installed("_foo", version = "1.0")))
-    (expect_error(check_installed(c("_foo", "_bar"), version = c("1.0", NA))))
-    (expect_error(check_installed(c("_foo", "_bar"), version = c(NA, "2.0"))))
-    (expect_error(check_installed(c("_foo", "_bar"), "to proceed.", version = c("1.0", "2.0"))))
+    (expect_error(check_installed("rlangFoo", version = "1.0")))
+    (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA))))
+    (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0"))))
+    (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.", version = c("1.0", "2.0"))))
+    (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (>= 2.0)"), "to proceed.")))
   })
 })
 

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -120,12 +120,38 @@ test_that("`pkg` is type-checked", {
 })
 
 test_that("pkg_version_info() parses info", {
-  pkg <- c("foo (>= 0.99)", "bar", "baz (> 0.1)")
+  local_error_call(call("caller"))
+
+  pkg <- c("foo (>= 1.0)", "bar", "baz (> 3.0)")
   out <- pkg_version_info(pkg, NULL)
 
   expect_equal(out, data_frame(
     pkg = c("foo", "bar", "baz"),
     op = c(">=", NA, ">"),
-    ver = c("0.99", NA, "0.1")
+    ver = c("1.0", NA, "3.0")
   ))
+
+  pkg <- c("foo (>= 1.0)", "bar", "baz (> 3.0)", "quux")
+  out <- pkg_version_info(pkg, c(NA, "2.0", NA, NA))
+
+  expect_equal(out, data_frame(
+    pkg = c("foo", "bar", "baz", "quux"),
+    op = c(">=", ">=", ">", NA),
+    ver = c("1.0", "2.0", "3.0", NA)
+  ))
+
+  pkg <- c("foo (>= 1.0)", "bar", "baz (> 3.0)", "quux")
+  out <- pkg_version_info(pkg, c(NA, "2.0", NA, "4.0"))
+
+  expect_equal(out, data_frame(
+    pkg = c("foo", "bar", "baz", "quux"),
+    op = c(">=", ">=", ">", ">="),
+    ver = c("1.0", "2.0", "3.0", "4.0")
+  ))
+
+  expect_snapshot({
+    (expect_error(pkg_version_info("foo 1.0"), "valid"))
+    (expect_error(pkg_version_info("foo (1.0)"), "parse"))
+    (expect_error(pkg_version_info("foo (>= 1.0)", "1.0"), "both"))
+  })
 })

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -103,7 +103,9 @@ test_that("can handle check-installed", {
     withCallingHandlers(
       rlib_error_package_not_found = function(cnd) {
         override <<- value
-        invokeRestart("rlib_restart_package_not_found")
+        if (!is_null(findRestart("rlib_restart_package_not_found"))) {
+          invokeRestart("rlib_restart_package_not_found")
+        }
       },
       expr
     )

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -197,3 +197,13 @@ test_that("pkg_version_info() supports `cmp`", {
     err(pkg_version_info("foo", "1.0", "!="))
   })
 })
+
+test_that("`src` is checked", {
+  expect_null(check_src(c("a", "b"), c("c", "d")))
+  expect_null(check_src(NULL, c("c", "d")))
+
+  expect_snapshot({
+    err(check_installed("foo", src = c("a", "b")))
+    err(check_installed("foo", src = 1))
+  })
+})

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -197,3 +197,10 @@ test_that("pkg_version_info() supports `cmp`", {
     err(pkg_version_info("foo", "1.0", "!="))
   })
 })
+
+test_that("`action` is checked", {
+  expect_snapshot({
+    err(check_installed("foo", action = "identity"))
+    err(check_installed("foo", action = identity))
+  })
+})

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -109,3 +109,12 @@ test_that("can handle check-installed", {
     "are required"
   )
 })
+
+test_that("`pkg` is type-checked", {
+  expect_snapshot({
+    (expect_error(is_installed(1)))
+    (expect_error(is_installed(na_chr)))
+    (expect_error(check_installed(c("foo", ""))))
+    (expect_error(check_installed(c("foo", "bar"), version = c("1", ""))))
+  })
+})


### PR DESCRIPTION
Branched from #1331.

* DESCRIPTION-style requirements are now supported, e.g. `is_installed("rlang (>= 1.0.0)"`.
* New `compare` argument to supply requirement info programmatically.
* When `<` or `<=` is used, `check_installed()` doesn't prompt for install.

This will allow support for `check_installed()` in pkgload, so that we get install prompts on missing deps.