### PR TITLE
Use alert bullets in error messages

### DIFF
--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -208,8 +208,10 @@ cnd_message_format_prefixed <- function(cnd,
                                         ...,
                                         parent = FALSE,
                                         alert = NULL) {
-  alert <- alert %||% is_error(cnd)
   type <- cnd_type(cnd)
+  if (is_null(alert)) {
+    alert <- type %in% c("error", "warning")
+  }
 
   if (parent) {
     prefix <- sprintf("Caused by %s", type)

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -208,8 +208,11 @@ cnd_message_format_prefixed <- function(cnd,
                                         ...,
                                         parent = FALSE,
                                         alert = NULL) {
-  alert <- alert %||% is_error(cnd)
   type <- cnd_type(cnd)
+
+  if (is_null(alert)) {
+    alert <- is_error(cnd) || parent
+  }
 
   if (parent) {
     prefix <- sprintf("Caused by %s", type)

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -208,10 +208,8 @@ cnd_message_format_prefixed <- function(cnd,
                                         ...,
                                         parent = FALSE,
                                         alert = NULL) {
+  alert <- alert %||% is_error(cnd)
   type <- cnd_type(cnd)
-  if (is_null(alert)) {
-    alert <- type %in% c("error", "warning")
-  }
 
   if (parent) {
     prefix <- sprintf("Caused by %s", type)

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -431,15 +431,22 @@ cnd_print <- function(x, ...) {
 cnd_format <- function(x,
                        ...,
                        backtrace = TRUE,
-                       simplify = c("branch", "collapse", "none")) {
+                       simplify = c("branch", "collapse", "none"),
+                       prefix = TRUE,
+                       alert = NULL) {
   simplify <- arg_match(simplify)
+  alert <- alert %||% is_error(x)
 
   orig <- x
   parent <- x$parent
   style <- cli_box_chars()
 
   header <- cnd_type_header(x)
-  message <- cnd_message_format_prefixed(x)
+  if (prefix) {
+    message <- cnd_message_format_prefixed(x, alert = alert)
+  } else {
+    message <- cnd_message_format(x, alert = alert)
+  }
 
   out <- paste_line(
     header,

--- a/man/topic-data-mask-programming.Rd
+++ b/man/topic-data-mask-programming.Rd
@@ -181,9 +181,9 @@ my_mean(mtcars, tolower("CYL"))
 
 The \code{.data} pronoun can only be subsetted with single column names. It doesn't support single-bracket indexing:\if{html}{\out{<div class="sourceCode r">}}\preformatted{mtcars \%>\% dplyr::summarise(.data[c("cyl", "am")])
 #> Error in `dplyr::summarise()`:
-#>   Problem while computing `..1 = .data[c("cyl", "am")]`.
+#> ! Problem while computing `..1 = .data[c("cyl", "am")]`.
 #> Caused by error in `.data[c("cyl", "am")]`:
-#>   `[` is not supported by the `.data` pronoun, use `[[` or $ instead.
+#> ! `[` is not supported by the `.data` pronoun, use `[[` or $ instead.
 }\if{html}{\out{</div>}}
 
 There is no plural variant of \code{.data} built in tidy eval. Instead, we'll used the \code{all_of()} operator available in tidy selections to supply character vectors. This is straightforward in functions that take tidy selections, like \code{tidyr::pivot_longer()}:\if{html}{\out{<div class="sourceCode r">}}\preformatted{vars <- c("cyl", "am")

--- a/man/topic-data-mask.Rd
+++ b/man/topic-data-mask.Rd
@@ -28,9 +28,9 @@ Let's see what happens when we pass arguments to a data-masking function like \c
 
 my_mean(mtcars, cyl, am)
 #> Error in `dplyr::summarise()`:
-#>   Problem while computing `..1 = mean(var1 + var2)`.
+#> ! Problem while computing `..1 = mean(var1 + var2)`.
 #> Caused by error in `mean()`:
-#>   object 'cyl' not found
+#> ! object 'cyl' not found
 }\if{html}{\out{</div>}}
 
 The problem here is that \code{summarise()} defuses the R code it was supplied, i.e. \code{mean(var1 + var2)}.  Instead we want it to see \code{mean(cyl + am)}. This is why we need injection, we need to modify that piece of code by injecting the code supplied to the function in place of \code{var1} and \code{var2}.

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -22,41 +22,41 @@
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "discrete" or "continuous", not "continuuos".
+      ! `my_arg` must be one of "discrete" or "continuous", not "continuuos".
       i Did you mean "continuous"?
     Code
       (expect_error(arg_match_wrapper("fou", c("bar", "foo"), "my_arg")))
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "bar" or "foo", not "fou".
+      ! `my_arg` must be one of "bar" or "foo", not "fou".
       i Did you mean "foo"?
     Code
       (expect_error(arg_match_wrapper("fu", c("ba", "fo"), "my_arg")))
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "ba" or "fo", not "fu".
+      ! `my_arg` must be one of "ba" or "fo", not "fu".
       i Did you mean "fo"?
     Code
       (expect_error(arg_match_wrapper("baq", c("foo", "baz", "bas"), "my_arg")))
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "foo", "baz", or "bas", not "baq".
+      ! `my_arg` must be one of "foo", "baz", or "bas", not "baq".
       i Did you mean "baz"?
     Code
       (expect_error(arg_match_wrapper("", character(), "my_arg")))
     Output
       <error/rlang_error>
       Error in `arg_match0()`:
-      `values` must have at least one element.
+      ! `values` must have at least one element.
     Code
       (expect_error(arg_match_wrapper("fo", "foo", quote(f()))))
     Output
       <error/rlang_error>
       Error in `arg_match0()`:
-      `arg_nm` must be a string or symbol.
+      ! `arg_nm` must be a string or symbol.
 
 # `arg_match()` provides no suggestion when the edit distance is too large
 
@@ -65,13 +65,13 @@
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "fooquxs" or "discrete", not "foobaz".
+      ! `my_arg` must be one of "fooquxs" or "discrete", not "foobaz".
     Code
       (expect_error(arg_match0_wrapper("a", c("b", "c"), "my_arg")))
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "b" or "c", not "a".
+      ! `my_arg` must be one of "b" or "c", not "a".
 
 # `arg_match()` makes case-insensitive match
 
@@ -81,7 +81,7 @@
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "A" or "B", not "a".
+      ! `my_arg` must be one of "A" or "B", not "a".
       i Did you mean "A"?
     Code
       (expect_error(arg_match0_wrapper("aa", c("AA", "aA"), "my_arg"),
@@ -89,7 +89,7 @@
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "AA" or "aA", not "aa".
+      ! `my_arg` must be one of "AA" or "aA", not "aa".
       i Did you mean "aA"?
 
 # check_required() checks argument is supplied (#1118)
@@ -99,13 +99,13 @@
     Output
       <error/rlang_error>
       Error in `f()`:
-      `x` must be supplied.
+      ! `x` must be supplied.
     Code
       (expect_error(g()))
     Output
       <error/rlang_error>
       Error in `f()`:
-      `x` must be supplied.
+      ! `x` must be supplied.
 
 # arg_match() supports symbols and scalar strings
 
@@ -114,7 +114,7 @@
     Output
       <error/rlang_error>
       Error in `arg_match0_wrapper()`:
-      `my_arg` must be one of "bar" or "foo", not "fo".
+      ! `my_arg` must be one of "bar" or "foo", not "fo".
       i Did you mean "foo"?
 
 # arg_match() requires an argument symbol
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `wrapper()`:
-      `arg` must be a symbol.
+      ! `arg` must be a symbol.
       ! This is an internal error, please report it to the package authors.
 
 # can match multiple arguments
@@ -134,14 +134,14 @@
     Output
       <error/rlang_error>
       Error in `my_wrapper()`:
-      `my_arg` must be one of "foo", "bar", or "baz", not "ba".
+      ! `my_arg` must be one of "foo", "bar", or "baz", not "ba".
       i Did you mean "bar"?
     Code
       (expect_error(my_wrapper(c("foo", "ba"))))
     Output
       <error/rlang_error>
       Error in `my_wrapper()`:
-      `my_arg` must be one of "foo", "bar", or "baz", not "ba".
+      ! `my_arg` must be one of "foo", "bar", or "baz", not "ba".
       i Did you mean "bar"?
 
 # arg_match0() defuses argument
@@ -151,12 +151,13 @@
     Output
       <error/rlang_error>
       Error in `fn()`:
-      `arg` must be one of "bar" or "baz", not "foo".
+      ! `arg` must be one of "bar" or "baz", not "foo".
     Code
       (expect_error(arg_match0("foo", c("bar", "baz"))))
     Output
       <error/rlang_error>
-      Error: `"foo"` must be one of "bar" or "baz", not "foo".
+      Error:
+      ! `"foo"` must be one of "bar" or "baz", not "foo".
 
 # check_exclusive works
 
@@ -165,19 +166,19 @@
     Output
       <error/rlang_error>
       Error in `check_exclusive()`:
-      Must supply at least two arguments.
+      ! Must supply at least two arguments.
     Code
       (expect_error(g()))
     Output
       <error/rlang_error>
       Error in `check_exclusive()`:
-      Must supply at least two arguments.
+      ! Must supply at least two arguments.
     Code
       (expect_error(h()))
     Output
       <error/rlang_error>
       Error in `check_exclusive()`:
-      Must supply at least two arguments.
+      ! Must supply at least two arguments.
 
 ---
 
@@ -186,7 +187,7 @@
     Output
       <error/rlang_error>
       Error in `f()`:
-      One of `foo` or `bar` must be supplied.
+      ! One of `foo` or `bar` must be supplied.
 
 ---
 
@@ -196,13 +197,13 @@
     Output
       <error/rlang_error>
       Error in `g()`:
-      Exactly one of `foo`, `bar`, or `baz` must be supplied.
+      ! Exactly one of `foo`, `bar`, or `baz` must be supplied.
     Code
       # Some arguments supplied
       (expect_error(g(foo, bar)))
     Output
       <error/rlang_error>
       Error in `g()`:
-      Exactly one of `foo`, `bar`, or `baz` must be supplied.
+      ! Exactly one of `foo`, `bar`, or `baz` must be supplied.
       x `foo` and `bar` were supplied together.
 

--- a/tests/testthat/_snaps/attr.md
+++ b/tests/testthat/_snaps/attr.md
@@ -5,11 +5,11 @@
     Output
       <error/rlang_error>
       Error in `set_names()`:
-      `x` must be a vector
+      ! `x` must be a vector
     Code
       (expect_error(set_names(1:10, letters[1:4])))
     Output
       <error/rlang_error>
       Error in `set_names()`:
-      The size of `nm` (4) must be compatible with the size of `x` (10).
+      ! The size of `nm` (4) must be compatible with the size of `x` (10).
 

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -4,7 +4,8 @@
       (expect_warning(tryCatch(abort("foo"), error = identity)))
     Output
       <warning/rlang_warning>
-      Warning: Invalid `rlang_backtrace_on_error` option.
+      Warning:
+      Invalid `rlang_backtrace_on_error` option.
       i The option was just reset to `NULL`.
 
 # error is printed with backtrace
@@ -13,14 +14,14 @@
       cat_line(default_interactive)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Run `rlang::last_error()` to see where the error occurred.
       Execution halted
     Code
       cat_line(default_non_interactive)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Backtrace:
           x
        1. \-global f()
@@ -33,13 +34,13 @@
       cat_line(reminder)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Execution halted
     Code
       cat_line(branch)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Backtrace:
        1. global f()
        4. global g()
@@ -49,7 +50,7 @@
       cat_line(collapse)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Backtrace:
           x
        1. \-global f()
@@ -61,7 +62,7 @@
       cat_line(full)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Backtrace:
           x
        1. \-global f()
@@ -74,14 +75,14 @@
       cat_line(rethrown_interactive)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Run `rlang::last_error()` to see where the error occurred.
       Execution halted
     Code
       cat_line(rethrown_non_interactive)
     Output
       Error in `h()`:
-      Error message
+      ! Error message
       Backtrace:
           x
        1. +-base::tryCatch(f(), error = function(cnd) rlang::cnd_signal(cnd))
@@ -100,18 +101,20 @@
     Code
       cat_line(branch_depth_0)
     Output
-      Error: foo
+      Error:
+      ! foo
       Execution halted
     Code
       cat_line(full_depth_0)
     Output
-      Error: foo
+      Error:
+      ! foo
       Execution halted
     Code
       cat_line(branch_depth_1)
     Output
       Error in `f()`:
-      foo
+      ! foo
       Backtrace:
        1. global f()
       Execution halted
@@ -119,7 +122,7 @@
       cat_line(full_depth_1)
     Output
       Error in `f()`:
-      foo
+      ! foo
       Backtrace:
           x
        1. \-global f()
@@ -131,18 +134,18 @@
       cat_line(interactive)
     Output
       Error:
-        bar
+      ! bar
       Caused by error in `h()`:
-        foo
+      ! foo
       Run `rlang::last_error()` to see where the error occurred.
       Execution halted
     Code
       cat_line(non_interactive)
     Output
       Error:
-        bar
+      ! bar
       Caused by error in `h()`:
-        foo
+      ! foo
       Backtrace:
            x
         1. \-global a()
@@ -165,7 +168,7 @@
     Output
       <error/rlang_error>
       Error in `h()`:
-      foo
+      ! foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -177,7 +180,7 @@
     Output
       <error/rlang_error>
       Error in `h()`:
-      foo
+      ! foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -193,7 +196,7 @@
     Output
       <error/rlang_error>
       Error in `h()`:
-      foo
+      ! foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -209,7 +212,7 @@
     Output
       <error/rlang_error>
       Error in `h()`:
-      foo
+      ! foo
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -230,9 +233,9 @@
     Output
       <error/rlang_error>
       Error:
-        no wrapper
+      ! no wrapper
       Caused by error in `failing()`:
-        low-level
+      ! low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -248,9 +251,9 @@
     Output
       <error/rlang_error>
       Error:
-        wrapper
+      ! wrapper
       Caused by error in `failing()`:
-        low-level
+      ! low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -266,9 +269,9 @@
     Output
       <error/rlang_error>
       Error:
-        wrapper
+      ! wrapper
       Caused by error in `failing()`:
-        low-level
+      ! low-level
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -280,9 +283,9 @@
     Output
       <error/rlang_error>
       Error:
-        bar
+      ! bar
       Caused by error in `baz()`:
-        foo
+      ! foo
       Backtrace:
         1. rlang:::catch_error(...)
        10. rlang foo()
@@ -295,7 +298,7 @@
       run("rlang::abort('foo', call = quote(bar(baz)))")
     Output
       Error in `bar()`:
-      foo
+      ! foo
       Execution halted
 
 ---
@@ -304,7 +307,7 @@
       run("rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))")
     Output
       Error in `bar()`:
-      foo
+      ! foo
       Execution halted
 
 # abort() accepts environment as `call` field.
@@ -314,7 +317,7 @@
     Output
       <error/rlang_error>
       Error in `h()`:
-      `arg` must be supplied.
+      ! `arg` must be supplied.
 
 # local_error_call() works
 
@@ -323,7 +326,7 @@
     Output
       <error/rlang_error>
       Error in `expected()`:
-      tilt
+      ! tilt
 
 # can disable error call inference for unexported functions
 
@@ -332,7 +335,7 @@
     Output
       <error/rlang_error>
       Error in `foo()`:
-      foo
+      ! foo
     Code
       local({
         local_options(`rlang:::restrict_default_error_call` = TRUE)
@@ -340,7 +343,8 @@
       })
     Output
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
     Code
       local({
         local_options(`rlang:::restrict_default_error_call` = TRUE)
@@ -349,7 +353,7 @@
     Output
       <error/rlang_error>
       Error in `dots_list()`:
-      `.homonyms` must be one of "keep", "first", "last", or "error", not "k".
+      ! `.homonyms` must be one of "keep", "first", "last", or "error", not "k".
       i Did you mean "keep"?
 
 # NSE doesn't interfere with error call contexts
@@ -358,19 +362,22 @@
       (expect_error(local(arg_match0("f", "foo"))))
     Output
       <error/rlang_error>
-      Error: `"f"` must be one of "foo", not "f".
+      Error:
+      ! `"f"` must be one of "foo", not "f".
       i Did you mean "foo"?
     Code
       (expect_error(eval_bare(quote(arg_match0("f", "foo")))))
     Output
       <error/rlang_error>
-      Error: `"f"` must be one of "foo", not "f".
+      Error:
+      ! `"f"` must be one of "foo", not "f".
       i Did you mean "foo"?
     Code
       (expect_error(eval_bare(quote(arg_match0("f", "foo")), env())))
     Output
       <error/rlang_error>
-      Error: `"f"` must be one of "foo", not "f".
+      Error:
+      ! `"f"` must be one of "foo", not "f".
       i Did you mean "foo"?
 
 # error_call() and format_error_call() preserve special syntax ops
@@ -409,9 +416,9 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
         1. testthat::expect_error(foo())
         7. rlang foo()
@@ -425,9 +432,9 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
            x
         1. +-testthat::expect_error(foo())
@@ -453,9 +460,9 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Caused by error:
-        foo
+      ! foo
       Backtrace:
         1. testthat::expect_error(foo())
         7. rlang foo()
@@ -470,9 +477,9 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Caused by error:
-        foo
+      ! foo
       Backtrace:
            x
         1. +-testthat::expect_error(foo())
@@ -503,25 +510,25 @@
     Output
       <error/rlang_error>
       Error in `f1()`:
-      foo
+      ! foo
     Code
       err(f2())
     Output
       <error/rlang_error>
       Error in `f2()`:
-      foo
+      ! foo
     Code
       err(f3())
     Output
       <error/rlang_error>
       Error in `f3()`:
-      foo
+      ! foo
     Code
       err(f4(NULL))
     Output
       <error/rlang_error>
       Error in `f4()`:
-      foo
+      ! foo
 
 # errors are fully displayed (parents, calls) in knitted files
 
@@ -545,13 +552,13 @@
           )
       
           ## Error in `f()`:
-          ##   Message.
-          ##   x Bullet A
-          ##   i Bullet B.
+          ## ! Message.
+          ## x Bullet A
+          ## i Bullet B.
           ## Caused by error in `foo()`:
-          ##   Parent message.
-          ##   * Bullet 1.
-          ##   * Bullet 2.
+          ## ! Parent message.
+          ## * Bullet 1.
+          ## * Bullet 2.
       
       Warning.
       
@@ -562,12 +569,12 @@
           )
       
           ## Warning in f(): Message.
-          ##   x Bullet A
-          ##   i Bullet B.
+          ## x Bullet A
+          ## i Bullet B.
           ## Caused by error in `foo()`:
-          ##   Parent message.
-          ##   * Bullet 1.
-          ##   * Bullet 2.
+          ## ! Parent message.
+          ## * Bullet 1.
+          ## * Bullet 2.
       
       Message.
       
@@ -578,12 +585,12 @@
           )
       
           ## Message.
-          ##   x Bullet A
-          ##   i Bullet B.
+          ## x Bullet A
+          ## i Bullet B.
           ## Caused by error in `foo()`:
-          ##   Parent message.
-          ##   * Bullet 1.
-          ##   * Bullet 2.
+          ## ! Parent message.
+          ## * Bullet 1.
+          ## * Bullet 2.
 
 # can supply bullets both through `message` and `body`
 
@@ -591,14 +598,16 @@
       (expect_error(abort("foo", body = c("a", "b"))))
     Output
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
       a
       b
     Code
       (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
     Output
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
       * bar
       a
       b
@@ -609,14 +618,16 @@
       (expect_error(abort("foo", body = c("a", "b"))))
     Output
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
       a
       b
     Code
       (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
     Output
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
       bar
       a
       b

--- a/tests/testthat/_snaps/cnd-entrace.md
+++ b/tests/testthat/_snaps/cnd-entrace.md
@@ -7,14 +7,16 @@
       Calls: f -> g -> h
       Run `rlang::last_error()` to see where the error occurred.
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
       Backtrace:
        1. global f()
        2. global g()
        3. global h()
       Run `rlang::last_trace()` to see the full context.
       <error/rlang_error>
-      Error: foo
+      Error:
+      ! foo
       Backtrace:
           x
        1. \-global f()
@@ -24,11 +26,11 @@
       cat_line(rlang)
     Output
       Error in `h()`:
-      foo
+      ! foo
       Run `rlang::last_error()` to see where the error occurred.
       <error/rlang_error>
       Error in `h()`:
-      foo
+      ! foo
       Backtrace:
        1. global f()
        2. global g()
@@ -36,7 +38,7 @@
       Run `rlang::last_trace()` to see the full context.
       <error/rlang_error>
       Error in `h()`:
-      foo
+      ! foo
       Backtrace:
           x
        1. \-global f()
@@ -50,7 +52,7 @@
     Output
       <error/rlang_error>
       Error in `1 + ""`:
-      non-numeric argument to binary operator
+      ! non-numeric argument to binary operator
       Backtrace:
         1. rlang::catch_cnd(...)
         9. rlang f()
@@ -61,7 +63,7 @@
 # can set `entrace()` as a global handler
 
     Error in `1 + ""`:
-    non-numeric argument to binary operator
+    ! non-numeric argument to binary operator
     Backtrace:
         x
      1. \-global f()
@@ -72,7 +74,7 @@
 ---
 
     Error in `1 + ""`:
-    non-numeric argument to binary operator
+    ! non-numeric argument to binary operator
     Backtrace:
         x
      1. \-global f()

--- a/tests/testthat/_snaps/cnd-handlers.md
+++ b/tests/testthat/_snaps/cnd-handlers.md
@@ -5,7 +5,7 @@
     Output
       <error/rlang_error>
       Error in `try_call()`:
-      `...` must be named with condition classes.
+      ! `...` must be named with condition classes.
 
 # can rethrow from `try_call()`
 
@@ -15,9 +15,9 @@
     Output
       <error/rlang_error>
       Error:
-        bar
+      ! bar
       Caused by error in `h()`:
-        foo
+      ! foo
       Backtrace:
         1. rlang:::catch_error(...)
        15. rlang f()
@@ -28,9 +28,9 @@
     Output
       <error/rlang_error>
       Error:
-        bar
+      ! bar
       Caused by error in `h()`:
-        foo
+      ! foo
       Backtrace:
            x
         1. +-rlang:::catch_error(...)

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -5,7 +5,7 @@
     Output
       <error/rlang_error>
       Error in `cnd_body()`:
-      `body` field must be a character vector or a function.
+      ! `body` field must be a character vector or a function.
 
 # can request a line break in error bullets (#1130)
 
@@ -14,7 +14,8 @@
         "Header 2", x = "Bullet 3", x = "Bullet 4"))))
     Output
       <error/rlang_error>
-      Error: Main header.
+      Error:
+      ! Main header.
       Header 1
       x Bullet 1
       x Bullet 2
@@ -27,7 +28,8 @@
       )
     Output
       <error/rlang_error>
-      Error: Main header.
+      Error:
+      ! Main header.
       Header 1
       x Bullet 1
         Break line
@@ -87,7 +89,7 @@
       writeLines(cnd_message_format_prefixed(err))
     Output
       Error in `foo()`:
-      msg
+      ! msg
     Code
       err1 <- error_cnd(message = "msg", call = expr(foo(bar = !!(1:3))))
       err2 <- error_cnd(message = "msg", call = quote(foo$bar()))
@@ -95,15 +97,17 @@
       writeLines(cnd_message_format_prefixed(err1))
     Output
       Error in `foo()`:
-      msg
+      ! msg
     Code
       writeLines(cnd_message_format_prefixed(err2))
     Output
-      Error: msg
+      Error:
+      ! msg
     Code
       writeLines(cnd_message_format_prefixed(err3))
     Output
-      Error: msg
+      Error:
+      ! msg
 
 # long prefixes cause a line break
 
@@ -112,7 +116,7 @@
     Output
       <error/rlang_error>
       Error in `very_very_very_very_very_long_function_name()`:
-      My somewhat longish and verbose error message.
+      ! My somewhat longish and verbose error message.
 
 # prefixes include srcrefs
 
@@ -121,7 +125,7 @@
     Output
       <error/rlang_error>
       Error in `g()` at bar/baz/myfile.R:2:9:
-      Foo.
+      ! Foo.
 
 # inform() and warn() use fallback bullets formatting
 
@@ -189,12 +193,14 @@
       (catch_cnd(inform(c(i = "foo")), "message"))
     Output
       <message/rlang_message>
-      Message: i foo
+      Message:
+      i foo
     Code
       (catch_cnd(warn(c(i = "foo")), "warning"))
     Output
       <warning/rlang_warning>
-      Warning: i foo
+      Warning:
+      i foo
 
 # parent errors prints with bullets in all cases
 
@@ -203,19 +209,19 @@
     Output
       <error/rlang_error>
       Error:
-        Wrapper
+      ! Wrapper
       Caused by error in `f()`:
-        Header
-        i Bullet
+      ! Header
+      i Bullet
     Code
       (expect_error(f(FALSE)))
     Output
       <error/rlang_error>
       Error:
-        Wrapper
+      ! Wrapper
       Caused by error in `f()`:
-        Header
-        i Bullet
+      ! Header
+      i Bullet
 
 # special syntax calls handle edge cases
 
@@ -237,20 +243,21 @@
       parent = foo, use_cli_format = TRUE)
       writeLines(cnd_message(foo, prefix = TRUE))
     Output
-      Error: Parent message.
+      Error:
+      ! Parent message.
       * Bullet 1.
       * Bullet 2.
     Code
       writeLines(cnd_message(bar, prefix = TRUE))
     Output
       Error:
-        Message.
-        * Bullet A.
-        * Bullet B.
+      ! Message.
+      * Bullet A.
+      * Bullet B.
       Caused by error:
-        Parent message.
-        * Bullet 1.
-        * Bullet 2.
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
     Code
       writeLines(cnd_message(foo, prefix = FALSE))
     Output
@@ -261,12 +268,12 @@
       writeLines(cnd_message(bar, prefix = FALSE))
     Output
       Message.
-        * Bullet A.
-        * Bullet B.
+      * Bullet A.
+      * Bullet B.
       Caused by error:
-        Parent message.
-        * Bullet 1.
-        * Bullet 2.
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
 
 # can print message without inheritance
 
@@ -277,13 +284,15 @@
       parent = foo, use_cli_format = TRUE)
       writeLines(cnd_message(foo, inherit = FALSE, prefix = TRUE))
     Output
-      Error: Parent message.
+      Error:
+      ! Parent message.
       * Bullet 1.
       * Bullet 2.
     Code
       writeLines(cnd_message(bar, inherit = FALSE, prefix = TRUE))
     Output
-      Error: Message.
+      Error:
+      ! Message.
       * Bullet A.
       * Bullet B.
     Code
@@ -305,7 +314,7 @@
       cat(as.character(cnd_with(error_cnd)))
     Output
       Error in `bar()`:
-      Message.
+      ! Message.
       * Bullet A.
       * Bullet B.
     Code
@@ -318,6 +327,7 @@
     Code
       cat(as.character(cnd_with(message_cnd)))
     Output
+      Message in `bar()`:
       Message.
       * Bullet A.
       * Bullet B.
@@ -325,41 +335,42 @@
       cat(as.character(cnd_with(error_cnd, parent = TRUE)))
     Output
       Error in `bar()`:
-        Message.
-        * Bullet A.
-        * Bullet B.
+      ! Message.
+      * Bullet A.
+      * Bullet B.
       Caused by error in `foo()`:
-        Parent message.
-        * Bullet 1.
-        * Bullet 2.
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
     Code
       cat(as.character(cnd_with(warning_cnd, parent = TRUE)))
     Output
       Warning in `bar()`:
-        Message.
-        * Bullet A.
-        * Bullet B.
+      Message.
+      * Bullet A.
+      * Bullet B.
       Caused by error in `foo()`:
-        Parent message.
-        * Bullet 1.
-        * Bullet 2.
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
     Code
       cat(as.character(cnd_with(message_cnd, parent = TRUE)))
     Output
+      Message in `bar()`:
       Message.
-        * Bullet A.
-        * Bullet B.
+      * Bullet A.
+      * Bullet B.
       Caused by error in `foo()`:
-        Parent message.
-        * Bullet 1.
-        * Bullet 2.
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
 
 # multiline operator calls are preserved
 
     <error/rlang_error>
     Error in `1 + ("veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long" +
         "veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery_long")`:
-    This is the error message.
+    ! This is the error message.
 
 ---
 
@@ -371,7 +382,7 @@
         2
         3
       }`:
-    This is the error message.
+    ! This is the error message.
 
 ---
 
@@ -380,5 +391,5 @@
         1
         2
       }]`:
-    This is the error message.
+    ! This is the error message.
 

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -321,7 +321,7 @@
       cat(as.character(cnd_with(warning_cnd)))
     Output
       Warning in `bar()`:
-      ! Message.
+      Message.
       * Bullet A.
       * Bullet B.
     Code
@@ -346,7 +346,7 @@
       cat(as.character(cnd_with(warning_cnd, parent = TRUE)))
     Output
       Warning in `bar()`:
-      ! Message.
+      Message.
       * Bullet A.
       * Bullet B.
       Caused by error in `foo()`:

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -308,7 +308,7 @@
       * Bullet A.
       * Bullet B.
 
-# as.character() methods for errors, warnings, and messages
+# as.character() and conditionMessage() methods for errors, warnings, and messages
 
     Code
       cat(as.character(cnd_with(error_cnd)))
@@ -357,6 +357,54 @@
       cat(as.character(cnd_with(message_cnd, parent = TRUE)))
     Output
       Message in `bar()`:
+      Message.
+      * Bullet A.
+      * Bullet B.
+      Caused by error in `foo()`:
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
+    Code
+      cat(conditionMessage(cnd_with(error_cnd)))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
+    Code
+      cat(conditionMessage(cnd_with(warning_cnd)))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
+    Code
+      cat(conditionMessage(cnd_with(message_cnd)))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
+    Code
+      cat(conditionMessage(cnd_with(error_cnd, parent = TRUE)))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
+      Caused by error in `foo()`:
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
+    Code
+      cat(conditionMessage(cnd_with(warning_cnd, parent = TRUE)))
+    Output
+      Message.
+      * Bullet A.
+      * Bullet B.
+      Caused by error in `foo()`:
+      ! Parent message.
+      * Bullet 1.
+      * Bullet 2.
+    Code
+      cat(conditionMessage(cnd_with(message_cnd, parent = TRUE)))
+    Output
       Message.
       * Bullet A.
       * Bullet B.

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -321,7 +321,7 @@
       cat(as.character(cnd_with(warning_cnd)))
     Output
       Warning in `bar()`:
-      Message.
+      ! Message.
       * Bullet A.
       * Bullet B.
     Code
@@ -346,7 +346,7 @@
       cat(as.character(cnd_with(warning_cnd, parent = TRUE)))
     Output
       Warning in `bar()`:
-      Message.
+      ! Message.
       * Bullet A.
       * Bullet B.
       Caused by error in `foo()`:

--- a/tests/testthat/_snaps/cnd-signal.md
+++ b/tests/testthat/_snaps/cnd-signal.md
@@ -4,6 +4,8 @@
       print(err)
     Output
       <error/rlang_error_foobar>
+      Error:
+      ! 
       Backtrace:
         1. rlang::catch_cnd(f())
         8. rlang f()
@@ -40,13 +42,13 @@
     Output
       <error/rlang_error>
       Error in `inform()`:
-      `.frequency_id` must be supplied with `.frequency`.
+      ! `.frequency_id` must be supplied with `.frequency`.
     Code
       (expect_error(warn("foo", .frequency = "once", .frequency_id = 1L)))
     Output
       <error/rlang_error>
       Error in `warn()`:
-      `.frequency` must be a string.
+      ! `.frequency` must be a string.
 
 # signal functions check inputs
 
@@ -55,23 +57,23 @@
     Output
       <error/rlang_error>
       Error in `abort()`:
-      `message` must be a character vector.
+      ! `message` must be a character vector.
     Code
       (expect_error(inform(error_cnd("foo"))))
     Output
       <error/rlang_error>
       Error in `inform()`:
-      `message` must be a character vector.
+      ! `message` must be a character vector.
     Code
       (expect_error(warn(class = error_cnd("foo"))))
     Output
       <error/rlang_error>
       Error in `warn()`:
-      `class` must be a character vector.
+      ! `class` must be a character vector.
     Code
       (expect_error(abort("foo", call = base::call)))
     Output
       <error/rlang_error>
       Error in `abort()`:
-      `call` must be a call or environment.
+      ! `call` must be a call or environment.
 

--- a/tests/testthat/_snaps/cnd.md
+++ b/tests/testthat/_snaps/cnd.md
@@ -477,7 +477,7 @@
     Header.
     i Bullet.
     Caused by warning in `quux()`:
-    Header.
+    ! Header.
     i Bullet.
     Backtrace:
      1. foo()

--- a/tests/testthat/_snaps/cnd.md
+++ b/tests/testthat/_snaps/cnd.md
@@ -477,7 +477,7 @@
     Header.
     i Bullet.
     Caused by warning in `quux()`:
-    ! Header.
+    Header.
     i Bullet.
     Backtrace:
      1. foo()

--- a/tests/testthat/_snaps/cnd.md
+++ b/tests/testthat/_snaps/cnd.md
@@ -4,14 +4,14 @@
       cat_line(interactive)
     Output
       Error in `h()`:
-      dispatched!
+      ! dispatched!
       Run `rlang::last_error()` to see where the error occurred.
       Execution halted
     Code
       cat_line(non_interactive)
     Output
       Error in `h()`:
-      dispatched!
+      ! dispatched!
       Backtrace:
           x
        1. \-global f()
@@ -26,7 +26,7 @@
     Output
       <error/foobar>
       Error in `h()`:
-      Low-level message
+      ! Low-level message
       Backtrace:
         1. rlang:::catch_error(f())
         9. rlang f()
@@ -40,14 +40,14 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang a()
        10. rlang b()
        11. rlang c()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang a()
@@ -64,7 +64,7 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -79,7 +79,7 @@
        10.   \-rlang b()
        11.     \-rlang c()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -109,7 +109,7 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -124,7 +124,7 @@
        10.   \-rlang b()
        11.     \-rlang c()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -151,7 +151,7 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
@@ -159,7 +159,7 @@
        10.   \-rlang b()
        11.     \-rlang c()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
            x
         1. +-[ rlang:::catch_error(...) ] with 7 more calls
@@ -176,14 +176,14 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang a()
        10. rlang b()
        11. rlang c()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
         1. rlang:::catch_error(a())
         9. rlang a()
@@ -200,11 +200,11 @@
     Output
       <error/high>
       Error:
-        High-level
+      ! High-level
       Caused by error:
-        Mid-level
+      ! Mid-level
       Caused by error in `low()`:
-        Low-level
+      ! Low-level
 
 # summary.rlang_error() prints full backtrace
 
@@ -213,9 +213,9 @@
     Output
       <error/rlang_error>
       Error:
-        The high-level error message
+      ! The high-level error message
       Caused by error in `h()`:
-        The low-level error message
+      ! The low-level error message
       Backtrace:
            x
         1. +-rlang:::catch_error(a())
@@ -244,6 +244,8 @@
       print(err)
     Output
       <error/foo>
+      Error:
+      ! 
 
 # base parent errors are printed with rlang method
 
@@ -252,9 +254,9 @@
     Output
       <error/bar>
       Error:
-        baz
+      ! baz
       Caused by error:
-        foo
+      ! foo
 
 # errors are printed with call
 
@@ -263,7 +265,7 @@
     Output
       <error/rlang_error>
       Error in `foo()`:
-      msg
+      ! msg
 
 # calls are consistently displayed on rethrow (#1240)
 
@@ -272,17 +274,17 @@
     Output
       <error/rlang_error>
       Error in `step_dummy()`:
-        Problem while executing step.
+      ! Problem while executing step.
       Caused by error in `base_problem()`:
-        oh no!
+      ! oh no!
     Code
       (expect_error(with_context(rlang_problem(), "step_dummy")))
     Output
       <error/rlang_error>
       Error in `step_dummy()`:
-        Problem while executing step.
+      ! Problem while executing step.
       Caused by error in `rlang_problem()`:
-        oh no!
+      ! oh no!
 
 # external backtraces are displayed (#1098)
 
@@ -291,7 +293,7 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
         1. rlang::catch_cnd(foo(), "error")
         8. rlang foo()
@@ -301,7 +303,7 @@
        13. rlang g()
        14. rlang h()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
        1. quux()
        2. foofy()
@@ -310,7 +312,7 @@
     Output
       <error/rlang_error>
       Error:
-        High-level message
+      ! High-level message
       Backtrace:
            x
         1. +-rlang::catch_cnd(foo(), "error")
@@ -328,7 +330,7 @@
        13.         \-rlang g()
        14.           \-rlang h()
       Caused by error in `h()`:
-        Low-level message
+      ! Low-level message
       Backtrace:
           x
        1. \-quux()
@@ -342,7 +344,7 @@
     Output
       <error/rlang_error>
       Error:
-        bar
+      ! bar
       Backtrace:
            x
         1. +-rlang::catch_cnd(foo(), "error")
@@ -356,7 +358,7 @@
         9.   \-rlang bar()
        10.     \-rlang baz()
       Caused by error in `h()`:
-        foo
+      ! foo
       Backtrace:
            x
         1. +-rlang::catch_cnd(foo(), "error")
@@ -382,7 +384,7 @@
     Output
       <error/rlang_error>
       Error:
-        bar
+      ! bar
       Backtrace:
            x
         1. +-[ rlang::catch_cnd(...) ] with 6 more calls
@@ -390,7 +392,7 @@
         9.   \-rlang bar()
        10.     \-rlang baz()
       Caused by error in `h()`:
-        foo
+      ! foo
       Backtrace:
            x
         1. +-[ rlang::catch_cnd(...) ] with 6 more calls
@@ -407,14 +409,14 @@
     Output
       <error/rlang_error>
       Error:
-        bar
+      ! bar
       Backtrace:
         1. rlang::catch_cnd(foo(), "error")
         8. rlang foo()
         9. rlang bar()
        10. rlang baz()
       Caused by error in `h()`:
-        foo
+      ! foo
       Backtrace:
         1. rlang::catch_cnd(foo(), "error")
         8. rlang foo()
@@ -431,13 +433,13 @@
     Output
       <error/rlang_error>
       Error in `cnd()`:
-      `class` must be supplied.
+      ! `class` must be supplied.
     Code
       (expect_error(signal("")))
     Output
       <error/rlang_error>
       Error in `signal()`:
-      `class` must be supplied.
+      ! `class` must be supplied.
 
 # cnd_type_header() formats condition classes
 
@@ -472,11 +474,11 @@
 
     <message/rlang_message>
     Message in `quux()`:
-      Header.
-      i Bullet.
+    Header.
+    i Bullet.
     Caused by warning in `quux()`:
-      Header.
-      i Bullet.
+    Header.
+    i Bullet.
     Backtrace:
      1. foo()
      2. bar()
@@ -531,19 +533,19 @@
     Output
       <error/rlang_error>
       Error in `warning_cnd()`:
-      `class` must be a character vector.
+      ! `class` must be a character vector.
     Code
       (expect_error(error_cnd(class = list())))
     Output
       <error/rlang_error>
       Error in `error_cnd()`:
-      `class` must be a character vector.
+      ! `class` must be a character vector.
     Code
       (expect_error(message_cnd(message = 1)))
     Output
       <error/rlang_error>
       Error in `message_cnd()`:
-      `message` must be a character vector.
+      ! `message` must be a character vector.
 
 # picks up cli format flag
 

--- a/tests/testthat/_snaps/compat-downstream-deps.md
+++ b/tests/testthat/_snaps/compat-downstream-deps.md
@@ -8,5 +8,6 @@
       }))
     Output
       <warning/rlang_warning>
-      Warning: The package `utils` (>= 100.10) is required as of rlang 0.5.0.
+      Warning:
+      The package `utils` (>= 100.10) is required as of rlang 0.5.0.
 

--- a/tests/testthat/_snaps/compat-s3-register.md
+++ b/tests/testthat/_snaps/compat-s3-register.md
@@ -5,7 +5,8 @@
         ...) NULL)))
     Output
       <warning/rlang_warning>
-      Warning: Can't find generic `foobarbaz` in package testthat to register S3 method.
+      Warning:
+      Can't find generic `foobarbaz` in package testthat to register S3 method.
       i This message is only shown to developers using devtools.
       i Do you need to update testthat to the latest version?
 

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -10,7 +10,7 @@
     Output
       <error/rlib_error_dots_named>
       Error in `f()`:
-      Arguments in `...` must be passed by position, not name.
+      ! Arguments in `...` must be passed by position, not name.
       x Problematic arguments:
       * xy = 4
       * x = 5
@@ -22,7 +22,7 @@
     Output
       <error/rlib_error_dots_nonempty>
       Error in `f()`:
-      `...` must be empty.
+      ! `...` must be empty.
       x Problematic argument:
       * xy = 4
     Code
@@ -30,7 +30,7 @@
     Output
       <error/rlib_error_dots_nonempty>
       Error in `f0()`:
-      `...` must be empty.
+      ! `...` must be empty.
       x Problematic argument:
       * xy = 4
 

--- a/tests/testthat/_snaps/dots.md
+++ b/tests/testthat/_snaps/dots.md
@@ -5,14 +5,14 @@
     Output
       <error/rlang_error>
       Error in `list_error()`:
-      Arguments can't have the same name.
+      ! Arguments can't have the same name.
       x Multiple arguments named `a` at positions 2 and 3.
     Code
       (expect_error(list_error(1, a = 2, b = 3, 4, b = 5, b = 6, 7, a = 8)))
     Output
       <error/rlang_error>
       Error in `list_error()`:
-      Arguments can't have the same name.
+      ! Arguments can't have the same name.
       x Multiple arguments named `a` at positions 2 and 8.
       x Multiple arguments named `b` at positions 3, 5, and 6.
     Code
@@ -20,7 +20,7 @@
     Output
       <error/rlang_error>
       Error in `list_error()`:
-      Arguments can't have the same name.
+      ! Arguments can't have the same name.
       x Multiple arguments named `a` at positions 2 and 8.
       x Multiple arguments named `b` at positions 3, 5, and 6.
 
@@ -31,7 +31,7 @@
     Output
       <error/rlang_error>
       Error in `dots_list()`:
-      `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
+      ! `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
       i Did you mean "trailing"?
     Code
       foo <- (function() dots_list(.ignore_empty = "t"))
@@ -39,6 +39,6 @@
     Output
       <error/rlang_error>
       Error in `dots_list()`:
-      `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
+      ! `.ignore_empty` must be one of "trailing", "none", or "all", not "t".
       i Did you mean "trailing"?
 

--- a/tests/testthat/_snaps/env-binding.md
+++ b/tests/testthat/_snaps/env-binding.md
@@ -5,11 +5,11 @@
     Output
       <error/rlang_error>
       Error in `env_get()`:
-      Can't find `foobar` in environment.
+      ! Can't find `foobar` in environment.
     Code
       (expect_error(env_get_list(env(), "foobar")))
     Output
       <error/rlang_error>
       Error in `env_get_list()`:
-      Can't find `foobar` in environment.
+      ! Can't find `foobar` in environment.
 

--- a/tests/testthat/_snaps/eval-tidy.md
+++ b/tests/testthat/_snaps/eval-tidy.md
@@ -7,14 +7,14 @@
     Output
       <error/rlang_error>
       Error in `f()`:
-      Can't subset `.data` outside of a data mask context.
+      ! Can't subset `.data` outside of a data mask context.
     Code
       f <- (function() .data[["foo"]])
       (expect_error(f(), "subset"))
     Output
       <error/rlang_error>
       Error in `f()`:
-      Can't subset `.data` outside of a data mask context.
+      ! Can't subset `.data` outside of a data mask context.
 
 # `.data` pronoun fails informatively
 
@@ -23,60 +23,60 @@
     Output
       <error/rlang_error>
       Error in `g()`:
-      Can't subset `.data` outside of a data mask context.
+      ! Can't subset `.data` outside of a data mask context.
     Code
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error_data_pronoun_not_found>
       Error in `.data$foo`:
-      Column `foo` not found in `.data`.
+      ! Column `foo` not found in `.data`.
     Code
       g <- (function(data) h(.data[[2]], data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.data[[2]]`:
-      Must subset the data pronoun with a string, not a double vector.
+      ! Must subset the data pronoun with a string, not a double vector.
     Code
       g <- (function(data) h(.data["foo"], data = data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.data["foo"]`:
-      `[` is not supported by the `.data` pronoun, use `[[` or $ instead.
+      ! `[` is not supported by the `.data` pronoun, use `[[` or $ instead.
     Code
       g <- (function(data) h(.data[["foo"]] <- 1, data = data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.data[["foo"]] <- ...`:
-      Can't modify the data pronoun.
+      ! Can't modify the data pronoun.
     Code
       g <- (function(data) h(.data$foo <- 1, data = data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.data$"foo" <- ...`:
-      Can't modify the data pronoun.
+      ! Can't modify the data pronoun.
     Code
       g <- (function(data) h(.env["foo"], data = data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.env["foo"]`:
-      `[` is not supported by the `.env` pronoun, use `[[` or $ instead.
+      ! `[` is not supported by the `.env` pronoun, use `[[` or $ instead.
     Code
       g <- (function(data) h(.env$foo <- 1, data = data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.env$"foo" <- ...`:
-      Can't modify the context pronoun.
+      ! Can't modify the context pronoun.
     Code
       g <- (function(data) h(.env[["foo"]] <- 1, data = data))
       (expect_error(f(mtcars)))
     Output
       <error/rlang_error>
       Error in `.env[["foo"]] <- ...`:
-      Can't modify the context pronoun.
+      ! Can't modify the context pronoun.
 

--- a/tests/testthat/_snaps/fn.md
+++ b/tests/testthat/_snaps/fn.md
@@ -4,30 +4,32 @@
       (expect_error(as_function(1)))
     Output
       <error/rlang_error>
-      Error: Can't convert `1`, a double vector, to a function.
+      Error:
+      ! Can't convert `1`, a double vector, to a function.
     Code
       (expect_error(as_function(1, arg = "foo")))
     Output
       <error/rlang_error>
-      Error: Can't convert `foo`, a double vector, to a function.
+      Error:
+      ! Can't convert `foo`, a double vector, to a function.
     Code
       (expect_error(my_function(1 + 2)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      Can't convert `my_arg`, a double vector, to a function.
+      ! Can't convert `my_arg`, a double vector, to a function.
     Code
       (expect_error(my_function(1)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      Can't convert `my_arg`, a double vector, to a function.
+      ! Can't convert `my_arg`, a double vector, to a function.
     Code
       (expect_error(my_function(a ~ b)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      Can't convert `my_arg`, a two-sided formula, to a function.
+      ! Can't convert `my_arg`, a two-sided formula, to a function.
 
 # check inputs in function accessors
 
@@ -36,17 +38,17 @@
     Output
       <error/rlang_error>
       Error in `fn_fmls()`:
-      `fn` must be an R function, not a double vector.
+      ! `fn` must be an R function, not a double vector.
     Code
       (expect_error(fn_body(1)))
     Output
       <error/rlang_error>
       Error in `fn_body()`:
-      `fn` must be an R function, not a double vector.
+      ! `fn` must be an R function, not a double vector.
     Code
       (expect_error(fn_env(1)))
     Output
       <error/rlang_error>
       Error in `fn_env()`:
-      `fn` must be a function, not a double vector.
+      ! `fn` must be a function, not a double vector.
 

--- a/tests/testthat/_snaps/nse-force.md
+++ b/tests/testthat/_snaps/nse-force.md
@@ -5,6 +5,6 @@
     Output
       <error/rlang_error>
       Error in `englue()`:
-      Must use `{{`.
+      ! Must use `{{`.
       i Use `glue::glue()` for interpolation with `{`.
 

--- a/tests/testthat/_snaps/operators.md
+++ b/tests/testthat/_snaps/operators.md
@@ -5,25 +5,25 @@
     Output
       <error/rlang_error>
       Error in `c(1L, NA) %|% 2`:
-      Replacement values must have type integer, not type double
+      ! Replacement values must have type integer, not type double
     Code
       (expect_error(c(1, NA) %|% ""))
     Output
       <error/rlang_error>
       Error in `c(1, NA) %|% ""`:
-      Replacement values must have type double, not type character
+      ! Replacement values must have type double, not type character
     Code
       (expect_error(c(1, NA) %|% call("fn")))
     Output
       <error/rlang_error>
       Error in `c(1, NA) %|% call("fn")`:
-      Replacement values must have type double, not type language
+      ! Replacement values must have type double, not type language
     Code
       (expect_error(call("fn") %|% 1))
     Output
       <error/rlang_error>
       Error in `call("fn") %|% 1`:
-      Cannot replace missing values in an object of type language
+      ! Cannot replace missing values in an object of type language
 
 # %|% fails with wrong length
 
@@ -32,17 +32,17 @@
     Output
       <error/rlang_error>
       Error in `c(1L, NA) %|% 1:3`:
-      The replacement values must have size 1 or 2, not 3
+      ! The replacement values must have size 1 or 2, not 3
     Code
       (expect_error(1:10 %|% 1:4))
     Output
       <error/rlang_error>
       Error in `1:10 %|% 1:4`:
-      The replacement values must have size 1 or 10, not 4
+      ! The replacement values must have size 1 or 10, not 4
     Code
       (expect_error(1L %|% 1:4))
     Output
       <error/rlang_error>
       Error in `1L %|% 1:4`:
-      The replacement values must have size 1, not 4
+      ! The replacement values must have size 1, not 4
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -5,19 +5,19 @@
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The package `rlangFoo` is required.
+      ! The package `rlangFoo` is required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"))))
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The packages `rlangFoo` and `rlangBar` are required.
+      ! The packages `rlangFoo` and `rlangBar` are required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.")))
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The packages `rlangFoo` and `rlangBar` are required to proceed.
+      ! The packages `rlangFoo` and `rlangBar` are required to proceed.
 
 # is_installed() checks minimal versions
 
@@ -27,7 +27,7 @@
     Output
       <error/rlang_error>
       Error in `is_installed()`:
-      `version` must be `NULL` or a vector of versions the same length as `pkg`.
+      ! `version` must be `NULL` or a vector of versions the same length as `pkg`.
 
 # check_installed() checks minimal versions
 
@@ -36,41 +36,41 @@
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      `version` must be `NULL` or a vector of versions the same length as `pkg`.
+      ! `version` must be `NULL` or a vector of versions the same length as `pkg`.
     Code
       (expect_error(check_installed("rlangFoo", version = "1.0")))
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The package `rlangFoo` (>= 1.0) is required.
+      ! The package `rlangFoo` (>= 1.0) is required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA)))
       )
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The packages `rlangFoo` (>= 1.0) and `rlangBar` are required.
+      ! The packages `rlangFoo` (>= 1.0) and `rlangBar` are required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0")))
       )
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The packages `rlangFoo` and `rlangBar` (>= 2.0) are required.
+      ! The packages `rlangFoo` and `rlangBar` (>= 2.0) are required.
     Code
       (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.",
       version = c("1.0", "2.0"))))
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The packages `rlangFoo` (>= 1.0) and `rlangBar` (>= 2.0) are required to proceed.
+      ! The packages `rlangFoo` (>= 1.0) and `rlangBar` (>= 2.0) are required to proceed.
     Code
       (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"),
       "to proceed.")))
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The packages `rlangFoo` (>= 1.0) and `rlangBar` (> 2.0) are required to proceed.
+      ! The packages `rlangFoo` (>= 1.0) and `rlangBar` (> 2.0) are required to proceed.
 
 # < requirements can't be recovered with restart
 
@@ -79,7 +79,7 @@
     Output
       <error/rlib_error_package_not_found>
       Error in `foo()`:
-      The package `rlang` (< 0.1) is required.
+      ! The package `rlang` (< 0.1) is required.
 
 # `pkg` is type-checked
 
@@ -88,25 +88,25 @@
     Output
       <error/rlang_error>
       Error in `is_installed()`:
-      `pkg` must be a package name or a vector of package names.
+      ! `pkg` must be a package name or a vector of package names.
     Code
       (expect_error(is_installed(na_chr)))
     Output
       <error/rlang_error>
       Error in `is_installed()`:
-      `pkg` must be a package name or a vector of package names.
+      ! `pkg` must be a package name or a vector of package names.
     Code
       (expect_error(check_installed(c("foo", ""))))
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      `pkg` must be a package name or a vector of package names.
+      ! `pkg` must be a package name or a vector of package names.
     Code
       (expect_error(check_installed(c("foo", "bar"), version = c("1", ""))))
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      `version` must be `NULL` or a vector of versions the same length as `pkg`.
+      ! `version` must be `NULL` or a vector of versions the same length as `pkg`.
 
 # pkg_version_info() parses info
 
@@ -115,7 +115,7 @@
     Output
       <error/rlang_error>
       Error in `caller()`:
-      Must supply valid package names.
+      ! Must supply valid package names.
       x Problematic names:
       * "foo 1.0"
     Code
@@ -123,13 +123,13 @@
     Output
       <error/rlang_error>
       Error in `caller()`:
-      Can't parse version in `pkg`.
+      ! Can't parse version in `pkg`.
     Code
       (expect_error(pkg_version_info("foo (>= 1.0)", "1.0"), "both"))
     Output
       <error/rlang_error>
       Error in `caller()`:
-      Can't supply version in both `pkg` and `version`.
+      ! Can't supply version in both `pkg` and `version`.
       x Redundant versions:
       * "foo (>= 1.0)"
     Code
@@ -137,7 +137,7 @@
     Output
       <error/rlang_error>
       Error in `caller()`:
-      `compare` must be one of ">", ">=", "<", or "<=".
+      ! `compare` must be one of ">", ">=", "<", or "<=".
 
 # pkg_version_info() supports `cmp`
 
@@ -146,19 +146,19 @@
     Output
       <error/rlang_error>
       Error in `caller()`:
-      `version` must be supplied when `compare` is supplied.
+      ! `version` must be supplied when `compare` is supplied.
     Code
       err(pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">=")))
     Output
       <error/rlang_error>
       Error in `caller()`:
-      `version` must be supplied when `compare` is supplied.
+      ! `version` must be supplied when `compare` is supplied.
     Code
       err(pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">=")))
     Output
       <error/rlang_error>
       Error in `caller()`:
-      Can't supply version in both `pkg` and `version`.
+      ! Can't supply version in both `pkg` and `version`.
       x Redundant versions:
       * "bar (>= 2.0)"
     Code
@@ -166,7 +166,7 @@
     Output
       <error/rlang_error>
       Error in `caller()`:
-      `compare` must be one of ">", ">=", "<", or "<=".
+      ! `compare` must be one of ">", ">=", "<", or "<=".
 
 # `action` is checked
 
@@ -175,11 +175,11 @@
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      `action` must `NULL` or a function.
+      ! `action` must `NULL` or a function.
     Code
       err(check_installed("foo", action = identity))
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      `action` must take a `...` argument.
+      ! `action` must take a `...` argument.
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -977,7 +977,7 @@
           f()
       
           ## Error in `h()`:
-          ## foo
+          ## ! foo
       
       Currently needs to be in a different chunk:
       
@@ -985,7 +985,7 @@
       
           ## <error/rlang_error>
           ## Error in `h()`:
-          ## foo
+          ## ! foo
           ## Backtrace:
           ##  1. global f()
           ##  2. global g()
@@ -996,7 +996,7 @@
       
           ## <error/rlang_error>
           ## Error in `h()`:
-          ## foo
+          ## ! foo
           ## Backtrace:
           ##     x
           ##  1. \-global f()
@@ -1007,7 +1007,7 @@
           f()
       
           ## Error in `h()`:
-          ## foo
+          ## ! foo
       
           ## Run `rlang::last_error()` to see where the error occurred.
       
@@ -1015,7 +1015,7 @@
           f()
       
           ## Error in `h()`:
-          ## foo
+          ## ! foo
       
           ## Backtrace:
           ##     x
@@ -1042,7 +1042,7 @@
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
       [1m[33mError[39m in [1m[1m[30m[47m`1 + ""`[49m[39m:[22m
-      non-numeric argument to binary operator
+      [33m![39m non-numeric argument to binary operator
       [1mBacktrace:[22m
       [90m  1. [39m[1mrlang[22m::catch_cnd(withCallingHandlers(f(), error = entrace), "error")
       [90m  9. [39mrlang f()
@@ -1054,7 +1054,7 @@
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
       [1m[33mError[39m in [1m[1m[30m[47m`1 + ""`[49m[39m:[22m
-      non-numeric argument to binary operator
+      [33m![39m non-numeric argument to binary operator
       [1mBacktrace:[22m
       [90m     [39mx
       [90m  1. [39m+-[1mrlang[22m::catch_cnd(withCallingHandlers(f(), error = entrace), "error")
@@ -1077,7 +1077,7 @@
     Output
       <error/rlang_error>
       Error in `trace_back()`:
-      `bottom` must be a positive integer.
+      ! `bottom` must be a positive integer.
 
 # collapsed case in branch formatting
 

--- a/tests/testthat/_snaps/types.md
+++ b/tests/testthat/_snaps/types.md
@@ -5,19 +5,19 @@
     Output
       <error/rlang_error>
       Error in `is_string2()`:
-      `empty` must be `NULL` or a logical value.
+      ! `empty` must be `NULL` or a logical value.
     Code
       (expect_error(is_string2("foo", empty = NA)))
     Output
       <error/rlang_error>
       Error in `is_string2()`:
-      `empty` must be `NULL` or a logical value.
+      ! `empty` must be `NULL` or a logical value.
     Code
       (expect_error(is_string2("foo", "foo", empty = TRUE)))
     Output
       <error/rlang_error>
       Error in `is_string2()`:
-      Exactly one of `string` and `empty` must be supplied.
+      ! Exactly one of `string` and `empty` must be supplied.
 
 # is_character2() matches empty and missing values
 
@@ -26,5 +26,5 @@
     Output
       <error/rlang_error>
       Error in `is_character2()`:
-      Exactly one of `missing` and `empty` can be `TRUE`.
+      ! Exactly one of `missing` and `empty` can be `TRUE`.
 

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -444,7 +444,7 @@ test_that("ANSI escapes are supported in `conditionMessage()`", {
   expect_equal(out_bare, cli::ansi_strip(out_ansi))
 })
 
-test_that("as.character() methods for errors, warnings, and messages", {
+test_that("as.character() and conditionMessage() methods for errors, warnings, and messages", {
   parent_cnd <- error_cnd(
     "foo",
     message = "Parent message.",
@@ -472,6 +472,14 @@ test_that("as.character() methods for errors, warnings, and messages", {
     cat(as.character(cnd_with(error_cnd, parent = TRUE)))
     cat(as.character(cnd_with(warning_cnd, parent = TRUE)))
     cat(as.character(cnd_with(message_cnd, parent = TRUE)))
+
+    cat(conditionMessage(cnd_with(error_cnd)))
+    cat(conditionMessage(cnd_with(warning_cnd)))
+    cat(conditionMessage(cnd_with(message_cnd)))
+
+    cat(conditionMessage(cnd_with(error_cnd, parent = TRUE)))
+    cat(conditionMessage(cnd_with(warning_cnd, parent = TRUE)))
+    cat(conditionMessage(cnd_with(message_cnd, parent = TRUE)))
   })
 })
 


### PR DESCRIPTION
* Use `!` bullet for error headers and for all parent headers
* Remove indent in chained errors

We can't use `!` for warnings because there is no straightforward way of decoupling this style from `conditionMessage()`, since we don't control output for warnings. Given the above two changes, we get slightly suboptimal output in some cases, e.g.:

```r
parent <- error_cnd(message = "This is an error.")
warn("This is a warning.", parent = parent)
#> Warning message:
#> This is a warning.
#> Caused by error:
#> ! This is an error.

parent <- warning_cnd(message = "This is a warning.")
abort("This is a message.", parent = parent)
#> Error:
#> ! This is a message.
#> Caused by warning:
#> ! This is a warning.
```