### PR TITLE
Add `.internal` argument to `abort()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,10 @@
 
 ## Features and bugfixes
 
+* `abort()` gains a `.internal` argument. When set to `TRUE`, a footer
+  bullet is added to `message` to let the user know that the error is
+  internal and that they should report it to the package authors.
+
 * `is_installed()` and `check_installed()` now support
   DESCRIPTION-style version requirements like `"rlang (>= 1.0)"`.
   They also gain `version` and `compare` arguments to supply requirements

--- a/R/arg.R
+++ b/R/arg.R
@@ -38,7 +38,11 @@ arg_match <- function(arg,
 
   arg_expr <- enexpr(arg)
   if (!is_symbol(arg_expr)) {
-    stop_internal(sprintf("%s must be a symbol.", format_arg("arg")))
+    abort(
+      sprintf("%s must be a symbol.", format_arg("arg")),
+      call = caller_env(),
+      .internal = TRUE
+    )
   }
 
   error_arg <- as_string(error_arg)

--- a/R/utils.R
+++ b/R/utils.R
@@ -293,7 +293,7 @@ stop_internal <- function(message, ..., call = caller_env(2)) {
   abort(message, ..., call = call, .internal = TRUE)
 }
 stop_internal_c_lib <- function(fn, message) {
-  if (!is_installed("winch")) {
+  if (!is_installed("winch") && is_interactive()) {
     message <- c(
       message,
       "i" = sprintf(

--- a/R/utils.R
+++ b/R/utils.R
@@ -289,19 +289,13 @@ split_lines <- function(x) {
   strsplit(x, "\n", fixed = TRUE)[[1]]
 }
 
-stop_internal <- function(msg, call = caller_env(2)) {
-  msg <- c(msg, "!" = "This is an internal error, please report it to the package authors.")
-  abort(msg, call = call)
+stop_internal <- function(message, ..., call = caller_env(2)) {
+  abort(message, ..., call = call, .internal = TRUE)
 }
-stop_internal_c_lib <- function(fn, msg) {
-  msg <- c(
-    sprintf("Internal error in `%s()`: %s", fn, msg),
-    "!" = "This error should be reported to the package authors."
-  )
-
+stop_internal_c_lib <- function(fn, message) {
   if (!is_installed("winch")) {
-    msg <- c(
-      msg,
+    message <- c(
+      message,
       "i" = sprintf(
         "Install the %s package to get additional debugging info the next time you get this error.",
         format_pkg("winch")
@@ -309,7 +303,7 @@ stop_internal_c_lib <- function(fn, msg) {
     )
   }
 
-  abort(msg, call = NULL)
+  abort(message, call = call(fn), .internal = TRUE)
 }
 
 with_srcref <- function(src, env = caller_env(), file = NULL) {

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -17,6 +17,7 @@ abort(
   trace = NULL,
   parent = NULL,
   use_cli_format = NULL,
+  .internal = FALSE,
   .file = NULL,
   .subclass = deprecated()
 )
@@ -102,6 +103,10 @@ The downside is that you can no longer format (assemble multiple
 lines into a single string with lines separated by \verb{\\\\n}
 characters) \code{message} ahead of time because that would conflict
 with cli formatting.}
+
+\item{.internal}{If \code{TRUE}, a footer bullet is added to \code{message}
+to let the user know that the error is internal and that they
+should report it to the package authors.}
 
 \item{.file}{A connection or a string specifying where to print the
 message. The default depends on the context, see the \code{stdout} vs

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -125,7 +125,7 @@
       <error/rlang_error>
       Error in `wrapper()`:
       ! `arg` must be a symbol.
-      ! This is an internal error, please report it to the package authors.
+      i This is an internal error, please report it to the package authors.
 
 # can match multiple arguments
 

--- a/tests/testthat/_snaps/c-api.md
+++ b/tests/testthat/_snaps/c-api.md
@@ -1,3 +1,20 @@
+# can push to arrays in dynamic list-of
+
+    Code
+      err(lof_arr_push_back(lof, 0, 42L), "Location 0 does not exist")
+    Output
+      <error/rlang_error>
+      Error in `r_lof_arr_push_back()`:
+      ! Location 0 does not exist.
+      i This is an internal error, please report it to the package authors.
+    Code
+      err(lof_arr_push_back(lof, 10, 42L), "Location 10 does not exist")
+    Output
+      <error/rlang_error>
+      Error in `r_lof_arr_push_back()`:
+      ! Location 10 does not exist.
+      i This is an internal error, please report it to the package authors.
+
 # re-encoding fails purposefully with any bytes
 
     Code

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -632,3 +632,41 @@
       a
       b
 
+# setting `.internal` adds footer bullet
+
+    Code
+      err(abort(c("foo", x = "bar"), .internal = TRUE))
+    Output
+      <error/rlang_error>
+      Error:
+      ! foo
+      x bar
+      i This is an internal error, please report it to the package authors.
+    Code
+      err(abort("foo", body = c(x = "bar"), .internal = TRUE))
+    Output
+      <error/rlang_error>
+      Error:
+      ! foo
+      x bar
+      i This is an internal error, please report it to the package authors.
+
+# setting `.internal` adds footer bullet (fallback)
+
+    Code
+      err(abort(c("foo", x = "bar"), .internal = TRUE))
+    Output
+      <error/rlang_error>
+      Error:
+      ! foo
+      x bar
+      i This is an internal error, please report it to the package authors.
+    Code
+      err(abort("foo", body = c(x = "bar"), .internal = TRUE))
+    Output
+      <error/rlang_error>
+      Error:
+      ! foo
+      x bar
+      i This is an internal error, please report it to the package authors.
+

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -1020,14 +1020,10 @@ test_that("can push to dynamic list-of", {
 
 test_that("can push to arrays in dynamic list-of", {
   lof <- new_dyn_list_of("integer", 3, 2)
-  expect_error(
-    lof_arr_push_back(lof, 0, 42L),
-    "Location 0 does not exist"
-  )
-  expect_error(
-    lof_arr_push_back(lof, 10, 42L),
-    "Location 10 does not exist"
-  )
+  expect_snapshot({
+    err(lof_arr_push_back(lof, 0, 42L), "Location 0 does not exist")
+    err(lof_arr_push_back(lof, 10, 42L), "Location 10 does not exist")
+  })
   lof_push_back(lof)
   lof_push_back(lof)
   lof_push_back(lof)

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -532,3 +532,18 @@ test_that("can supply bullets both through `message` and `body` (cli case)", {
     (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
   })
 })
+
+test_that("setting `.internal` adds footer bullet", {
+  expect_snapshot({
+    err(abort(c("foo", "x" = "bar"), .internal = TRUE))
+    err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
+  })
+})
+
+test_that("setting `.internal` adds footer bullet (fallback)", {
+  local_use_cli(format = FALSE)
+  expect_snapshot({
+    err(abort(c("foo", "x" = "bar"), .internal = TRUE))
+    err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
+  })
+})


### PR DESCRIPTION
And use it in `arg_match()`.

Making it an argument to `abort()` will be useful with input checkers. For instance, checkers can take `...` to be passed on to `abort()`, and then internal errors can be signalled as

```r
check_bool(x, .internal = TRUE)
```