### PR TITLE
Improve `friendly_type_of()`

### DIFF
--- a/R/compat-friendly-type.R
+++ b/R/compat-friendly-type.R
@@ -35,34 +35,36 @@ friendly_type_of <- function(x, length = FALSE) {
     return(sprintf("a <%s> object", type))
   }
 
-  if (is_na(x)) {
-    return(switch(
-      typeof(x),
-      logical = "`NA`",
-      integer = "an integer `NA`",
-      double = "a numeric `NA`",
-      complex = "a complex `NA`",
-      character = "a character `NA`"
-    ))
-  }
-
-  if (rlang::is_scalar_vector(x)) {
-    return(switch(
-      typeof(x),
-      logical = if (x) "`TRUE`" else "`FALSE`",
-      integer = "an integer",
-      double = "a number",
-      complex = "a complex number",
-      character = if (nzchar(x)) "a string" else "`\"\"`",
-      raw = "a raw value"
-    ))
-  }
-
   if (!rlang::is_vector(x)) {
     return(.rlang_as_friendly_type(typeof(x)))
   }
 
   n_dim <- length(dim(x))
+
+  if (!n_dim) {
+    if (is_na(x)) {
+      return(switch(
+        typeof(x),
+        logical = "`NA`",
+        integer = "an integer `NA`",
+        double = "a numeric `NA`",
+        complex = "a complex `NA`",
+        character = "a character `NA`"
+      ))
+    }
+    if (rlang::is_scalar_vector(x)) {
+      return(switch(
+        typeof(x),
+        logical = if (x) "`TRUE`" else "`FALSE`",
+        integer = "an integer",
+        double = "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "`\"\"`",
+        raw = "a raw value"
+      ))
+    }
+  }
+
   type <- .rlang_as_friendly_vector_type(typeof(x), n_dim)
 
   if (length && !n_dim) {

--- a/R/compat-friendly-type.R
+++ b/R/compat-friendly-type.R
@@ -3,6 +3,9 @@
 # Changelog
 # =========
 #
+# 2021-12-20:
+# - Added support for scalar values.
+#
 # 2021-06-30:
 # - Added support for missing arguments.
 #
@@ -30,6 +33,29 @@ friendly_type_of <- function(x, length = FALSE) {
       type <- paste(class(x), collapse = "/")
     }
     return(sprintf("a <%s> object", type))
+  }
+
+  if (is_na(x)) {
+    return(switch(
+      typeof(x),
+      logical = "`NA`",
+      integer = "an integer `NA`",
+      double = "a numeric `NA`",
+      complex = "a complex `NA`",
+      character = "a character `NA`"
+    ))
+  }
+
+  if (rlang::is_scalar_vector(x)) {
+    return(switch(
+      typeof(x),
+      logical = if (x) "`TRUE`" else "`FALSE`",
+      integer = "an integer",
+      double = "a number",
+      complex = "a complex number",
+      character = if (nzchar(x)) "a string" else "`\"\"`",
+      raw = "a raw value"
+    ))
   }
 
   if (!rlang::is_vector(x)) {

--- a/R/compat-friendly-type.R
+++ b/R/compat-friendly-type.R
@@ -4,7 +4,7 @@
 # =========
 #
 # 2021-12-20:
-# - Added support for scalar values.
+# - Added support for scalar values and empty vectors.
 #
 # 2021-06-30:
 # - Added support for missing arguments.
@@ -49,10 +49,11 @@ friendly_type_of <- function(x, length = FALSE) {
         integer = "an integer `NA`",
         double = "a numeric `NA`",
         complex = "a complex `NA`",
-        character = "a character `NA`"
+        character = "a character `NA`",
+        .rlang_stop_unexpected_typeof(x)
       ))
     }
-    if (rlang::is_scalar_vector(x)) {
+    if (length(x) == 1 && !is_list(x)) {
       return(switch(
         typeof(x),
         logical = if (x) "`TRUE`" else "`FALSE`",
@@ -60,7 +61,21 @@ friendly_type_of <- function(x, length = FALSE) {
         double = "a number",
         complex = "a complex number",
         character = if (nzchar(x)) "a string" else "`\"\"`",
-        raw = "a raw value"
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
+    }
+    if (length(x) == 0) {
+      return(switch(
+        typeof(x),
+        logical = "an empty logical vector",
+        integer = "an empty integer vector",
+        double = "an empty numeric vector",
+        complex = "an empty complex vector",
+        character = "an empty character vector",
+        raw = "an empty raw vector",
+        list = "an empty list",
+        .rlang_stop_unexpected_typeof(x)
       ))
     }
   }
@@ -137,6 +152,13 @@ friendly_type_of <- function(x, length = FALSE) {
     closure = "a function",
 
     type
+  )
+}
+
+.rlang_stop_unexpected_typeof <- function(x, call = rlang::caller_env()) {
+  rlang::abort(
+    sprintf("Unexpected type <%s>.", typeof(x)),
+    call = call
   )
 }
 

--- a/R/compat-friendly-type.R
+++ b/R/compat-friendly-type.R
@@ -17,11 +17,12 @@
 
 #' Return English-friendly type
 #' @param x Any R object.
+#' @param value Whether to describe the value of `x`.
 #' @param length Whether to mention the length of vectors and lists.
 #' @return A string describing the type. Starts with an indefinite
 #'   article, e.g. "an integer vector".
 #' @noRd
-friendly_type_of <- function(x, length = FALSE) {
+friendly_type_of <- function(x, value = TRUE, length = FALSE) {
   if (is_missing(x)) {
     return("absent")
   }
@@ -41,7 +42,7 @@ friendly_type_of <- function(x, length = FALSE) {
 
   n_dim <- length(dim(x))
 
-  if (!n_dim) {
+  if (value && !n_dim) {
     if (is_na(x)) {
       return(switch(
         typeof(x),

--- a/R/lifecycle-retired.R
+++ b/R/lifecycle-retired.R
@@ -399,7 +399,7 @@ env_as_list <- function(x) {
   set_names(x, .Call(ffi_unescape_character, names_x))
 }
 vec_as_list <- function(x) {
-  coerce_type_vec(x, friendly_type_of(list()),
+  coerce_type_vec(x, friendly_type_of(list(), value = FALSE),
     logical = ,
     integer = ,
     double = ,
@@ -412,28 +412,28 @@ vec_as_list <- function(x) {
 }
 
 legacy_as_logical <- function(x) {
-  coerce_type_vec(x, friendly_type_of(lgl()),
+  coerce_type_vec(x, friendly_type_of(lgl(), value = FALSE),
     logical = { attributes(x) <- NULL; x },
     integer = as_base_type(x, as.logical),
     double = as_integerish_type(x, as.logical, lgl())
   )
 }
 legacy_as_integer <- function(x) {
-  coerce_type_vec(x, friendly_type_of(int()),
+  coerce_type_vec(x, friendly_type_of(int(), value = FALSE),
     logical = as_base_type(x, as.integer),
     integer = { attributes(x) <- NULL; x },
-    double = as_integerish_type(x, as.integer, int())
+    double = as_integerish_type(x, as.integer, int(), value = FALSE)
   )
 }
 legacy_as_double <- function(x) {
-  coerce_type_vec(x, friendly_type_of(dbl()),
+  coerce_type_vec(x, friendly_type_of(dbl(), value = FALSE),
     logical = ,
     integer = as_base_type(x, as.double),
     double = { attributes(x) <- NULL; x }
   )
 }
 legacy_as_complex <- function(x) {
-  coerce_type_vec(x, friendly_type_of(cpl()),
+  coerce_type_vec(x, friendly_type_of(cpl(), value = FALSE),
     logical = ,
     integer = ,
     double = as_base_type(x, as.complex),
@@ -444,7 +444,9 @@ legacy_as_character <- function(x, encoding = NULL) {
   if (is_unspecified(x)) {
     return(rep_along(x, na_chr))
   }
-  coerce_type_vec(x, friendly_type_of(chr()),
+  coerce_type_vec(
+    x,
+    friendly_type_of(chr(), value = FALSE),
     string = ,
     character = {
       attributes(x) <- NULL
@@ -475,12 +477,14 @@ as_base_type <- function(x, as_type) {
 
   as_type(x)
 }
-as_integerish_type <- function(x, as_type, to) {
+as_integerish_type <- function(x, as_type, to, value = FALSE) {
   if (is_integerish(x)) {
     as_base_type(x, as_type)
   } else {
     abort(paste0(
-      "Can't convert a fractional double vector to ", friendly_type_of(to), ""
+      "Can't convert a fractional double vector to ",
+      friendly_type_of(to, value = value),
+      ""
     ))
   }
 }
@@ -488,7 +492,7 @@ as_integerish_type <- function(x, as_type, to) {
 coerce_type_vec <- function(.x, .to, ...) {
   # Cannot reuse coerce_type() because switch() has a bug with
   # fallthrough and multiple levels of dots forwarding.
-  out <- switch(type_of_(.x), ..., abort_coercion(.x, .to))
+  out <- switch(type_of_(.x), ..., abort_coercion(.x, .to, call = NULL))
 
   if (!is_null(names(.x))) {
     # Avoid a copy of `out` when we restore the names, since it could be

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,7 +5,7 @@ abort_coercion <- function(x,
                            x_type = NULL,
                            arg = NULL,
                            call = caller_env()) {
-  x_type <- x_type %||% friendly_type_of(x)
+  x_type <- x_type %||% friendly_type_of(x, value = TRUE)
 
   if (is_null(arg)) {
     msg <- sprintf("Can't convert %s to %s.", x_type, to_type)

--- a/tests/testthat/_snaps/eval-tidy.md
+++ b/tests/testthat/_snaps/eval-tidy.md
@@ -36,7 +36,7 @@
     Output
       <error/rlang_error>
       Error in `.data[[2]]`:
-      ! Must subset the data pronoun with a string, not a double vector.
+      ! Must subset the data pronoun with a string, not a number.
     Code
       g <- (function(data) h(.data["foo"], data = data))
       (expect_error(f(mtcars)))

--- a/tests/testthat/_snaps/fn.md
+++ b/tests/testthat/_snaps/fn.md
@@ -5,25 +5,25 @@
     Output
       <error/rlang_error>
       Error:
-      ! Can't convert `1`, a double vector, to a function.
+      ! Can't convert `1`, a number, to a function.
     Code
       (expect_error(as_function(1, arg = "foo")))
     Output
       <error/rlang_error>
       Error:
-      ! Can't convert `foo`, a double vector, to a function.
+      ! Can't convert `foo`, a number, to a function.
     Code
       (expect_error(my_function(1 + 2)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      ! Can't convert `my_arg`, a double vector, to a function.
+      ! Can't convert `my_arg`, a number, to a function.
     Code
       (expect_error(my_function(1)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      ! Can't convert `my_arg`, a double vector, to a function.
+      ! Can't convert `my_arg`, a number, to a function.
     Code
       (expect_error(my_function(a ~ b)))
     Output
@@ -38,17 +38,17 @@
     Output
       <error/rlang_error>
       Error in `fn_fmls()`:
-      ! `fn` must be an R function, not a double vector.
+      ! `fn` must be an R function, not a number.
     Code
       (expect_error(fn_body(1)))
     Output
       <error/rlang_error>
       Error in `fn_body()`:
-      ! `fn` must be an R function, not a double vector.
+      ! `fn` must be an R function, not a number.
     Code
       (expect_error(fn_env(1)))
     Output
       <error/rlang_error>
       Error in `fn_env()`:
-      ! `fn` must be a function, not a double vector.
+      ! `fn` must be a function, not a number.
 

--- a/tests/testthat/test-bytes.R
+++ b/tests/testthat/test-bytes.R
@@ -1,6 +1,6 @@
 test_that("bytes() coerces unspecified vectors but not logical ones", {
   expect_equal(bytes2(c(NA, NA), NA), new_bytes(dbl(NA, NA, NA)))
-  expect_error(bytes2(TRUE), "Can't coerce a logical")
+  expect_error(bytes2(TRUE), "Can't coerce")
 })
 
 test_that("can create empty and unspecified bytes() vector", {

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -91,7 +91,7 @@ test_that("finds correct env type", {
 })
 
 test_that("current_env() fails if no default", {
-  expect_error(get_env(list()), "Can't extract an environment from a list")
+  expect_error(get_env(list()), "Can't extract an environment from")
 })
 
 test_that("current_env() picks up default", {

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -548,7 +548,7 @@ test_that("`.data` pronoun fails informatively", {
 
     g <- function(data) h(.env$foo <- 1, data = data)
     (expect_error(f(mtcars)))
-    
+
     g <- function(data) h(.env[["foo"]] <- 1, data = data)
     (expect_error(f(mtcars)))
   })

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -20,3 +20,22 @@ test_that("friendly_type_of() supports matrices and arrays (#141)", {
 test_that("friendly_type_of() supports missing arguments", {
   expect_equal(friendly_type_of(missing_arg()), "absent")
 })
+
+test_that("friendly_type_of() handles scalars", {
+  expect_equal(friendly_type_of(NA), "`NA`")
+  expect_equal(friendly_type_of(na_int), "an integer `NA`")
+  expect_equal(friendly_type_of(na_dbl), "a numeric `NA`")
+  expect_equal(friendly_type_of(na_cpl), "a complex `NA`")
+  expect_equal(friendly_type_of(na_chr), "a character `NA`")
+
+  expect_equal(friendly_type_of(TRUE), "`TRUE`")
+  expect_equal(friendly_type_of(FALSE), "`FALSE`")
+
+  expect_equal(friendly_type_of(1L), "an integer")
+  expect_equal(friendly_type_of(1.0), "a number")
+  expect_equal(friendly_type_of(1i), "a complex number")
+  expect_equal(friendly_type_of(as.raw(1)), "a raw value")
+
+  expect_equal(friendly_type_of("foo"), "a string")
+  expect_equal(friendly_type_of(""), "`\"\"`")
+})

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -38,4 +38,7 @@ test_that("friendly_type_of() handles scalars", {
 
   expect_equal(friendly_type_of("foo"), "a string")
   expect_equal(friendly_type_of(""), "`\"\"`")
+
+  expect_equal(friendly_type_of(matrix(NA)), "a logical matrix")
+  expect_equal(friendly_type_of(matrix(1)), "a double matrix")
 })

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -4,15 +4,15 @@ test_that("friendly_type_of() supports objects", {
 })
 
 test_that("friendly_type_of() supports matrices and arrays (#141)", {
-  expect_equal(friendly_type_of(list()), "a list")
+  expect_equal(friendly_type_of(list()), "an empty list")
   expect_equal(friendly_type_of(matrix(list(1, 2))), "a list matrix")
   expect_equal(friendly_type_of(array(list(1, 2, 3), dim = 1:3)), "a list array")
 
-  expect_equal(friendly_type_of(int()), "an integer vector")
+  expect_equal(friendly_type_of(int()), "an empty integer vector")
   expect_equal(friendly_type_of(matrix(1:3)), "an integer matrix")
   expect_equal(friendly_type_of(array(1:3, dim = 1:3)), "an integer array")
 
-  expect_equal(friendly_type_of(chr()), "a character vector")
+  expect_equal(friendly_type_of(chr()), "an empty character vector")
   expect_equal(friendly_type_of(matrix(letters)), "a character matrix")
   expect_equal(friendly_type_of(array(letters[1:3], dim = 1:3)), "a character array")
 })
@@ -39,6 +39,18 @@ test_that("friendly_type_of() handles scalars", {
   expect_equal(friendly_type_of("foo"), "a string")
   expect_equal(friendly_type_of(""), "`\"\"`")
 
+  expect_equal(friendly_type_of(list(1)), "a list")
+
   expect_equal(friendly_type_of(matrix(NA)), "a logical matrix")
   expect_equal(friendly_type_of(matrix(1)), "a double matrix")
+})
+
+test_that("friendly_type_of() handles empty vectors", {
+  expect_equal(friendly_type_of(lgl()), "an empty logical vector")
+  expect_equal(friendly_type_of(int()), "an empty integer vector")
+  expect_equal(friendly_type_of(dbl()), "an empty numeric vector")
+  expect_equal(friendly_type_of(cpl()), "an empty complex vector")
+  expect_equal(friendly_type_of(chr()), "an empty character vector")
+  expect_equal(friendly_type_of(raw()), "an empty raw vector")
+  expect_equal(friendly_type_of(list()), "an empty list")
 })

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -43,7 +43,7 @@ test_that("as_list() zaps attributes", {
 
 test_that("as_list() only coerces vector or dictionary types", {
   expect_identical(as_list(1:3), list(1L, 2L, 3L))
-  expect_error(as_list(quote(symbol)), "a symbol to a list")
+  expect_error(as_list(quote(symbol)), "a symbol to")
 })
 
 test_that("as_list() bypasses environment method and leaves input intact", {
@@ -56,8 +56,8 @@ test_that("as_list() bypasses environment method and leaves input intact", {
 })
 
 test_that("as_integer() and as_logical() require integerish input", {
-  expect_error(as_integer(1.5), "a fractional double vector to an integer vector")
-  expect_error(as_logical(1.5), "a fractional double vector to a logical vector")
+  expect_error(as_integer(1.5), "a fractional double vector to")
+  expect_error(as_logical(1.5), "a fractional double vector to")
 })
 
 test_that("names are preserved", {

--- a/tests/testthat/test-vec-new.R
+++ b/tests/testthat/test-vec-new.R
@@ -66,8 +66,8 @@ test_that("atomic inputs are implicitly coerced", {
   expect_identical(lgl(10L, FALSE, list(TRUE, 0L, 0)), c(TRUE, FALSE, TRUE, FALSE, FALSE))
   expect_identical(dbl(10L, 10, TRUE, list(10L, 0, TRUE)), c(10, 10, 1, 10, 0, 1))
 
-  expect_error(lgl("foo"), "Can't convert a character vector to a logical vector")
-  expect_error(chr(10), "Can't convert a double vector to a character vector")
+  expect_error(lgl("foo"), "Can't convert a string to a logical vector")
+  expect_error(chr(10), "Can't convert a number to a character vector")
 })
 
 test_that("type errors are handled", {


### PR DESCRIPTION
Branched from #1334.

New `value` argument that controls whether to be more informative about the input type. When set, we mention whether the input is a missing value, a scalar value, or an empty value.

In the future, I think we should show the contents of scalar values, but this will be tackled another time.