### PR TITLE
Draft input checkers

### DIFF
--- a/R/arg.R
+++ b/R/arg.R
@@ -37,26 +37,15 @@ arg_match <- function(arg,
   check_dots_empty0(...)
 
   arg_expr <- enexpr(arg)
-  if (!is_symbol(arg_expr)) {
-    abort(
-      sprintf("%s must be a symbol.", format_arg("arg")),
-      call = caller_env(),
-      .internal = TRUE
-    )
-  }
-
   error_arg <- as_string(error_arg)
+
+  check_symbol(arg_expr, arg = "arg", call = caller_env(), .internal = TRUE)
+  check_character(arg, arg = error_arg, call = error_call)
 
   if (is_null(values)) {
     fn <- caller_fn()
     values <- formals(fn)[[error_arg]]
     values <- eval_bare(values, get_env(fn))
-  }
-  if (!is_character(arg)) {
-    abort(
-      sprintf("%s must be a character vector.", format_arg(error_arg)),
-      call = error_call
-    )
   }
 
   if (multiple) {

--- a/R/call.R
+++ b/R/call.R
@@ -343,9 +343,11 @@ is_call2 <- function(x, ...) {
 #' call_print_type(call)
 #' @noRd
 call_print_type <- function(call) {
-  type <- call_print_fine_type(call)
+  check_call(call)
 
-  switch(type,
+  type <- call_print_fine_type(call)
+  switch(
+    type,
     call = "prefix",
     control = ,
     delim = ,
@@ -354,16 +356,15 @@ call_print_type <- function(call) {
   )
 }
 call_print_fine_type <- function(call) {
-  if (!is_call(call)) {
-    abort("`call` must be a call")
-  }
+  check_call(call)
 
   op <- call_parse_type(call)
   if (op == "") {
     return("call")
   }
 
-  switch(op,
+  switch(
+    op,
     `+unary` = ,
     `-unary` = ,
     `~unary` = ,
@@ -616,21 +617,9 @@ call_modify <- function(.call,
                         .standardise = NULL,
                         .env = caller_env()) {
   args <- dots_list(..., .preserve_empty = TRUE, .homonyms = .homonyms)
+
   expr <- get_expr(.call)
-
-  if (!is_null(.standardise)) {
-    warn_deprecated(paste_line(
-      "`.standardise` is deprecated as of rlang 0.3.0.",
-      "Please use `call_standardise()` prior to calling `call_modify()`."
-    ))
-    if (.standardise) {
-      expr <- get_expr(call_standardise(.call, env = .env))
-    }
-  }
-
-  if (!is_call(expr)) {
-    abort_call_input_type(".call")
-  }
+  check_call(expr, arg = ".call")
 
   expr <- duplicate(expr, shallow = TRUE)
 
@@ -892,10 +881,8 @@ call_name <- function(call) {
   if (is_quosure(call) || is_formula(call)) {
     call <- get_expr(call)
   }
+  check_call(call)
 
-  if (!is_call(call)) {
-    abort_call_input_type("call")
-  }
   if (is_call(call, c("::", ":::"))) {
     return(NULL)
   }
@@ -914,6 +901,7 @@ call_ns <- function(call) {
   if (is_quosure(call) || is_formula(call)) {
     call <- get_expr(call)
   }
+  check_call(call)
 
   if (!is_call(call)) {
     abort_call_input_type("call")
@@ -985,9 +973,7 @@ call_args <- function(call) {
   if (is_quosure(call) || is_formula(call)) {
     call <- get_expr(call)
   }
-  if (!is_call(call)) {
-    abort_call_input_type("call")
-  }
+  check_call(call)
 
   args <- as.list(call[-1])
   set_names((args), names2(args))
@@ -1000,9 +986,8 @@ call_args_names <- function(call) {
   if (is_quosure(call) || is_formula(call)) {
     call <- get_expr(call)
   }
-  if (!is_call(call)) {
-    abort_call_input_type("call")
-  }
+  check_call(call)
+
   names2(call[-1])
 }
 

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -721,12 +721,7 @@ NULL
 #' @export
 caller_arg <- function(arg) {
   arg <- substitute(arg)
-  if (!is_symbol(arg)) {
-    abort(sprintf(
-      "%s must be an argument name.",
-      format_arg("arg")
-    ))
-  }
+  check_arg(arg)
 
   expr <- do.call(substitute, list(arg), envir = caller_env())
   as_label(expr)
@@ -923,10 +918,8 @@ call_restore <- function(x, to) {
   x
 }
 
-trace_trim_context <- function(trace, idx) {
-  if (!is_scalar_integerish(idx)) {
-    abort("`frame` must be a frame environment or index")
-  }
+trace_trim_context <- function(trace, idx, call = caller_env()) {
+  check_frame(idx, arg = "frame", call = call)
 
   to_trim <- seq2(idx, trace_length(trace))
   if (length(to_trim)) {
@@ -934,6 +927,16 @@ trace_trim_context <- function(trace, idx) {
   }
 
   trace
+}
+check_frame <- function(x, arg, call) {
+  if (!is_scalar_integerish(x)) {
+    stop_input_type(
+      x,
+      "a frame environment or index",
+      arg = arg,
+      call = call
+    )
+  }
 }
 
 # Assumes we're called from a calling or exiting handler

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -239,7 +239,11 @@ interrupt <- function() {
   .Call(ffi_interrupt)
 }
 
-validate_signal_args <- function(msg, class, call, subclass, env = caller_env()) {
+validate_signal_args <- function(message,
+                                 class,
+                                 call,
+                                 subclass,
+                                 env = caller_env()) {
   local_error_call("caller")
 
   if (!is_missing(subclass)) {
@@ -249,30 +253,23 @@ validate_signal_args <- function(msg, class, call, subclass, env = caller_env())
 
   if (!is_missing(call)) {
     if (!is_null(call) && !is_environment(call) && !is_call(call)) {
-      abort(sprintf(
-        "%s must be a call or environment.",
-        format_arg("call")
-      ))
+      stop_input_type(call, "a call or environment", arg = "call", call = env)
     }
   }
 
-  if (is_null(msg)) {
+  if (is_null(message)) {
     if (is_null(class)) {
-      abort("Either `message` or `class` must be supplied.")
+      abort("Either `message` or `class` must be supplied.", call = env)
     }
-    msg <- ""
+    message <- ""
   }
 
-  if (!is_character(msg)) {
-    msg <- sprintf("%s must be a character vector.", format_arg("message"))
-    abort(msg)
-  }
-  if (!is_character(class) && !is_null(class)) {
-    msg <- sprintf("%s must be a character vector.", format_arg("class"))
-    abort(msg)
+  check_character(message, call = env)
+  if (!is_null(class)) {
+    check_character(class, call = env)
   }
 
-  msg
+  message
 }
 
 
@@ -325,7 +322,7 @@ needs_signal <- function(frequency,
   }
 
   if (!inherits(sentinel, "POSIXct")) {
-    stop_internal("needs_signal", "Expected `POSIXct` value.")
+    abort("Expected `POSIXct` value.", .internal = TRUE)
   }
 
   # Signal every 8 hours

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -113,10 +113,10 @@ error_cnd <- function(class = NULL,
                       parent = NULL,
                       use_cli_format = NULL) {
   if (!is_null(trace) && !inherits(trace, "rlang_trace")) {
-    abort("`trace` must be NULL or an rlang backtrace")
+    stop_input_type(trace, "`NULL` or an rlang backtrace")
   }
   if (!is_null(parent) && !inherits(parent, "condition")) {
-    abort("`parent` must be NULL or a condition object")
+    stop_input_type(parent, "`NULL` or a condition object")
   }
 
   if (is_environment(call)) {

--- a/R/compat-friendly-type.R
+++ b/R/compat-friendly-type.R
@@ -5,6 +5,7 @@
 #
 # 2021-12-20:
 # - Added support for scalar values and empty vectors.
+# - Added `stop_input_type()`
 #
 # 2021-06-30:
 # - Added support for missing arguments.
@@ -161,6 +162,36 @@ friendly_type_of <- function(x, value = TRUE, length = FALSE) {
     sprintf("Unexpected type <%s>.", typeof(x)),
     call = call
   )
+}
+
+#' @param x The object type which does not conform to `what`. Its
+#'   `friendly_type_of()` is taken and mentioned in the error message.
+#' @param what The friendly expected type.
+#' @param ... Arguments passed to [abort()].
+#' @inheritParams args_error_context
+#' @noRd
+stop_input_type <- function(x,
+                            what,
+                            ...,
+                            arg = rlang::caller_arg(x),
+                            call = rlang::caller_env()) {
+  # From compat-cli.R
+  format_arg <- rlang::env_get(
+    nm = "format_arg",
+    last = topenv(),
+    default = NULL
+  )
+  if (!is.function(format_arg)) {
+    format_arg <- function(x) sprintf("`%s`", x)
+  }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    format_arg(arg),
+    what,
+    friendly_type_of(x)
+  )
+  rlang::abort(message, ..., call = call)
 }
 
 # nocov end

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -7,12 +7,9 @@ line_push <- function(line, text,
   if (!length(line)) {
     return(text)
   }
-  if (!is_string(line)) {
-    abort("`line` must be a string or empty")
-  }
-  if (!is_string(text)) {
-    abort("`text` must be a string")
-  }
+  check_string(line)
+  check_string(text)
+
   width <- width %||% peek_option("width")
 
   if (!has_overflown(line, text, width, has_colour)) {
@@ -950,10 +947,7 @@ as_label_infix <- function(x) {
   # In case something went wrong
   if (length(out) > 1) {
     if (testing()) {
-      abort(c(
-        "Deparsed `out` can't be multiline.",
-        i = "This is a bug in rlang, please file an issue."
-      ))
+      abort("Deparsed `out` can't be multiline.", .internal = TRUE)
     }
     paste(out[[1]], "...")
   } else {

--- a/R/env-binding.R
+++ b/R/env-binding.R
@@ -496,10 +496,7 @@ env_poke <- function(env = caller_env(),
 #' @export
 env_cache <- function(env, nm, default) {
   check_required(default)
-
-  if (!is_string(nm)) {
-    abort("`nm` must be a string.")
-  }
+  check_string(nm)
 
   if (env_has(env, nm)) {
     env_get(env, nm)
@@ -554,9 +551,7 @@ env_names <- function(env) {
 #' @rdname env_names
 #' @export
 env_length <- function(env) {
-  if (!is_environment(env)) {
-    abort("`env` must be an environment")
-  }
+  check_environment(env)
   length(env)
 }
 
@@ -641,11 +636,13 @@ env_binding_are_active <- function(env, nms = NULL) {
 env_binding_are_lazy <- function(env, nms = NULL) {
   env_binding_are_type(env, nms, 1L)
 }
-env_binding_are_type <- function(env, nms, type) {
-  if (!is_environment(env)) {
-    abort("`env` must be an environment.")
-  }
-  nms <- env_binding_validate_names(env, nms)
+env_binding_are_type <- function(env,
+                                 nms,
+                                 type,
+                                 error_call = caller_env()) {
+  check_environment(env, call = error_call)
+
+  nms <- env_binding_validate_names(env, nms, call = error_call)
   promise <- env_binding_types(env, nms)
 
   if (is_null(promise)) {
@@ -656,13 +653,15 @@ env_binding_are_type <- function(env, nms, type) {
   set_names(promise, nms)
 }
 
-env_binding_validate_names <- function(env, nms) {
+env_binding_validate_names <- function(env, nms, call = caller_env()) {
   if (is_null(nms)) {
     nms <- env_names(env)
   } else {
-    if (!is_character(nms)) {
-      abort("`nms` must be a character vector of names")
-    }
+    check_character(
+      nms,
+      what = "a character vector of names",
+      call = call
+    )
   }
   nms
 }

--- a/R/env-special.R
+++ b/R/env-special.R
@@ -85,9 +85,8 @@ search_envs <- function() {
 #' @rdname search_envs
 #' @export
 search_env <- function(name) {
-  if (!is_string(name)) {
-    abort("`name` must be a string")
-  }
+  check_string(name)
+
   if (!is_attached(name)) {
     abort(paste_line(
       sprintf("`%s` is not attached.", name),
@@ -114,9 +113,7 @@ is_attached <- function(x) {
   if (is_string(x)) {
     return(x %in% search())
   }
-  if (!is_environment(x)) {
-    abort("`x` must be an environment or a name")
-  }
+  check_environment(x, what = "an environment or a name")
 
   env <- global_env()
   while (!is_reference(env, empty_env())) {
@@ -228,7 +225,7 @@ ns_env <- function(x = caller_env()) {
   )
 
   if (!is_namespace(env)) {
-    abort("`x` must be a package name or a function inheriting from a namespace.")
+    stop_input_type(x, "a package name or a function inheriting from a namespace")
   }
 
   env
@@ -247,7 +244,7 @@ ns_env_name <- function(x = caller_env()) {
     builtin = ,
     special = ,
     closure = ns_env(x),
-    abort("`x` must be an environment or a function inheriting from a namespace.")
+    stop_input_type(x, "an environment or a function inheriting from a namespace")
   )
   unname(getNamespaceName(env))
 }
@@ -292,7 +289,7 @@ friendly_env_type <- function(type) {
     base = "the base environment",
     frame = "a frame environment",
     local = "a local environment",
-    abort("Internal error: unknown environment type")
+    abort("Unknown environment type.", .internal = TRUE)
   )
 }
 
@@ -346,9 +343,7 @@ env_format <- function(env) {
 #' env_name(env())
 #' env_label(env())
 env_name <- function(env) {
-  if (!is_environment(env)) {
-    abort("`env` must be an environment")
-  }
+  check_environment(env)
 
   if (is_reference(env, global_env())) {
     return("global")

--- a/R/env.R
+++ b/R/env.R
@@ -286,7 +286,7 @@ env_parent <- function(env = caller_env(), n = 1) {
 
   while (n > 0) {
     if (is_empty_env(env_)) {
-      abort("The empty environment has no parent")
+      abort("The empty environment has no parent.")
     }
     n <- n - 1
     env_ <- parent.env(env_)
@@ -317,8 +317,8 @@ env_parents <- function(env = caller_env(), last = global_env()) {
   n <- env_depth(env)
   out <- new_list(n)
 
-  if (!typeof(last) %in% c("environment", "NULL")) {
-    abort("`last` must be `NULL` or an environment")
+  if (!is_null(last)) {
+    check_environment(last, what = "`NULL` or an environment")
   }
 
   i <- 1L
@@ -454,7 +454,7 @@ get_env <- function(env, default = NULL) {
 
   if (is_null(out)) {
     type <- friendly_type_of(env)
-    abort(paste0("Can't extract an environment from ", type))
+    abort(paste0("Can't extract an environment from ", type, "."))
   } else {
     out
   }
@@ -509,7 +509,7 @@ set_env <- function(env, new_env = caller_env()) {
   }
 
   abort(paste0(
-    "Can't set environment for ", friendly_type_of(env)
+    "Can't set environment for ", friendly_type_of(env), "."
   ))
 }
 #' @rdname get_env

--- a/R/expr.R
+++ b/R/expr.R
@@ -222,7 +222,10 @@ expr_name <- function(expr) {
     return(name)
   }
 
-  abort("`expr` must quote a symbol, scalar, or call")
+  abort(sprintf(
+    "%s must be a symbol, scalar, or call.",
+    format_arg("expr")
+  ))
 }
 #' @rdname expr_label
 #' @export

--- a/R/fn.R
+++ b/R/fn.R
@@ -348,33 +348,6 @@ fn_env <- function(fn) {
   x
 }
 
-check_closure <- function(x,
-                          arg = caller_arg(x),
-                          call = caller_env()) {
-  if (!is_closure(x)) {
-    msg <- sprintf(
-      "%s must be an R function, not %s.",
-      format_arg(arg),
-      friendly_type_of(x)
-    )
-    abort(msg, call = call)
-  }
-}
-check_function <- function(x,
-                           arg = caller_arg(x),
-                           call = caller_env()) {
-  if (!is_function(x)) {
-    msg <- sprintf(
-      "%s must be a function, not %s.",
-      format_arg(arg),
-      friendly_type_of(x)
-    )
-    abort(msg, call = call)
-  }
-}
-
-
-
 #' Convert to function
 #'
 #' @description

--- a/R/formula.R
+++ b/R/formula.R
@@ -93,7 +93,7 @@ is_bare_formula <- function(x, scoped = TRUE, lhs = NULL) {
   } else if (is_false(scoped)) {
     exp_class <- "call"
   } else {
-    abort("`scoped` must be `NULL` or a logical value.")
+    stop_input_type(scoped, "`NULL` or a logical value.")
   }
   is_string(class(x), exp_class)
 }
@@ -135,9 +135,7 @@ f_rhs <- function(f) {
     signal_formula_access()
     return(quo_set_expr(x, value))
   }
-  if (!is_formula(x)) {
-    abort("`f` must be a formula")
-  }
+  check_formula(x, arg = "LHS")
   x[[length(x)]] <- value
   x
 }
@@ -147,7 +145,7 @@ f_rhs <- function(f) {
 f_lhs <- function(f) {
   if (is_quosure(f)) {
     signal_formula_access()
-    abort("Can't retrieve the LHS of a quosure")
+    abort("Can't retrieve the LHS of a quosure.")
   }
   .Call(ffi_f_lhs, f)
 }
@@ -157,11 +155,9 @@ f_lhs <- function(f) {
 `f_lhs<-` <- function(x, value) {
   if (is_quosure(x)) {
     signal_formula_access()
-    abort("Can't set the LHS of a quosure")
+    abort("Can't set the LHS of a quosure.")
   }
-  if (!is_formula(x)) {
-    abort("`f` must be a formula")
-  }
+  check_formula(x, arg = "LHS")
 
   if (length(x) < 3) {
     x <- duplicate(x)
@@ -180,9 +176,7 @@ f_env <- function(f) {
     signal_formula_access()
     return(quo_get_env(f))
   }
-  if (!is_formula(f)) {
-    abort("`f` must be a formula")
-  }
+  check_formula(f)
   attr(f, ".Environment")
 }
 

--- a/R/nse-defuse.R
+++ b/R/nse-defuse.R
@@ -428,7 +428,8 @@ endots <- function(call,
                    ignore_empty,
                    unquote_names,
                    homonyms,
-                   check_assign) {
+                   check_assign,
+                   error_call = caller_env()) {
   ignore_empty <- arg_match0(ignore_empty, c("trailing", "none", "all"))
   syms <- as.list(node_cdr(call))
 
@@ -443,7 +444,10 @@ endots <- function(call,
   splice_dots <- FALSE
   dots <- map(syms, function(sym) {
     if (!is_symbol(sym)) {
-      abort("Inputs to capture must be argument names")
+      abort(
+        "Inputs to defuse must be argument names.",
+        call = error_call
+      )
     }
     if (identical(sym, dots_sym)) {
       splice_dots <<- TRUE
@@ -488,7 +492,7 @@ endots <- function(call,
   } else if (is_false(named)) {
     names(dots) <- names2(dots)
   } else if (!is_null(named)) {
-    abort("`.named` must be a logical value.")
+    check_bool(named, arg = ".named", call = error_call)
   }
 
   dots

--- a/R/parse.R
+++ b/R/parse.R
@@ -58,10 +58,12 @@ parse_expr <- function(x) {
   exprs <- parse_exprs(x)
 
   n <- length(exprs)
-  if (n == 0) {
-    abort("No expression to parse")
-  } else if (n > 1) {
-    abort("More than one expression parsed")
+  if (n != 1) {
+    abort(sprintf(
+      "%s must contain exactly 1 expression, not %d.",
+      format_arg("x"),
+      n
+    ))
   }
 
   exprs[[1]]
@@ -78,7 +80,7 @@ parse_exprs <- function(x) {
   } else if (is.character(x)) {
     exprs <- chr_parse_exprs(x)
   } else {
-    abort("`x` must be a character vector or an R connection")
+    stop_input_type(x, "a character vector or an R connection")
   }
   as.list(exprs)
 }
@@ -106,7 +108,7 @@ chr_parse_exprs <- function(x) {
 #' @export
 parse_quo <- function(x, env = global_env()) {
   if (missing(env)) {
-    abort("The quosure environment should be explicitly supplied as `env`")
+    abort("The quosure environment must be supplied as `env`.")
   }
   new_quosure(parse_expr(x), as_environment(env))
 }
@@ -114,7 +116,7 @@ parse_quo <- function(x, env = global_env()) {
 #' @export
 parse_quos <- function(x, env = global_env()) {
   if (missing(env)) {
-    abort("The quosure environment should be explicitly supplied as `env`")
+    abort("The quosure environment must be supplied as `env`.")
   }
   out <- map(parse_exprs(x), new_quosure, env = as_environment(env))
   new_quosures(out)

--- a/R/s3.R
+++ b/R/s3.R
@@ -37,7 +37,7 @@
 #' inherits_only(obj, c("foo", "bar", "baz"))
 inherits_any <- function(x, class) {
   if (is_empty(class)) {
-    abort("`class` can't be empty")
+    abort("`class` can't be empty.")
   }
   inherits(x, class)
 }
@@ -45,7 +45,7 @@ inherits_any <- function(x, class) {
 #' @export
 inherits_all <- function(x, class) {
   if (is_empty(class)) {
-    abort("`class` can't be empty")
+    abort("`class` can't be empty.")
   }
 
   idx <- inherits(x, class, which = TRUE)

--- a/R/session.R
+++ b/R/session.R
@@ -293,13 +293,8 @@ check_pkg_version <- function(pkg,
 check_action <- function(action, call = caller_env()) {
   # Take `pkg`, `version`, and `compare`?
   if (!is_null(action)) {
-    if (!is_closure(action)) {
-      msg <- sprintf(
-        "%s must `NULL` or a function.",
-        format_arg("action")
-      )
-      abort(msg, call = call)
-    }
+    check_closure(action, what = "`NULL` or a function", call = call)
+
     if (!"..." %in% names(formals(action))) {
       msg <- sprintf(
         "%s must take a %s argument.",

--- a/R/state.R
+++ b/R/state.R
@@ -113,7 +113,7 @@ is_interactive <- function() {
   if (!is_null(opt)) {
     if (!is_bool(opt)) {
       options(rlang_interactive = NULL)
-      abort("`rlang_interactive` must be a single `TRUE` of `FALSE`")
+      check_bool(opt, arg = "rlang_interactive")
     }
     return(opt)
   }

--- a/R/sym.R
+++ b/R/sym.R
@@ -61,7 +61,7 @@ sym <- function(x) {
     return(missing_arg())
   }
   if (!is_string(x)) {
-    abort("Only strings can be converted to symbols")
+    abort_coercion(x, "a symbol")
   }
   .Call(ffi_symbol, x)
 }

--- a/R/types-check.R
+++ b/R/types-check.R
@@ -1,0 +1,104 @@
+# Scalars -----------------------------------------------------------------
+
+check_bool <- function(x,
+                       ...,
+                       what = "`TRUE` or `FALSE`",
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!is_bool(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_string <- function(x,
+                         ...,
+                         what = "a single string",
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!is_string(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_symbol <- function(x,
+                         ...,
+                         what = "a symbol",
+                         arg = caller_arg(x),
+                         call = caller_env()) {
+  if (!is_symbol(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_arg <- function(x,
+                      ...,
+                      what = "an argument name",
+                      arg = caller_arg(x),
+                      call = caller_env()) {
+  check_symbol(x, ..., what = what, arg = arg, call = call)
+}
+
+check_call <- function(x,
+                       ...,
+                       what = "a defused call",
+                       arg = caller_arg(x),
+                       call = caller_env()) {
+  if (!is_call(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_environment <- function(x,
+                              ...,
+                              what = "an environment",
+                              arg = caller_arg(x),
+                              call = caller_env()) {
+  if (!is_environment(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_function <- function(x,
+                           ...,
+                           what = "a function",
+                           arg = caller_arg(x),
+                           call = caller_env()) {
+  if (!is_function(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_closure <- function(x,
+                           ...,
+                           what = "an R function",
+                           arg = caller_arg(x),
+                           call = caller_env()) {
+  if (!is_closure(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+check_formula <- function(x,
+                          ...,
+                          what = "a formula",
+                          arg = caller_arg(x),
+                          call = caller_env()) {
+  if (!is_formula(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}
+
+
+# Vectors -----------------------------------------------------------------
+
+# TODO: Restrict missing and special values
+
+check_character <- function(x,
+                            ...,
+                            what = "a character vector",
+                            arg = caller_arg(x),
+                            call = caller_env()) {
+  if (!is_character(x)) {
+    stop_input_type(x, what, ..., arg = arg, call = call)
+  }
+}

--- a/R/utils-encoding.R
+++ b/R/utils-encoding.R
@@ -123,7 +123,7 @@ string <- function(x, encoding = NULL) {
   } else if (is_raw(x)) {
     x <- rawToChar(x)
   } else if (!is_string(x)) {
-    abort("`x` must be a string or raw vector")
+    stop_input_type(x, "a string or a raw vector")
   }
 
   if (!is_null(encoding)) {
@@ -133,13 +133,13 @@ string <- function(x, encoding = NULL) {
   x
 }
 
-cast_raw <- function(x) {
+cast_raw <- function(x, call = caller_env()) {
   if (is_integerish(x)) {
     as.raw(x)
   } else if (is_raw(x)) {
     x
   } else {
-    abort("input should be integerish")
+    abort("`...` must be numbers.", call = call)
   }
 }
 
@@ -149,5 +149,5 @@ legacy_as_raw <- function(x) {
     raw = return(x),
     character = if (is_string(x)) return(charToRaw(x))
   )
-  abort("`x` must be a string or raw vector")
+  stop_input_type(x, "a string or a raw vector", call = NULL)
 }

--- a/R/vec-na.R
+++ b/R/vec-na.R
@@ -111,7 +111,7 @@ na_cpl <- NA_complex_
 #' @export
 are_na <- function(x) {
   if (!is_atomic(x)) {
-    abort("`x` must be an atomic vector")
+    stop_input_type(x, "an atomic vector")
   }
   is.na(x)
 }

--- a/R/vec-new.R
+++ b/R/vec-new.R
@@ -194,9 +194,7 @@ rep_along <- function(along, x) {
 #' @rdname rep_along
 rep_named <- function(names, x) {
   names <- names %||% chr()
-  if (!is_character(names)) {
-    abort("`names` must be `NULL` or a character vector")
-  }
+  check_character(names, what = "`NULL` or a character vector")
 
   set_names(rep_len(x, length(names)), names)
 }

--- a/R/vec.R
+++ b/R/vec.R
@@ -20,10 +20,10 @@
 #' seq2_along(10, letters)
 seq2 <- function(from, to) {
   if (length(from) != 1) {
-    abort("`from` must be length one")
+    abort(sprintf("%s must be length one.", format_arg("from")))
   }
   if (length(to) != 1) {
-    abort("`to` must be length one")
+    abort(sprintf("%s must be length one.", format_arg("to")))
   }
 
   if (from > to) {

--- a/src/internal/arg.c
+++ b/src/internal/arg.c
@@ -62,7 +62,8 @@ r_obj* ffi_ensym(r_obj* sym, r_obj* frame) {
     }
     // else fallthrough
   default:
-    r_abort("Only strings can be converted to symbols");
+    // FIXME: Should call `abort_coercion()`
+    r_abort("Can't convert to a symbol.");
   }
 
   return expr;

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `wrapper()`:
-      ! `arg` must be a symbol.
+      ! `arg` must be a symbol, not a string.
       i This is an internal error, please report it to the package authors.
 
 # can match multiple arguments

--- a/tests/testthat/_snaps/call.md
+++ b/tests/testthat/_snaps/call.md
@@ -1,0 +1,65 @@
+# call functions type-check their input (#187)
+
+    Code
+      x <- list(a = 1)
+      err(call_modify(x, NULL))
+    Output
+      <error/rlang_error>
+      Error in `call_modify()`:
+      ! `.call` must be a defused call, not a list.
+    Code
+      err(call_standardise(x))
+    Output
+      <error/rlang_error>
+      Error in `call_standardise()`:
+      ! `call` must be a quoted call.
+    Code
+      err(call_name(x))
+    Output
+      <error/rlang_error>
+      Error in `call_name()`:
+      ! `call` must be a defused call, not a list.
+    Code
+      err(call_args(x))
+    Output
+      <error/rlang_error>
+      Error in `call_args()`:
+      ! `call` must be a defused call, not a list.
+    Code
+      err(call_args_names(x))
+    Output
+      <error/rlang_error>
+      Error in `call_args_names()`:
+      ! `call` must be a defused call, not a list.
+    Code
+      q <- quo(!!x)
+      err(call_modify(q, NULL))
+    Output
+      <error/rlang_error>
+      Error in `call_modify()`:
+      ! `.call` must be a defused call, not a list.
+    Code
+      err(call_standardise(q))
+    Output
+      <error/rlang_error>
+      Error in `call_standardise()`:
+      ! `call` must be a quoted call.
+    Code
+      err(call_name(q))
+    Output
+      <error/rlang_error>
+      Error in `call_name()`:
+      ! `call` must be a defused call, not a list.
+    Code
+      err(call_args(q))
+    Output
+      <error/rlang_error>
+      Error in `call_args()`:
+      ! `call` must be a defused call, not a list.
+    Code
+      err(call_args_names(q))
+    Output
+      <error/rlang_error>
+      Error in `call_args_names()`:
+      ! `call` must be a defused call, not a list.
+

--- a/tests/testthat/_snaps/cnd-signal.md
+++ b/tests/testthat/_snaps/cnd-signal.md
@@ -57,23 +57,23 @@
     Output
       <error/rlang_error>
       Error in `abort()`:
-      ! `message` must be a character vector.
+      ! `message` must be a character vector, not a <foo/rlang_error/error/condition> object.
     Code
       (expect_error(inform(error_cnd("foo"))))
     Output
       <error/rlang_error>
       Error in `inform()`:
-      ! `message` must be a character vector.
+      ! `message` must be a character vector, not a <foo/rlang_error/error/condition> object.
     Code
       (expect_error(warn(class = error_cnd("foo"))))
     Output
       <error/rlang_error>
       Error in `warn()`:
-      ! `class` must be a character vector.
+      ! `class` must be a character vector, not a <foo/rlang_error/error/condition> object.
     Code
       (expect_error(abort("foo", call = base::call)))
     Output
       <error/rlang_error>
       Error in `abort()`:
-      ! `call` must be a call or environment.
+      ! `call` must be a call or environment, not a primitive function.
 

--- a/tests/testthat/_snaps/nse-defuse.md
+++ b/tests/testthat/_snaps/nse-defuse.md
@@ -1,3 +1,30 @@
+# ensyms() captures multiple symbols
+
+    Code
+      err(fn(foo()))
+    Output
+      <error/rlang_error>
+      Error in `sym()`:
+      ! Can't convert a call to a symbol.
+
+# ensym() unwraps quosures
+
+    Code
+      err(fn(!!quo(foo())))
+    Output
+      <error/rlang_error>
+      Error in `ensym()`:
+      ! Can't convert to a symbol.
+
+# ensyms() unwraps quosures
+
+    Code
+      err(fn(!!!quos(foo, bar())))
+    Output
+      <error/rlang_error>
+      Error in `sym()`:
+      ! Can't convert a call to a symbol.
+
 # auto-named expressions can be unique-repaired
 
     Code

--- a/tests/testthat/_snaps/parse.md
+++ b/tests/testthat/_snaps/parse.md
@@ -1,0 +1,15 @@
+# parse_expr() throws meaningful error messages
+
+    Code
+      err(parse_expr(""))
+    Output
+      <error/rlang_error>
+      Error in `parse_expr()`:
+      ! `x` must contain exactly 1 expression, not 0.
+    Code
+      err(parse_expr("foo; bar"))
+    Output
+      <error/rlang_error>
+      Error in `parse_expr()`:
+      ! `x` must contain exactly 1 expression, not 2.
+

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -175,7 +175,7 @@
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      ! `action` must `NULL` or a function.
+      ! `action` must be `NULL` or a function, not a string.
     Code
       err(check_installed("foo", action = identity))
     Output

--- a/tests/testthat/_snaps/state.md
+++ b/tests/testthat/_snaps/state.md
@@ -1,0 +1,4 @@
+# is_interactive() honors rlang_interactive option, above all else
+
+    `rlang_interactive` must be `TRUE` or `FALSE`, not `NA`.
+

--- a/tests/testthat/_snaps/sym.md
+++ b/tests/testthat/_snaps/sym.md
@@ -1,0 +1,24 @@
+# ensym() fails with calls
+
+    Code
+      err(capture_sym(foo(bar)))
+    Output
+      <error/rlang_error>
+      Error in `ensym()`:
+      ! Can't convert to a symbol.
+
+# must supply strings to sym()
+
+    Code
+      err(sym(letters))
+    Output
+      <error/rlang_error>
+      Error in `sym()`:
+      ! Can't convert a character vector to a symbol.
+    Code
+      err(sym(1:2))
+    Output
+      <error/rlang_error>
+      Error in `sym()`:
+      ! Can't convert an integer vector to a symbol.
+

--- a/tests/testthat/_snaps/types-check.md
+++ b/tests/testthat/_snaps/types-check.md
@@ -1,0 +1,144 @@
+# `check_bool()` checks
+
+    Code
+      err(checker(NA, check_bool))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be `TRUE` or `FALSE`, not `NA`.
+    Code
+      err(checker(lgl(), check_bool))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be `TRUE` or `FALSE`, not an empty logical vector.
+    Code
+      err(checker(c(TRUE, FALSE), check_bool))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be `TRUE` or `FALSE`, not a logical vector.
+    Code
+      err(checker(1, check_bool))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be `TRUE` or `FALSE`, not a number.
+
+# `check_string()` checks
+
+    Code
+      err(checker(NA, check_string))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a single string, not `NA`.
+    Code
+      err(checker(chr(), check_string))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a single string, not an empty character vector.
+    Code
+      err(checker(na_chr, check_string))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a single string, not a character `NA`.
+    Code
+      err(checker(c("", ""), check_string))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a single string, not a character vector.
+    Code
+      err(checker(1, check_string))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a single string, not a number.
+
+# `check_symbol()` checks
+
+    Code
+      err(checker(TRUE, check_symbol))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a symbol, not `TRUE`.
+    Code
+      err(checker(alist(foo, bar), check_symbol))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a symbol, not a list.
+    Code
+      err(checker("foo", check_symbol))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a symbol, not a string.
+    Code
+      err(checker(quote(foo()), check_symbol))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a symbol, not a call.
+
+# `check_call()` checks
+
+    Code
+      err(checker(TRUE, check_call))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a defused call, not `TRUE`.
+    Code
+      err(checker(alist(foo(), bar()), check_call))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a defused call, not a list.
+    Code
+      err(checker(quote(foo), check_call))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a defused call, not a symbol.
+
+# `check_environment()` checks
+
+    Code
+      err(checker(FALSE, check_environment))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be an environment, not `FALSE`.
+    Code
+      err(checker(list(env(), env()), check_environment))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be an environment, not a list.
+
+# `check_character()` checks
+
+    Code
+      err(checker(NA, check_character))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a character vector, not `NA`.
+    Code
+      err(checker(1, check_character))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a character vector, not a number.
+    Code
+      err(checker(list("foo", "bar"), check_character))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a character vector, not a list.
+

--- a/tests/testthat/helper-rlang.R
+++ b/tests/testthat/helper-rlang.R
@@ -109,3 +109,7 @@ arg_match0_wrapper <- function(arg, values, arg_nm = "arg", ...) {
 err <- function(...) {
   (expect_error(...))
 }
+
+checker <- function(foo, check) {
+  check(foo)
+}

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -339,23 +339,25 @@ test_that("precedence of associative ops", {
 })
 
 test_that("call functions type-check their input (#187)", {
-  x <- list(a = 1)
-  expect_error(call_modify(x, NULL), "must be a quoted call")
-  expect_error(call_standardise(x), "must be a quoted call")
-  expect_error(call_name(x), "must be a quoted call")
-  expect_error(call_args(x), "must be a quoted call")
-  expect_error(call_args_names(x), "must be a quoted call")
+  expect_snapshot({
+    x <- list(a = 1)
+    err(call_modify(x, NULL))
+    err(call_standardise(x))
+    err(call_name(x))
+    err(call_args(x))
+    err(call_args_names(x))
 
-  q <- quo(!!x)
-  expect_error(call_modify(q, NULL), "must be a quoted call")
-  expect_error(call_standardise(q), "must be a quoted call")
-  expect_error(call_name(q), "must be a quoted call")
-  expect_error(call_args(q), "must be a quoted call")
-  expect_error(call_args_names(q), "must be a quoted call")
+    q <- quo(!!x)
+    err(call_modify(q, NULL))
+    err(call_standardise(q))
+    err(call_name(q))
+    err(call_args(q))
+    err(call_args_names(q))
+  })
 })
 
 test_that("call_print_type() returns correct enum", {
-  expect_error(call_print_type(""), "must be a call")
+  expect_error(call_print_type(""), "must be a defused call")
   expect_identical(call_print_type(quote(foo())), "prefix")
 
   expect_identical(call_print_type(quote(~a)), "prefix")
@@ -434,7 +436,7 @@ test_that("call_print_type() returns correct enum", {
 })
 
 test_that("call_print_fine_type() returns correct enum", {
-  expect_error(call_print_fine_type(""), "must be a call")
+  expect_error(call_print_fine_type(""), "must be a defused call")
   expect_identical(call_print_fine_type(quote(foo())), "call")
 
   expect_identical(call_print_fine_type(quote(~a)), "prefix")
@@ -520,7 +522,7 @@ test_that("call_name() fails with namespaced objects (#670)", {
 })
 
 test_that("call_ns() retrieves namespaces", {
-  expect_error(call_ns(quote(foo)), "must be a quoted call")
+  expect_error(call_ns(quote(foo)), "must be a defused call")
   expect_null(call_ns(quote(foo())))
   expect_identical(call_ns(quote(foo::bar())), "foo")
   expect_identical(call_ns(quote(foo:::bar())), "foo")

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -1,8 +1,8 @@
 test_that("error_cnd() checks its fields", {
   expect_no_error(error_cnd(trace = NULL))
-  expect_error(error_cnd(trace = env()), "`trace` must be NULL or an rlang backtrace")
+  expect_error(error_cnd(trace = env()), "`trace` must be `NULL` or an rlang backtrace")
   expect_no_error(error_cnd(parent = NULL))
-  expect_error(error_cnd(parent = env()), "`parent` must be NULL or a condition object")
+  expect_error(error_cnd(parent = env()), "`parent` must be `NULL` or a condition object")
 })
 
 test_that("can use conditionMessage() method in subclasses of rlang errors", {

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -53,8 +53,8 @@ test_that("expr_name() with symbols, calls, and literals", {
   expect_identical(expr_name(function() NULL), "function () ...")
   expect_identical(expr_name(expr(function() { a; b })), "function() ...")
   expect_identical(expr_name(NULL), "NULL")
-  expect_error(expr_name(1:2), "must quote")
-  expect_error(expr_name(env()), "must quote")
+  expect_error(expr_name(1:2), "must be")
+  expect_error(expr_name(env()), "must be")
 })
 
 # --------------------------------------------------------------------

--- a/tests/testthat/test-nse-defuse.R
+++ b/tests/testthat/test-nse-defuse.R
@@ -388,7 +388,7 @@ test_that("endots() supports `.ignore_empty`", {
 test_that("ensyms() captures multiple symbols", {
   fn <- function(arg, ...) ensyms(arg, ...)
   expect_identical(fn(foo, bar, baz), exprs(foo, bar, baz))
-  expect_error(fn(foo()), "Only strings can be converted to symbols")
+  expect_snapshot(err(fn(foo())))
 })
 
 test_that("enquos() works with lexically scoped dots", {
@@ -492,13 +492,13 @@ test_that("ensym() unwraps quosures", {
   fn <- function(arg) ensym(arg)
   expect_identical(fn(!!quo(foo)), quote(foo))
   expect_identical(fn(!!quo("foo")), quote(foo))
-  expect_error(fn(!!quo(foo())), "Only strings can be converted to symbols")
+  expect_snapshot(err(fn(!!quo(foo()))))
 })
 
 test_that("ensyms() unwraps quosures", {
   fn <- function(...) ensyms(...)
   expect_identical(fn(!!!quos(foo, "bar")), exprs(foo, bar))
-  expect_error(fn(!!!quos(foo, bar())), "Only strings can be converted to symbols")
+  expect_snapshot(err(fn(!!!quos(foo, bar()))))
 })
 
 test_that("enquo0() and enquos0() capture arguments without injection", {

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -19,8 +19,10 @@ test_that("temporary connections are closed", {
 })
 
 test_that("parse_expr() throws meaningful error messages", {
-  expect_error(parse_expr(""), "No expression to parse")
-  expect_error(parse_expr("foo; bar"), "More than one expression parsed")
+  expect_snapshot({
+    err(parse_expr(""))
+    err(parse_expr("foo; bar"))
+  })
 })
 
 test_that("parse_exprs() and parse_quos() handle character vectors", {

--- a/tests/testthat/test-retired.R
+++ b/tests/testthat/test-retired.R
@@ -106,8 +106,8 @@ test_that("lang_modify() forwards to call_modify()", {
   fn <- function(foo = "bar") NULL
   call <- quote(fn(f = "foo"))
   expect_identical(
-    lang_modify(call, baz = "bam", .standardise = TRUE),
-    call_modify(call, baz = "bam", .standardise = TRUE)
+    lang_modify(call, baz = "bam", .standardise = FALSE),
+    call_modify(call, baz = "bam", .standardise = FALSE)
   )
 })
 
@@ -206,12 +206,6 @@ test_that("can standardise call frame", {
   fn <- function(foo = "bar") call_standardise(call_frame())
   expect_identical(fn(), quote(fn()))
   expect_identical(fn("baz"), quote(fn(foo = "baz")))
-})
-
-test_that("can modify call frame", {
-  fn <- function(foo = "bar") call_modify(call_frame(), baz = "bam", .standardise = TRUE)
-  expect_identical(fn(), quote(fn(baz = "bam")))
-  expect_identical(fn("foo"), quote(fn(foo = "foo", baz = "bam")))
 })
 
 # Beware some sys.x() take `n` and some take `which`

--- a/tests/testthat/test-state.R
+++ b/tests/testthat/test-state.R
@@ -16,7 +16,7 @@ test_that("is_interactive() is FALSE when testthat runs", {
 test_that("is_interactive() honors rlang_interactive option, above all else", {
   expect_true(with_options(rlang_interactive = TRUE, is_interactive()))
   expect_false(with_options(rlang_interactive = FALSE, is_interactive()))
-  expect_error(with_options(rlang_interactive = NA, is_interactive()), "must be a single")
+  expect_snapshot_error(with_options(rlang_interactive = NA, is_interactive()))
 
   local_interactive(FALSE)
   expect_false(is_interactive())

--- a/tests/testthat/test-sym.R
+++ b/tests/testthat/test-sym.R
@@ -1,7 +1,9 @@
 test_that("ensym() fails with calls", {
   capture_sym <- function(arg) ensym(arg)
   expect_identical(capture_sym(foo), quote(foo))
-  expect_error(capture_sym(foo(bar)), "Only strings can be converted to symbols")
+  expect_snapshot({
+    err(capture_sym(foo(bar)))
+  })
 })
 
 test_that("ensym() supports strings and symbols", {
@@ -31,8 +33,10 @@ test_that("is_symbol() matches any name in a vector", {
 })
 
 test_that("must supply strings to sym()", {
-  expect_error(sym(letters), "strings")
-  expect_error(sym(1:2), "strings")
+  expect_snapshot({
+    err(sym(letters))
+    err(sym(1:2))
+  })
 })
 
 test_that("data_sym() and data_syms() work", {

--- a/tests/testthat/test-types-check.R
+++ b/tests/testthat/test-types-check.R
@@ -1,0 +1,68 @@
+test_that("`check_bool()` checks", {
+  expect_null(check_bool(TRUE))
+  expect_null(check_bool(FALSE))
+
+  expect_snapshot({
+    err(checker(NA, check_bool))
+    err(checker(lgl(), check_bool))
+    err(checker(c(TRUE, FALSE), check_bool))
+    err(checker(1, check_bool))
+  })
+})
+
+test_that("`check_string()` checks", {
+  expect_null(check_string(""))
+  expect_null(check_string("foo"))
+
+  expect_snapshot({
+    err(checker(NA, check_string))
+    err(checker(chr(), check_string))
+    err(checker(na_chr, check_string))
+    err(checker(c("", ""), check_string))
+    err(checker(1, check_string))
+  })
+})
+
+test_that("`check_symbol()` checks", {
+  expect_null(check_symbol(quote(foo)))
+
+  expect_snapshot({
+    err(checker(TRUE, check_symbol))
+    err(checker(alist(foo, bar), check_symbol))
+    err(checker("foo", check_symbol))
+    err(checker(quote(foo()), check_symbol))
+  })
+})
+
+test_that("`check_call()` checks", {
+  expect_null(check_call(quote(foo())))
+
+  expect_snapshot({
+    err(checker(TRUE, check_call))
+    err(checker(alist(foo(), bar()), check_call))
+    err(checker(quote(foo), check_call))
+  })
+})
+
+test_that("`check_environment()` checks", {
+  expect_null(check_environment(env()))
+
+  expect_snapshot({
+    err(checker(FALSE, check_environment))
+    err(checker(list(env(), env()), check_environment))
+  })
+})
+
+test_that("`check_character()` checks", {
+  expect_null(check_character(""))
+  expect_null(check_character(na_chr))
+  expect_null(check_character(chr()))
+  expect_null(check_character("foo"))
+  expect_null(check_character(letters))
+
+  expect_snapshot({
+    err(checker(NA, check_character))
+    err(checker(1, check_character))
+    err(checker(list("foo", "bar"), check_character))
+  })
+})


### PR DESCRIPTION
Branched from #1335.

*  `compat-friendly-type-of.R` gains `stop_input_type()` to throw input type errors using friendly types.

*  New `types-check.R` file with input checkers of the form `check_symbol()`, `check_character()`.
    Each checker takes:
    * An `arg` argument which gets properly formatted.
    * A `call` argument to include in the error condition.
    * `...` passed on to `abort()`.
    * A friendly expected type `what` passed on to `stop_input_type()`.

The second commit goes through the codebase and uses these new utils to make the error messages more consistent and ensure they use the correct `call`.