### PR TITLE
Improve error message in as_version_info()

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -149,9 +149,15 @@ as_version_info <- function(pkg, call = caller_env()) {
   ver <- sub(version_regex, "\\2", pkg)
   ver <- strsplit(ver, " ")
 
-  if (!every(ver, is_character2, n = 2, missing = FALSE, empty = FALSE)) {
+  parsed <- vapply(
+    ver, is_character2, n = 2, missing = FALSE, empty = FALSE,
+    logical(1L)
+  )
+
+  if (!all(parsed)) {
+    error_pkg <- format_arg(pkg[!parsed][[1L]])
     abort(
-      sprintf("Can't parse version in %s.", format_arg("pkg")),
+      sprintf("Can't parse version in %s.", error_pkg),
       call = call
     )
   }

--- a/R/session.R
+++ b/R/session.R
@@ -151,7 +151,7 @@ as_version_info <- function(pkg, call = caller_env()) {
 
   parsed <- vapply(
     ver, is_character2, n = 2, missing = FALSE, empty = FALSE,
-    logical(1L)
+    FUN.VALUE = logical(1L)
   )
 
   if (!all(parsed)) {


### PR DESCRIPTION
My proposal to clear up the error message in `as_version_info()` as described in #1347 