### PR TITLE
Don't use `_t` suffix

### DIFF
--- a/src/internal/cnd-handlers.c
+++ b/src/internal/cnd-handlers.c
@@ -25,10 +25,10 @@ r_obj* ffi_try_fetch(r_obj* try_fetch_args) {
   // Build handlers arguments with updated index into the `handlers` list.
   // See `handler_call` at R level for the template.
   r_obj* args = r_null;
-  r_keep_t shelter; KEEP_HERE(args, &shelter);
+  r_keep_loc shelter; KEEP_HERE(args, &shelter);
 
   r_obj* exiting_args = r_null;
-  r_keep_t exiting_shelter; KEEP_HERE(exiting_args, &exiting_shelter);
+  r_keep_loc exiting_shelter; KEEP_HERE(exiting_args, &exiting_shelter);
 
   for (int i = n - 1; i >= 0; --i) {
     r_obj* cls = v_classes[i];

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -489,7 +489,7 @@ r_obj* dots_unquote(r_obj* dots, struct dots_capture_info* capture_info) {
         expr = r_eval(expr, env);
       }
 
-      r_keep_t i;
+      r_keep_loc i;
       KEEP_HERE(expr, &i);
 
       if (is_splice_box(expr)) {

--- a/src/internal/encoding.c
+++ b/src/internal/encoding.c
@@ -91,7 +91,7 @@ r_ssize chr_find_encoding_start(r_obj* x, r_ssize size) {
 
 static
 r_obj* list_encode_utf8(r_obj* x) {
-  r_keep_t pi;
+  r_keep_loc pi;
   KEEP_HERE(x, &pi);
 
   r_ssize size = r_length(x);
@@ -143,7 +143,7 @@ r_obj* attrib_encode_utf8(r_obj* x) {
   r_ssize loc = 0;
   bool owned = false;
 
-  r_keep_t pi;
+  r_keep_loc pi;
   KEEP_HERE(x, &pi);
 
   for (r_obj* node = x; node != r_null; node = r_node_cdr(node), ++loc) {

--- a/src/internal/replace-na.c
+++ b/src/internal/replace-na.c
@@ -70,7 +70,7 @@ r_obj* ffi_replace_na(r_obj* x, r_obj* replacement) {
   }
 
   case R_TYPE_complex: {
-    r_complex_t* arr = r_cpl_begin(x);
+    r_complex* arr = r_cpl_begin(x);
 
     for (; i < n; ++i) {
       if (ISNA(arr[i].r)) {
@@ -143,8 +143,8 @@ static r_obj* replace_na_(r_obj* x, r_obj* replacement, int i) {
   }
 
   case R_TYPE_complex: {
-    r_complex_t* arr = r_cpl_begin(x);
-    r_complex_t new_value = r_cpl_get(replacement, 0);
+    r_complex* arr = r_cpl_begin(x);
+    r_complex new_value = r_cpl_get(replacement, 0);
 
     for (; i < n; ++i) {
       if (ISNA(arr[i].r)) {
@@ -209,7 +209,7 @@ static r_obj* replace_na_vec_(r_obj* x, r_obj* replacement, int i) {
   }
 
   case R_TYPE_complex: {
-    r_complex_t* arr = r_cpl_begin(x);
+    r_complex* arr = r_cpl_begin(x);
     for (; i < n; ++i) {
       if (ISNA(arr[i].r)) {
         arr[i] = r_cpl_get(replacement, i);

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -93,7 +93,7 @@ void r_dyn_dbl_push_back(struct r_dyn_array* p_vec, double elt) {
   r_dyn_push_back(p_vec, &elt);
 }
 static inline
-void r_dyn_cpl_push_back(struct r_dyn_array* p_vec, r_complex_t elt) {
+void r_dyn_cpl_push_back(struct r_dyn_array* p_vec, r_complex elt) {
   r_dyn_push_back(p_vec, &elt);
 }
 static inline
@@ -119,8 +119,8 @@ double r_dyn_dbl_get(struct r_dyn_array* p_vec, r_ssize i) {
   return ((const double*) p_vec->v_data_const)[i];
 }
 static inline
-r_complex_t r_dyn_cpl_get(struct r_dyn_array* p_vec, r_ssize i) {
-  return ((const r_complex_t*) p_vec->v_data_const)[i];
+r_complex r_dyn_cpl_get(struct r_dyn_array* p_vec, r_ssize i) {
+  return ((const r_complex*) p_vec->v_data_const)[i];
 }
 static inline
 char r_dyn_raw_get(struct r_dyn_array* p_vec, r_ssize i) {
@@ -148,8 +148,8 @@ void r_dyn_dbl_poke(struct r_dyn_array* p_vec, r_ssize i, double value) {
   ((double*) p_vec->v_data)[i] = value;
 }
 static inline
-void r_dyn_cpl_poke(struct r_dyn_array* p_vec, r_ssize i, r_complex_t value) {
-  ((r_complex_t*) p_vec->v_data)[i] = value;
+void r_dyn_cpl_poke(struct r_dyn_array* p_vec, r_ssize i, r_complex value) {
+  ((r_complex*) p_vec->v_data)[i] = value;
 }
 static inline
 void r_dyn_raw_poke(struct r_dyn_array* p_vec, r_ssize i, char value) {

--- a/src/rlang/globals.c
+++ b/src/rlang/globals.c
@@ -28,7 +28,7 @@ void r_init_library_globals(r_obj* ns) {
   r_globals.na_lgl = NA_LOGICAL;
   r_globals.na_int = NA_INTEGER;
   r_globals.na_dbl = NA_REAL;
-  r_globals.na_cpl = (r_complex_t) { NA_REAL, NA_REAL };
+  r_globals.na_cpl = (r_complex) { NA_REAL, NA_REAL };
   r_globals.na_str = NA_STRING;
 
   r_preserve_global(r_chrs.empty_string = r_chr(""));

--- a/src/rlang/globals.h
+++ b/src/rlang/globals.h
@@ -14,7 +14,7 @@ struct r_globals {
   int na_lgl;
   int na_int;
   double na_dbl;
-  r_complex_t na_cpl;
+  r_complex na_cpl;
   r_obj* na_str;
 };
 

--- a/src/rlang/rlang-types.h
+++ b/src/rlang/rlang-types.h
@@ -21,7 +21,7 @@
 #define r_no_return __attribute__ ((noreturn))
 
 typedef struct SEXPREC r_obj;
-typedef Rcomplex r_complex_t;
+typedef Rcomplex r_complex;
 
 typedef R_xlen_t r_ssize;
 #define R_SSIZE_MAX R_XLEN_T_MAX
@@ -89,7 +89,7 @@ struct r_pair_callback {
 #define KEEP2(x, y) (KEEP(x), KEEP(y))
 #define KEEP_N(x, n) (++(*n), KEEP(x))
 
-#define r_keep_t PROTECT_INDEX
+#define r_keep_loc PROTECT_INDEX
 #define KEEP_AT REPROTECT
 #define KEEP_HERE PROTECT_WITH_INDEX
 

--- a/src/rlang/vec.c
+++ b/src/rlang/vec.c
@@ -81,7 +81,7 @@ r_obj* r_dbl_resize(r_obj* x, r_ssize size) {
   RESIZE(R_TYPE_double, double, r_dbl_cbegin, r_dbl_begin);
 }
 r_obj* r_cpl_resize(r_obj* x, r_ssize size) {
-  RESIZE(R_TYPE_complex, r_complex_t, r_cpl_cbegin, r_cpl_begin);
+  RESIZE(R_TYPE_complex, r_complex, r_cpl_cbegin, r_cpl_begin);
 }
 r_obj* r_raw_resize(r_obj* x, r_ssize size) {
   RESIZE(R_TYPE_raw, unsigned char, r_raw_cbegin, r_raw_begin);
@@ -188,8 +188,8 @@ void r_vec_poke_n(r_obj* x, r_ssize offset,
     break;
   }
   case R_TYPE_complex: {
-    r_complex_t* src_data = r_cpl_begin(y);
-    r_complex_t* dest_data = r_cpl_begin(x);
+    r_complex* src_data = r_cpl_begin(y);
+    r_complex* dest_data = r_cpl_begin(x);
     for (r_ssize i = 0; i != n; ++i)
       dest_data[i + offset] = src_data[i + from];
     break;
@@ -250,7 +250,7 @@ bool _r_is_finite(r_obj* x) {
     break;
   }
   case R_TYPE_complex: {
-    const r_complex_t* p_x = r_cpl_cbegin(x);
+    const r_complex* p_x = r_cpl_cbegin(x);
     for (r_ssize i = 0; i < n; ++i) {
       if (!isfinite(p_x[i].r) || !isfinite(p_x[i].i)) {
         return false;

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -17,7 +17,7 @@ double* r_dbl_begin(r_obj* x) {
   return REAL(x);
 }
 static inline
-r_complex_t* r_cpl_begin(r_obj* x) {
+r_complex* r_cpl_begin(r_obj* x) {
   return COMPLEX(x);
 }
 static inline
@@ -38,8 +38,8 @@ const double* r_dbl_cbegin(r_obj* x) {
   return (const double*) REAL(x);
 }
 static inline
-const r_complex_t* r_cpl_cbegin(r_obj* x) {
-  return (const r_complex_t*) COMPLEX(x);
+const r_complex* r_cpl_cbegin(r_obj* x) {
+  return (const r_complex*) COMPLEX(x);
 }
 static inline
 const void* r_raw_cbegin(r_obj* x) {
@@ -98,7 +98,7 @@ int r_vec_elt_sizeof0(enum r_type type) {
   case R_TYPE_logical: return sizeof(int);
   case R_TYPE_integer: return sizeof(int);
   case R_TYPE_double: return sizeof(double);
-  case R_TYPE_complex: return sizeof(r_complex_t);
+  case R_TYPE_complex: return sizeof(r_complex);
   case R_TYPE_raw: return sizeof(char);
   case R_TYPE_character: return sizeof(r_obj*);
   case R_TYPE_list: return sizeof(r_obj*);
@@ -123,7 +123,7 @@ double r_dbl_get(r_obj* x, r_ssize i) {
   return REAL(x)[i];
 }
 static inline
-r_complex_t r_cpl_get(r_obj* x, r_ssize i) {
+r_complex r_cpl_get(r_obj* x, r_ssize i) {
   return COMPLEX(x)[i];
 }
 static inline
@@ -156,7 +156,7 @@ void r_dbl_poke(r_obj* x, r_ssize i, double y) {
   REAL(x)[i] = y;
 }
 static inline
-void r_cpl_poke(r_obj* x, r_ssize i, r_complex_t y) {
+void r_cpl_poke(r_obj* x, r_ssize i, r_complex y) {
   COMPLEX(x)[i] = y;
 }
 static inline
@@ -231,7 +231,7 @@ r_obj* r_dbl(double x) {
   return Rf_ScalarReal(x);
 }
 static inline
-r_obj* r_cpl(r_complex_t x) {
+r_obj* r_cpl(r_complex x) {
   return Rf_ScalarComplex(x);
 }
 static inline
@@ -374,14 +374,14 @@ double r_as_double(r_obj* x) {
 }
 
 static inline
-r_complex_t r_arg_as_complex(r_obj* x, const char* arg) {
+r_complex r_arg_as_complex(r_obj* x, const char* arg) {
   if (!_r_is_complex(x, 1, 1)) {
     r_abort("`%s` must be a complex value.", arg);
   }
   return r_cpl_get(x, 0);
 }
 static inline
-r_complex_t r_as_complex(r_obj* x) {
+r_complex r_as_complex(r_obj* x) {
   return r_arg_as_complex(x, "x");
 }
 


### PR DESCRIPTION
For consistency with `r_ssize`, `r_obj`, etc., rename:

- `r_complex_t` to `r_complex`
- `r_keep_t` to `r_keep_loc`