### PR TITLE
Include `<exception>` header in `rlang.hpp`

### DIFF
--- a/src/rlang/cpp/vec.cpp
+++ b/src/rlang/cpp/vec.cpp
@@ -1,5 +1,5 @@
-#include <algorithm>
 #include <rlang.hpp>
+#include <algorithm>
 
 extern "C" {
 

--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <exception>
 using std::isfinite;
 
 // Include Rinternals.h with C++ linkage to avoid rlang including it while


### PR DESCRIPTION
It is used in `rcc_abort()` below. The only reason this hasn't caused issues so far is because the only place this header is included is in `vec.cpp`, which includes `<algorithm>` first and that includes the exception header, so we don't see the issue

I have also flipped the order of includes in `vec.cpp` because I believe that including your own headers first is better practice. See also https://github.com/tidyverse/readxl/commit/1059a768436df38fb7b33f8e0415c18585c11ac5