### PR TITLE
Make `rlang.hpp` more inclusion friendly

### DIFF
--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -27,6 +27,7 @@ extern "C" {
 #undef class
 }
 
+static inline
 r_no_return
 void rcc_abort(const char* fn) {
  try {

--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -1,3 +1,6 @@
+#ifndef RLANG_RLANG_HPP
+#define RLANG_RLANG_HPP
+
 #include <cmath>
 #include <exception>
 using std::isfinite;
@@ -35,3 +38,5 @@ void rcc_abort(const char* fn) {
    (r_stop_internal)("", -1, call, "Caught unknown C++ exception.");
  }
 }
+
+#endif


### PR DESCRIPTION
- Added header guards
- Make `rcc_abort()` `static inline`, since it is defined in a header file