### PR TITLE
Rename `r_syms.class` to `r_syms.class_`

### DIFF
--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -1065,7 +1065,7 @@ void rlang_init_dots(r_obj* ns) {
     r_preserve(splice_box_attrib);
     r_mark_shared(splice_box_attrib);
 
-    r_node_poke_tag(splice_box_attrib, r_syms.class);
+    r_node_poke_tag(splice_box_attrib, r_syms.class_);
     FREE(1);
   }
 
@@ -1086,7 +1086,7 @@ void rlang_init_dots(r_obj* ns) {
     r_preserve(quosures_attrib);
     r_mark_shared(quosures_attrib);
 
-    r_node_poke_tag(quosures_attrib, r_syms.class);
+    r_node_poke_tag(quosures_attrib, r_syms.class_);
     FREE(1);
   }
 

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -45,7 +45,7 @@ static r_obj* rlang_new_data_pronoun(r_obj* mask) {
   r_obj* pronoun = KEEP(r_alloc_list(1));
 
   r_list_poke(pronoun, 0, mask);
-  r_attrib_poke(pronoun, r_syms.class, data_pronoun_class);
+  r_attrib_poke(pronoun, r_syms.class_, data_pronoun_class);
 
   FREE(1);
   return pronoun;
@@ -53,7 +53,7 @@ static r_obj* rlang_new_data_pronoun(r_obj* mask) {
 static r_obj* rlang_new_ctxt_pronoun(r_obj* top) {
   r_obj* pronoun = KEEP(r_alloc_environment(0, r_env_parent(top)));
 
-  r_attrib_poke(pronoun, r_syms.class, ctxt_pronoun_class);
+  r_attrib_poke(pronoun, r_syms.class_, ctxt_pronoun_class);
 
   FREE(1);
   return pronoun;

--- a/src/rlang/attrib.c
+++ b/src/rlang/attrib.c
@@ -134,7 +134,7 @@ static
 r_obj* node_push_classes(r_obj* node, const char** tags, r_ssize n) {
   r_obj* tags_chr = KEEP(r_chr_n(tags, n));
   r_obj* attrs = r_new_node(tags_chr, node);
-  r_node_poke_tag(attrs, r_syms.class);
+  r_node_poke_tag(attrs, r_syms.class_);
 
   FREE(1);
   return attrs;

--- a/src/rlang/attrib.h
+++ b/src/rlang/attrib.h
@@ -31,11 +31,11 @@ r_obj* r_attrib_set(r_obj* x, r_obj* tag, r_obj* value);
 
 static inline
 r_obj* r_class(r_obj* x) {
-  return r_attrib_get(x, r_syms.class);
+  return r_attrib_get(x, r_syms.class_);
 }
 static inline
 void r_attrib_poke_class(r_obj* x, r_obj* classes) {
-  r_attrib_poke(x, r_syms.class, classes);
+  r_attrib_poke(x, r_syms.class_, classes);
 }
 
 void r_attrib_push_class(r_obj* x, const char* tag);
@@ -72,7 +72,7 @@ bool r_is_named(r_obj* x);
 
 
 #define r_attrib_poke(X, SYM, VALUE) Rf_setAttrib(X, SYM, VALUE)
-#define r_attrib_poke_class(X, VALUE) Rf_setAttrib(X, r_syms.class, VALUE)
+#define r_attrib_poke_class(X, VALUE) Rf_setAttrib(X, r_syms.class_, VALUE)
 #define r_attrib_poke_dim(X, VALUE) Rf_setAttrib(X, r_syms.dim, VALUE)
 #define r_attrib_poke_dim_names(X, VALUE) Rf_setAttrib(X, r_syms.dim_names, VALUE)
 #define r_attrib_poke_names(X, VALUE) Rf_setAttrib(X, r_syms.names, VALUE)

--- a/src/rlang/df.c
+++ b/src/rlang/df.c
@@ -32,11 +32,11 @@ r_obj* r_alloc_df_list(r_ssize n_rows,
 
 void r_init_data_frame(r_obj* x, r_ssize n_rows) {
   init_compact_rownames(x, n_rows);
-  r_attrib_poke(x, r_syms.class, r_classes.data_frame);
+  r_attrib_poke(x, r_syms.class_, r_classes.data_frame);
 }
 void r_init_tibble(r_obj* x, r_ssize n_rows) {
   r_init_data_frame(x, n_rows);
-  r_attrib_poke(x, r_syms.class, r_classes.tibble);
+  r_attrib_poke(x, r_syms.class_, r_classes.tibble);
 }
 
 static

--- a/src/rlang/dict.c
+++ b/src/rlang/dict.c
@@ -50,7 +50,7 @@ struct r_dict* r_new_dict(r_ssize size) {
   p_dict->p_buckets = r_list_cbegin(p_dict->buckets);
   p_dict->n_buckets = size;
 
-  r_attrib_poke(shelter, r_syms.class, r_chr("rlang_dict"));
+  r_attrib_poke(shelter, r_syms.class_, r_chr("rlang_dict"));
 
   FREE(1);
   return p_dict;

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -117,5 +117,5 @@ void r_dyn_resize(struct r_dyn_array* p_arr,
 
 void r_init_library_dyn_array() {
   r_preserve_global(attribs_dyn_array = r_pairlist(r_chr("rlang_dyn_array")));
-  r_node_poke_tag(attribs_dyn_array, r_syms.class);
+  r_node_poke_tag(attribs_dyn_array, r_syms.class_);
 }

--- a/src/rlang/globals.c
+++ b/src/rlang/globals.c
@@ -60,7 +60,7 @@ void r_init_library_globals_syms() {
   r_syms.brackets = R_BracketSymbol;
   r_syms.brackets2 = R_Bracket2Symbol;
   r_syms.call = r_sym("call");
-  r_syms.class = R_ClassSymbol;
+  r_syms.class_ = R_ClassSymbol;
   r_syms.colon2 = R_DoubleColonSymbol;
   r_syms.colon3 = R_TripleColonSymbol;
   r_syms.condition = r_sym("condition");

--- a/src/rlang/globals.h
+++ b/src/rlang/globals.h
@@ -44,7 +44,7 @@ struct r_globals_syms {
   r_obj* brackets;
   r_obj* brackets2;
   r_obj* call;
-  r_obj* class;
+  r_obj* class_;
   r_obj* condition;
   r_obj* dots;
   r_obj* dot_environment;

--- a/src/rlang/globals.h
+++ b/src/rlang/globals.h
@@ -44,6 +44,8 @@ struct r_globals_syms {
   r_obj* brackets;
   r_obj* brackets2;
   r_obj* call;
+  // `_` is required to avoid conflicts with the C++ keyword `class`.
+  // See https://github.com/r-lib/rlang/pull/1359 for details.
   r_obj* class_;
   r_obj* condition;
   r_obj* dots;

--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -3,11 +3,6 @@
 
 #include <exception>
 
-// Include Rinternals.h with C++ linkage to avoid rlang including it while
-// having C linkage, which causes issues with the GHA Mac machine
-#define R_NO_REMAP
-#include <Rinternals.h>
-
 extern "C" {
 #include <rlang.h>
 }

--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -11,20 +11,7 @@ using std::isfinite;
 #include <Rinternals.h>
 
 extern "C" {
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wkeyword-macro"
-#endif
-
-#define class klass
-
-#ifdef __clang__
-# pragma clang diagnostic pop
-#endif
-
 #include <rlang.h>
-
-#undef class
 }
 
 static inline

--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -1,9 +1,7 @@
 #ifndef RLANG_RLANG_HPP
 #define RLANG_RLANG_HPP
 
-#include <cmath>
 #include <exception>
-using std::isfinite;
 
 // Include Rinternals.h with C++ linkage to avoid rlang including it while
 // having C linkage, which causes issues with the GHA Mac machine


### PR DESCRIPTION
Follow up to https://github.com/r-lib/rlang/commit/70c90a8be9987c0b1fb96a74fd9d84d839b5d7ae and https://github.com/r-lib/rlang/commit/30cae2afc181c3ddfbb59a3fd5d323f919831413

We previously added workarounds to the fact that C++ doesn't like you to use `class` as a variable name at all by redefining it to `klass` before including `<rlang.h>`. This currently works, but I am afraid it is extremely brittle and is the reason for many other hacks we have had to do to make the C and C++ code here play nicely together.

I propose moving from `r_syms.class` to `r_syms.class_`, which is better than `cls` or `klass` because it works with auto-complete. That way in the future we won't ever think that we don't have a symbol for `class` and try and add one back in.

If you look at the `rlang.hpp` file now, it has become extremely simple, with all hacks removed.

---

There are 3 distinct hacks that we had to make, which we no longer have to make if we make this change.

1. The early inclusion of `<Rinternals.h>`. We did this because in rray3 I had found that this was necessary when using my own custom top level `rlang.h` C++ header that included the rlang C library. i.e. this commit https://github.com/DavisVaughan/rray3/commit/d5a0e4d3beb050816e886993c17673e61560b373#diff-25a6634263c1b1f6fc4697a04e2b9904ea4b042a89af59dc93ec1f5d44848a26. Now that I am just supposed to include the `<rlang.hpp>` that rlang already provides, this is no longer needed. I have tested here that we can no longer reproduce the original Mac issue on GitHub actions after making this change https://github.com/DavisVaughan/rray3/pull/1

2. The need for `klass`. This one is self explanatory, but now that we use `class_` we don't need to redefine the `class` symbol to `klass`. This is a big win though, because it leads into point 3

3. No need for early includes of `<cmath>` and `using std::isfinite`. This one is a bit of a head scratcher, but I think I figured out how this is related to `klass`.
    - `rlang.hpp` does the `extern "C"` inclusion of `<rlang.h>`, the whole rlang lib
    - That includes the `c-utils.h` header, which requires including `math.h` for `isfinite()` https://github.com/r-lib/rlang/blob/9df0a25768d6c7ba32da79a3aa3dcc8da3c69e42/src/rlang/c-utils.h#L4
    - Now, `math.h` is defined in both C and C++, and the C++ one is a bit special and is the one getting included here. On my computer, it has the special behavior in the code block below. This means that it swaps back to C++ linkage temporarily to add definitions for some template functions, which involve using the `class` keyword. Now, we redefined `class` to be `klass` at this moment in time, which C++ complains about because it looks like an unknown type (see further below). The "fix" was to include `<cmath>` very early on, which ensures that this all gets included before the redefinition to `klass`. But I am worried there are other headers that do the same thing, and trying to use them in the C rlang library will end up causing issues like this in the C++ bits.

```c++
#ifdef __cplusplus

// We support including .h headers inside 'extern "C"' contexts, so switch
// back to C++ linkage before including these C++ headers.
extern "C++" {

#include <type_traits>
#include <limits>

// signbit

#ifdef signbit

template <class _A1>
_LIBCPP_INLINE_VISIBILITY
bool
__libcpp_signbit(_A1 __lcpp_x) _NOEXCEPT
{
    return signbit(__lcpp_x);
}

#undef signbit
``` 

```c++
In file included from /Library/Developer/CommandLineTools/usr/include/c++/v1/math.h:310:
   /Library/Developer/CommandLineTools/usr/include/c++/v1/limits:141:20: error: a non-type template parameter cannot have type 'class _Tp'
   template <class _Tp, bool = is_arithmetic<_Tp>::value>
                      ^
   /Library/Developer/CommandLineTools/usr/include/c++/v1/limits:142:1: error: unknown type name 'klass'; did you mean 'class'?
   class __libcpp_numeric_limits
   ^
   ./rlang/rlang.hpp:17:15: note: expanded from macro 'class'
   #define class klass
                 ^
```