### PR TITLE
Fix trace creation performance regression

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rlang (development version)
 
+* `is_call()` is now implemented in C for performance.
+
+* Fixed performance regression in `trace_back()`.
+
 * Fixed a partial matching issue with `header`, `body`, and `footer`
   condition fields.
 

--- a/R/call.R
+++ b/R/call.R
@@ -234,54 +234,7 @@ is_callable <- function(x) {
 #' is_call(quote(foo(bar)), c("bar", "foo"))
 #' is_call(quote(base::list), c("::", ":::", "$", "@"))
 is_call <- function(x, name = NULL, n = NULL, ns = NULL) {
-  if (typeof(x) != "language") {
-    return(FALSE)
-  }
-
-  if (!is_null(ns)) {
-    good_ns <- FALSE
-
-    for (elt in ns) {
-      if (identical(elt, "") && !is_namespaced_call(x, private = FALSE)) {
-        good_ns <- TRUE
-        break
-      } else if (is_namespaced_call(x, elt, private = FALSE)) {
-        good_ns <- TRUE
-        break
-      }
-    }
-
-    if (!good_ns) {
-      return(FALSE)
-    }
-  }
-
-  x <- call_unnamespace(x)
-
-  if (!is_null(name)) {
-    # Wrap language objects in a list
-    if (!is_vector(name)) {
-      name <- list(name)
-    }
-
-    unmatched <- TRUE
-    for (elt in name) {
-      if (identical(node_car(x), sym(elt))) {
-        unmatched <- FALSE
-        break
-      }
-    }
-
-    if (unmatched) {
-      return(FALSE)
-    }
-  }
-
-  if (!is_null(n) && !has_length(x, n + 1L)) {
-    return(FALSE)
-  }
-
-  TRUE
+  .Call(ffi_is_call, x, name, n, ns)
 }
 
 # Until `is_call()` is fixed

--- a/R/call.R
+++ b/R/call.R
@@ -1057,22 +1057,10 @@ call_type <- function(x) {
 }
 
 call_zap_inline <- function(x) {
-  if (is_call(x)) {
-    if (is_call(x, "function")) {
-      if (!is_null(x[[2]])) {
-        x[[2]] <- as.pairlist(map(x[[2]], call_zap_inline))
-      }
-      x[[3]] <- call_zap_inline(x[[3]])
-    } else {
-      x[] <- map(x, call_zap_inline)
-    }
-    return(x)
-  }
+  .Call(ffi_call_zap_inline, x)
+}
 
-  if (is_symbol(x) || is_syntactic_literal(x)) {
-    x
-  } else {
-    name <- sprintf("<%s>", rlang_type_sum(x))
-    sym(name)
-  }
+# Called from C
+call_type_sum <- function(x) {
+  sym(sprintf("<%s>", rlang_type_sum(x)))
 }

--- a/R/node.R
+++ b/R/node.R
@@ -88,7 +88,7 @@ node_poke_cddr <- function(x, newcdr) {
 }
 
 node_get <- function(node, i) {
-  if (node < 1L) {
+  if (i < 1L) {
     abort("`i` must be an integer greater than 0.")
   }
   while (i > 1L) {

--- a/R/trace.R
+++ b/R/trace.R
@@ -109,7 +109,7 @@ trace_back <- function(top = NULL, bottom = NULL) {
   calls <- map(calls, call_zap_inline)
 
   context <- map2(calls, seq_along(calls), call_trace_context)
-  context <- inject(vec_rbind(empty_trace_context(), !!!context))
+  context <- inject(rbind(empty_trace_context(), !!!context))
 
   parents <- normalise_parents(parents)
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -108,11 +108,13 @@ trace_back <- function(top = NULL, bottom = NULL) {
   calls <- map(calls, call_fix_car)
   calls <- map(calls, call_zap_inline)
 
-  context_data <- map2(calls, seq_along(calls), call_trace_context)
-
   context <- empty_trace_context()
-  context$namespace <- do.call(base::c, map(context_data, `[[`, "namespace"))
-  context$scope <- do.call(base::c, map(context_data, `[[`, "scope"))
+
+  if (length(calls)) {
+    context_data <- map2(calls, seq_along(calls), call_trace_context)
+    context$namespace <- do.call(base::c, map(context_data, `[[`, "namespace"))
+    context$scope <- do.call(base::c, map(context_data, `[[`, "scope"))
+  }
   context <- new_data_frame(context)
 
   parents <- normalise_parents(parents)

--- a/R/trace.R
+++ b/R/trace.R
@@ -108,8 +108,12 @@ trace_back <- function(top = NULL, bottom = NULL) {
   calls <- map(calls, call_fix_car)
   calls <- map(calls, call_zap_inline)
 
-  context <- map2(calls, seq_along(calls), call_trace_context)
-  context <- inject(rbind(empty_trace_context(), !!!context))
+  context_data <- map2(calls, seq_along(calls), call_trace_context)
+
+  context <- empty_trace_context()
+  context$namespace <- do.call(base::c, map(context_data, `[[`, "namespace"))
+  context$scope <- do.call(base::c, map(context_data, `[[`, "scope"))
+  context <- new_data_frame(context)
 
   parents <- normalise_parents(parents)
 
@@ -240,7 +244,7 @@ call_trace_context <- function(call, fn) {
 }
 
 trace_context <- function(namespace = NA, scope = NA) {
-  data_frame(
+  list(
     namespace = namespace,
     scope = scope
   )

--- a/src/internal/decl/call-decl.h
+++ b/src/internal/decl/call-decl.h
@@ -1,2 +1,20 @@
 static
 bool is_callable(r_obj* x);
+
+static
+void call_zap_inline(r_obj* x);
+
+static
+void node_zap_inline(r_obj* x);
+
+static
+r_obj* call_zap_one(r_obj* x);
+
+static
+void call_zap_fn(r_obj* x);
+
+static
+r_obj* type_sum(r_obj* x);
+
+static
+r_obj* type_sum_call;

--- a/src/internal/decl/call-decl.h
+++ b/src/internal/decl/call-decl.h
@@ -1,4 +1,10 @@
 static
+bool call_is_namespaced(r_obj* x, r_obj* ns);
+
+static inline
+r_obj* call_unnamespace(r_obj* x);
+
+static
 bool is_callable(r_obj* x);
 
 static

--- a/src/internal/exported.c
+++ b/src/internal/exported.c
@@ -849,25 +849,6 @@ r_obj* ffi_vec_poke_range(r_obj* x, r_obj* offset,
   return x;
 }
 
-static r_ssize validate_n(r_obj* n) {
-  if (n == r_null) {
-    return -1;
-  }
-
-  switch (r_typeof(n)) {
-  case R_TYPE_integer:
-  case R_TYPE_double:
-    if (r_length(n) == 1) {
-      break;
-    }
-    // fallthrough
-  default:
-    r_abort("`n` must be NULL or a scalar integer");
-  }
-
-  return r_arg_as_ssize(n, "n");
-}
-
 static int validate_finite(r_obj* finite) {
   switch (r_typeof(finite)) {
   case R_TYPE_null:

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -101,6 +101,7 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_interp",                       (DL_FUNC) &ffi_interp, 2},
   {"ffi_interrupt",                    (DL_FUNC) &ffi_interrupt, 0},
   {"ffi_is_atomic",                    (DL_FUNC) &ffi_is_atomic, 2},
+  {"ffi_is_call",                      (DL_FUNC) &ffi_is_call, 4},
   {"ffi_is_character",                 (DL_FUNC) &ffi_is_character, 4},
   {"ffi_is_closure",                   (DL_FUNC) &ffi_is_closure, 1},
   {"ffi_is_complex",                   (DL_FUNC) &ffi_is_complex, 3},

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -16,6 +16,7 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_attrib",                       (DL_FUNC) &r_attrib, 1},
   {"ffi_c_tests",                      (DL_FUNC) &ffi_c_tests, 0},
   {"ffi_call_has_precedence",          (DL_FUNC) &ffi_call_has_precedence, 3},
+  {"ffi_call_zap_inline",              (DL_FUNC) &ffi_call_zap_inline, 1},
   {"ffi_chr_get",                      (DL_FUNC) &ffi_chr_get, 2},
   {"ffi_chr_has_curly",                (DL_FUNC) &ffi_chr_has_curly, 1},
   {"ffi_cnd_signal",                   (DL_FUNC) &ffi_cnd_signal, 1},

--- a/src/internal/internal.c
+++ b/src/internal/internal.c
@@ -43,12 +43,11 @@ r_obj* rlang_objs_trailing = NULL;
 r_obj* fns_function = NULL;
 r_obj* fns_quote = NULL;
 
-void rlang_init_arg(r_obj* ns);
-
 void rlang_init_internal(r_obj* ns) {
   rlang_init_utils();
   rlang_init_arg(ns);
   rlang_init_attr(ns);
+  rlang_init_call(ns);
   rlang_init_cnd(ns);
   rlang_init_cnd_handlers(ns);
   rlang_init_dots(ns);

--- a/src/internal/vec.c
+++ b/src/internal/vec.c
@@ -161,6 +161,25 @@ bool r_is_raw(r_obj* x, r_ssize n) {
   return r_typeof(x) == R_TYPE_raw && _r_has_correct_length(x, n);
 }
 
+r_ssize validate_n(r_obj* n) {
+  if (n == r_null) {
+    return -1;
+  }
+
+  switch (r_typeof(n)) {
+  case R_TYPE_integer:
+  case R_TYPE_double:
+    if (r_length(n) == 1) {
+      break;
+    }
+    // fallthrough
+  default:
+    r_abort("`n` must be NULL or a scalar integer");
+  }
+
+  return r_arg_as_ssize(n, "n");
+}
+
 
 // Coercion ----------------------------------------------------------
 

--- a/src/internal/vec.h
+++ b/src/internal/vec.h
@@ -23,6 +23,8 @@ bool is_character(r_obj* x,
                   enum option_bool empty);
 bool r_is_raw(r_obj* x, r_ssize n);
 
+r_ssize validate_n(r_obj* n);
+
 void r_vec_poke_coerce_n(r_obj* x, r_ssize offset,
                          r_obj* y, r_ssize from, r_ssize n);
 void r_vec_poke_coerce_range(r_obj* x, r_ssize offset,

--- a/src/rlang/call.c
+++ b/src/rlang/call.c
@@ -30,6 +30,37 @@ r_obj* r_expr_protect(r_obj* x) {
   }
 }
 
+static inline
+bool is_node(r_obj* x) {
+  switch (r_typeof(x)) {
+  case R_TYPE_call:
+  case R_TYPE_pairlist:
+    return true;
+  default:
+    return false;
+  }
+}
+
+r_obj* r_call_clone(r_obj* x) {
+  if (!is_node(x)) {
+    r_abort("Input must be a call.");
+  }
+
+  x = KEEP(r_clone(x));
+
+  r_obj* rest = x;
+  while (rest != r_null) {
+    r_obj* head = r_node_car(rest);
+    if (is_node(head)) {
+      r_node_poke_car(rest, r_call_clone(head));
+    }
+    rest = r_node_cdr(rest);
+  }
+
+  FREE(1);
+  return x;
+}
+
 
 void r_init_library_call() {
   quote_prim = r_base_ns_get("quote");

--- a/src/rlang/call.h
+++ b/src/rlang/call.h
@@ -15,6 +15,7 @@ bool r_is_call(r_obj* x, const char* name);
 bool r_is_call_any(r_obj* x, const char** names, int n);
 
 r_obj* r_expr_protect(r_obj* x);
+r_obj* r_call_clone(r_obj* x);
 
 
 #endif

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -555,6 +555,12 @@ test_that("call_zap_inline() works", {
     call_zap_inline(call),
     quote(function(x = `<int>`) foo(`<int>`))
   )
+
+  call2 <- expr(function(x = NULL) foo(!!(1:2)))
+  call2[[2]]$x <- 1:2
+
+  # No mutation
+  expect_equal(call, call2)
 })
 
 test_that("is_call_simple() works", {

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -248,6 +248,11 @@ test_that("quosures are not calls", {
   expect_false(is_call(quo()))
 })
 
+test_that("is_call() supports symbol `name`", {
+  expect_true(is_call(quote(foo()), quote(foo)))
+  expect_false(is_call(quote(foo()), quote(bar)))
+})
+
 test_that("is_call() vectorises name", {
   expect_false(is_call(quote(foo::bar), c("fn", "fn2")))
   expect_true(is_call(quote(foo::bar), c("fn", "::")))

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -169,6 +169,7 @@ test_that("entrace() preserves exit status in non-interactive sessions (#1052, r
   # Probably because of <https://github.com/wch/r-source/commit/3055aa86>
   skip_if(getRversion() < "3.3")
 
+  # This also tests for empty backtraces
   out <- Rscript(shQuote(c("--vanilla", "-e", 'options(error = rlang::entrace); stop("An error")')))
   expect_false(out$status == 0L)
 


### PR DESCRIPTION
Avoid data frames in a few places, and rewrite `call_zap_inline()` and `is_call()` in C.

This shrinks the benchmark below from 20ms to 1.1ms. This is still twice as slow as before (604µs), but after that point it becomes hard to optimise. The perf difference is due to the improved detection of namespaces and scopes stored in the backtrace.

cc @hadley.

```r
f <- function(n) {
  if (n) f(n - 1) else rlang::trace_back()
}
f(30)


bench::mark(f(30))[1:8]
# C `call_zap_inline()`
#>   expression      min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 f(30)        1.06ms   1.14ms      830.    13.1KB     19.1   390     9

# C `is_call()`
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 f(30)        2.65ms 2.72ms      338.    15.2KB     27.6   147    12

# Faster df ops
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 f(30)        3.33ms 3.49ms      266.    13.1KB     18.1   118     8

# rlang 1.0.0
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 f(30)        19.2ms   20ms      50.1    30.2KB     142.     6    17

# rlang 0.4.12
#>   expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
#> 1 f(30)         583µs  604µs     1589.     558KB     99.7   669    42
```