### PR TITLE
use consistent formatting for base version skip

### DIFF
--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -229,7 +229,7 @@ test_that("can supply handler environment as `bottom`", {
 })
 
 test_that("can set `entrace()` as a global handler", {
-  skip_if_not_installed("base", "4.0")
+  skip_if_not_installed("base", "4.0.0")
 
   expect_snapshot_output(run('{
     suppressMessages(testthat::local_reproducible_output())

--- a/tests/testthat/test-cnd-handlers.R
+++ b/tests/testthat/test-cnd-handlers.R
@@ -79,7 +79,7 @@ test_that("cnd_muffle() returns FALSE if the condition is not mufflable", {
 })
 
 test_that("drop_global_handlers() works and is idempotent", {
-  skip_if_not_installed("base", "4.0")
+  skip_if_not_installed("base", "4.0.0")
 
   code <- '{
     library(testthat)


### PR DESCRIPTION
Using 4.0.0 here:

https://github.com/r-lib/rlang/blob/68f768deed899ddded2ea102217531bc6e5a0b1e/tests/testthat/test-env.R#L364

There are also usages skipping based on `getRversion`, e.g.:

https://github.com/r-lib/rlang/blob/68f768deed899ddded2ea102217531bc6e5a0b1e/tests/testthat/test-compat-vctrs.R#L348

Should we unify those as well?

----

Of course it's somewhat trivial, but the test output is a bit noisy with the inconsistency. e.g. here's running from 3.6.3:

```
══ Skipped tests ═══════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
• Cannot set MBCS locale (1)
• !compiled_by_gcc() is TRUE (1)
• Disabled (1)
• Failing (1)
• getRversion() < "4.0" is TRUE (1)
• Installed base is version 3.6.3; but 4.0.0 is required (1)
• Installed base is version 3.6.3; but 4.0 is required (2)
• Not on Windows (1)
```