### PR TITLE
Avoid triggering active bindings in `env_binding_are_active()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `env_binding_are_active()` no longer accidentally triggers active bindings
+  (#1376).
+
 # rlang 1.0.2
 
 * Backtraces of parent errors are now reused on rethrow. This avoids

--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -20,12 +20,14 @@ static r_obj* new_binding_types(r_ssize n) {
 }
 
 static enum r_env_binding_type which_env_binding(r_obj* env, r_obj* sym) {
-  if (r_env_binding_is_promise(env, sym)) {
-    return R_ENV_BINDING_TYPE_promise;
+  if (r_env_binding_is_active(env, sym)) {
+    // Check for active bindings first, since promise detection triggers
+    // active bindings through `r_env_find()` (#1376)
+    return R_ENV_BINDING_TYPE_active;
   }
 
-  if (r_env_binding_is_active(env, sym)) {
-    return R_ENV_BINDING_TYPE_active;
+  if (r_env_binding_is_promise(env, sym)) {
+    return R_ENV_BINDING_TYPE_promise;
   }
 
   return R_ENV_BINDING_TYPE_value;

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -212,6 +212,14 @@ test_that("env_binding_are_active() doesn't force promises", {
   expect_identical(env_binding_are_lazy(env), lgl(foo = TRUE))
 })
 
+test_that("env_binding_are_active() doesn't trigger active bindings (#1376)", {
+  env <- env()
+  env_bind_active(env, foo = ~stop("kaboom"))
+  expect_no_error(env_binding_are_active(env))
+  expect_identical(env_binding_are_active(env), lgl(foo = TRUE))
+  expect_identical(env_binding_are_lazy(env), lgl(foo = FALSE))
+})
+
 test_that("env_binding_type_sum() detects types", {
   env <- env()
   env_bind_active(env, a = ~"foo")


### PR DESCRIPTION
Closes #1376 

See https://github.com/r-lib/rlang/issues/1376#issuecomment-1066765078 for details