### PR TITLE
Update docs for exprs_auto_name()

### DIFF
--- a/R/nse-defuse.R
+++ b/R/nse-defuse.R
@@ -173,7 +173,7 @@ expr <- function(expr) {
 #'   f({{ arg }} * 2)
 #' }
 #' g(100)
-#' 
+#'
 #' column <- sym("cyl")
 #' g(!!column)
 #'
@@ -502,9 +502,7 @@ endots <- function(call,
 #'
 #' This gives default names to unnamed elements of a list of
 #' expressions (or expression wrappers such as formulas or
-#' quosures). `exprs_auto_name()` deparses the expressions with
-#' [expr_name()] by default. `quos_auto_name()` deparses with
-#' [quo_name()].
+#' quosures), deparsed with [as_label()].
 #'
 #' @param exprs A list of expressions.
 #' @inheritParams args_dots_empty

--- a/man/exprs_auto_name.Rd
+++ b/man/exprs_auto_name.Rd
@@ -30,7 +30,5 @@ for information about name repairing.}
 \description{
 This gives default names to unnamed elements of a list of
 expressions (or expression wrappers such as formulas or
-quosures). \code{exprs_auto_name()} deparses the expressions with
-\code{\link[=expr_name]{expr_name()}} by default. \code{quos_auto_name()} deparses with
-\code{\link[=quo_name]{quo_name()}}.
+quosures), deparsed with \code{\link[=as_label]{as_label()}}.
 }


### PR DESCRIPTION
The current docs are pointing to questioning functions.

Should we soft-deprecate `quos_auto_name()`? It's forwarding to `exprs_auto_name()`, with fewer arguments.