### PR TITLE
Highlight call and argument in backtraces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,29 @@
 # rlang (development version)
 
+* Supplying a frame environment to the `call` argument of `abort()`
+  now causes the corresponding function call in the backtrace to be
+  highlighted.
+
+  In addition, if you store the argument name of a failing input in
+  the `arg` error field, the argument is also highlighted in the
+  backtrace.
+
+  The function name and function argument are also highlighted and
+  colour-code in the error message preceding the backtrace to make it
+  it easy to find the call and argument in the backtrace. This relies
+  on lazy formatting of the error message via a lambda function.
+  Instead of:
+
+  ```
+  cli::cli_abort("{.arg {arg}} must be a foobar.")
+  ```
+
+  Write:
+
+  ```
+  cli::cli_abort(\(...) cli::format_inline("{.arg {arg}} must be a foobar."), arg = arg)
+  ```
+
 * `abort(message = )` can now be a function. In this case, it is
   stored in the `header` field and acts as a `cnd_header()` method
   invoked when the message is displayed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rlang (development version)
 
+* `abort(message = )` can now be a function. In this case, it is
+  stored in the `header` field and acts as a `cnd_header()` method
+  invoked when the message is displayed.
+
 * New `obj_type_oo()` function in `compat-obj-type.R` (#1426).
 
 * `friendly_type_of()` from `compat-obj-type.R` (formerly

--- a/R/arg.R
+++ b/R/arg.R
@@ -56,7 +56,7 @@ arg_match <- function(arg,
     abort(
       ~ arg_match_invalid_msg(arg, values, error_arg),
       call = error_call,
-      check_arg = error_arg
+      arg = error_arg
     )
   }
 
@@ -112,7 +112,7 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
         format_arg("arg"),
         format_arg("values")
       )
-      abort(msg, call = quote(arg_match()), check_arg = "arg")
+      abort(msg, call = quote(arg_match()), arg = "arg")
     }
   }
 
@@ -149,7 +149,7 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
     msg
   }
 
-  abort(message, call = error_call, check_arg = error_arg)
+  abort(message, call = error_call, arg = error_arg)
 }
 
 arg_match_invalid_msg <- function(val, values, error_arg) {

--- a/R/arg.R
+++ b/R/arg.R
@@ -53,8 +53,8 @@ arg_match <- function(arg,
   }
 
   if (length(arg) > 1 && !setequal(arg, values)) {
-    header <- function(cnd, ..., highlight_error = FALSE) {
-      arg_match_invalid_msg(arg, values, error_arg, highlight_error)
+    header <- function(cnd, ..., error_highlight = FALSE) {
+      arg_match_invalid_msg(arg, values, error_arg, error_highlight)
     }
     abort(header = header, call = error_call, check_arg = error_arg)
   }
@@ -115,8 +115,8 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
     }
   }
 
-  header <- function(cnd, ..., highlight_error = FALSE) {
-    msg <- arg_match_invalid_msg(arg, values, error_arg, highlight_error)
+  header <- function(cnd, ..., error_highlight = FALSE) {
+    msg <- arg_match_invalid_msg(arg, values, error_arg, error_highlight)
 
     # Try suggest the most probable and helpful candidate value
     candidate <- NULL
@@ -154,8 +154,8 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
 arg_match_invalid_msg <- function(val,
                                   values,
                                   error_arg,
-                                  highlight_error = FALSE) {
-  format_arg <- if (highlight_error) format_error_arg_highlight else format_arg
+                                  error_highlight = FALSE) {
+  format_arg <- if (error_highlight) format_error_arg_highlight else format_arg
   msg <- paste0(format_arg(error_arg), " must be one of ")
   msg <- paste0(msg, chr_enumerate(chr_quoted(values, "\"")))
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -53,8 +53,8 @@ arg_match <- function(arg,
   }
 
   if (length(arg) > 1 && !setequal(arg, values)) {
-    header <- function(cnd, ..., error_highlight = FALSE) {
-      arg_match_invalid_msg(arg, values, error_arg, error_highlight)
+    header <- function(cnd, ...) {
+      arg_match_invalid_msg(arg, values, error_arg)
     }
     abort(header = header, call = error_call, check_arg = error_arg)
   }
@@ -115,8 +115,8 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
     }
   }
 
-  header <- function(cnd, ..., error_highlight = FALSE) {
-    msg <- arg_match_invalid_msg(arg, values, error_arg, error_highlight)
+  header <- function(cnd, ...) {
+    msg <- arg_match_invalid_msg(arg, values, error_arg)
 
     # Try suggest the most probable and helpful candidate value
     candidate <- NULL
@@ -151,11 +151,7 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
   abort(header = header, call = error_call, check_arg = error_arg)
 }
 
-arg_match_invalid_msg <- function(val,
-                                  values,
-                                  error_arg,
-                                  error_highlight = FALSE) {
-  format_arg <- if (error_highlight) format_error_arg_highlight else format_arg
+arg_match_invalid_msg <- function(val, values, error_arg) {
   msg <- paste0(format_arg(error_arg), " must be one of ")
   msg <- paste0(msg, chr_enumerate(chr_quoted(values, "\"")))
 

--- a/R/arg.R
+++ b/R/arg.R
@@ -53,10 +53,11 @@ arg_match <- function(arg,
   }
 
   if (length(arg) > 1 && !setequal(arg, values)) {
-    header <- function(cnd, ...) {
-      arg_match_invalid_msg(arg, values, error_arg)
-    }
-    abort(header = header, call = error_call, check_arg = error_arg)
+    abort(
+      ~ arg_match_invalid_msg(arg, values, error_arg),
+      call = error_call,
+      check_arg = error_arg
+    )
   }
 
   arg <- arg[[1]]
@@ -115,7 +116,7 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
     }
   }
 
-  header <- function(cnd, ...) {
+  message <- function(cnd, ...) {
     msg <- arg_match_invalid_msg(arg, values, error_arg)
 
     # Try suggest the most probable and helpful candidate value
@@ -148,7 +149,7 @@ stop_arg_match <- function(arg, values, error_arg, error_call) {
     msg
   }
 
-  abort(header = header, call = error_call, check_arg = error_arg)
+  abort(message, call = error_call, check_arg = error_arg)
 }
 
 arg_match_invalid_msg <- function(val, values, error_arg) {

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -314,10 +314,8 @@ abort <- function(message = NULL,
   extra_fields <- message_info$extra_fields
   use_cli_format <- message_info$use_cli_format
 
-  if (rethrowing) {
-    trace <- trace %||% parent[["trace"]]
-  }
-  if (is_null(trace) && is_null(peek_option("rlang:::disable_trace_capture"))) {
+  parent_trace <- if (rethrowing) parent[["trace"]]
+  if (is_null(trace) && is_null(parent_trace) && is_null(peek_option("rlang:::disable_trace_capture"))) {
     with_options(
       # Prevents infloops when rlang throws during trace capture
       "rlang:::disable_trace_capture" = TRUE,

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -243,6 +243,7 @@ abort <- function(message = NULL,
                   class = NULL,
                   ...,
                   call,
+                  header = NULL,
                   body = NULL,
                   footer = NULL,
                   trace = NULL,
@@ -299,9 +300,10 @@ abort <- function(message = NULL,
     call <- info$setup_caller
   }
 
-  message <- validate_signal_args(message, class, call, .subclass, "abort")
+  message <- validate_signal_args(message, class, call, .subclass, "abort", header = header)
   error_call <- error_call(call)
 
+  # FIXME! Pass `header` through here
   message_info <- cnd_message_info(
     message,
     body,
@@ -329,6 +331,7 @@ abort <- function(message = NULL,
     class,
     ...,
     message = message,
+    !!!compact(list(header = header)),
     !!!extra_fields,
     use_cli_format = use_cli_format,
     call = error_call,
@@ -1092,7 +1095,7 @@ caller_arg <- function(arg) {
 #' # function call form
 #' writeLines(format_error_call(quote(1 + 2)))
 #' @export
-format_error_call <- function(call) {
+format_error_call <- function(call, highlight = FALSE) {
   call <- error_call(call)
   if (is_null(call)) {
     return(NULL)
@@ -1104,7 +1107,11 @@ format_error_call <- function(call) {
   }
 
   if (grepl("\n", label)) {
-    cli_with_whiteline_escapes(label, format_code)
+    return(cli_with_whiteline_escapes(label, format_code))
+  }
+
+  if (highlight) {
+    format_error_call_highlight(label, quote = TRUE)
   } else {
     format_code(label)
   }

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -1104,7 +1104,7 @@ caller_arg <- function(arg) {
 #' # function call form
 #' writeLines(format_error_call(quote(1 + 2)))
 #' @export
-format_error_call <- function(call, highlight = FALSE) {
+format_error_call <- function(call) {
   call <- error_call(call)
   if (is_null(call)) {
     return(NULL)
@@ -1119,11 +1119,7 @@ format_error_call <- function(call, highlight = FALSE) {
     return(cli_with_whiteline_escapes(label, format_code))
   }
 
-  if (highlight) {
-    format_error_call_highlight(label, quote = TRUE)
-  } else {
-    format_code(label)
-  }
+  format_code(label)
 }
 
 error_call_as_string <- function(call) {

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -359,7 +359,7 @@ abort <- function(message = NULL,
       "rlang:::disable_trace_capture" = TRUE,
       "rlang:::visible_bottom" = info$bottom_frame,
       "rlang:::error_frame" = if (is_environment(call)) call else NULL,
-      "rlang:::check_arg" = cnd[["check_arg"]],
+      "rlang:::error_arg" = cnd[["arg"]],
       { trace <- trace_back() }
     )
   }

--- a/R/cnd-entrace.R
+++ b/R/cnd-entrace.R
@@ -196,7 +196,7 @@ has_recover <- function() {
 cnd_entrace <- function(cnd, ..., top = NULL, bottom = NULL) {
   check_dots_empty0(...)
 
-  if (!is_null(cnd$trace)) {
+  if (cnd_some(cnd, function(x) !is_null(x[["trace"]]))) {
     return(cnd)
   }
 

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -224,8 +224,12 @@ cnd_message_format_prefixed <- function(cnd,
     prefix <- col_yellow(capitalise(type))
   }
 
-  # FIXME
-  call <- format_error_call(cnd$call)
+  evalq({
+    if (is_true(peek_option("rlang:::error_highlight"))) {
+      local_error_highlight()
+    }
+    call <- format_error_call(cnd$call)
+  })
 
   message <- cnd_message_format(cnd, ..., alert = alert)
   message <- strip_trailing_newline(message)

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -104,8 +104,11 @@ cnd_backtrace_on_error <- function(cnd) {
   cnd[["rlang"]]$internal$backtrace_on_error
 }
 
-cnd_message_format <- function(cnd, ..., alert = FALSE) {
-  lines <- cnd_message_lines(cnd, ...)
+cnd_message_format <- function(cnd,
+                               ...,
+                               alert = FALSE,
+                               highlight_error = FALSE) {
+  lines <- cnd_message_lines(cnd, ..., highlight_error = highlight_error)
   if (is_string(lines, "")) {
     return("")
   }
@@ -151,7 +154,7 @@ cnd_header <- function(cnd, ...) {
   if (is_null(cnd[["header"]])) {
     UseMethod("cnd_header")
   } else {
-    exec_cnd_method("header", cnd)
+    exec_cnd_method("header", cnd, ...)
   }
 }
 #' @export
@@ -165,7 +168,7 @@ cnd_body <- function(cnd, ...) {
   if (is_null(cnd[["body"]])) {
     UseMethod("cnd_body")
   } else {
-    exec_cnd_method("body", cnd)
+    exec_cnd_method("body", cnd, ...)
   }
 }
 #' @export
@@ -179,7 +182,7 @@ cnd_footer <- function(cnd, ...) {
   if (is_null(cnd[["footer"]])) {
     UseMethod("cnd_footer")
   } else {
-    exec_cnd_method("footer", cnd)
+    exec_cnd_method("footer", cnd, ...)
   }
 }
 #' @export
@@ -187,14 +190,14 @@ cnd_footer.default <- function(cnd, ...) {
   chr()
 }
 
-exec_cnd_method <- function(name, cnd) {
+exec_cnd_method <- function(name, cnd, ...) {
   method <- cnd[[name]]
 
   if (is_function(method)) {
-    method(cnd)
+    method(cnd, ...)
   } else if (is_bare_formula(method)) {
     method <- as_function(method)
-    method(cnd)
+    method(cnd, ...)
   } else if (is_character(method)) {
     method
   } else {
@@ -211,7 +214,8 @@ cnd_message_format_prefixed <- function(cnd,
                                         ...,
                                         parent = FALSE,
                                         alert = NULL,
-                                        warning = FALSE) {
+                                        warning = FALSE,
+                                        highlight_error = FALSE) {
   type <- cnd_type(cnd)
 
   if (is_null(alert)) {
@@ -224,9 +228,14 @@ cnd_message_format_prefixed <- function(cnd,
     prefix <- col_yellow(capitalise(type))
   }
 
-  call <- format_error_call(cnd$call)
+  call <- format_error_call(cnd$call, highlight = highlight_error)
 
-  message <- cnd_message_format(cnd, ..., alert = alert)
+  message <- cnd_message_format(
+    cnd,
+    ...,
+    alert = alert,
+    highlight_error = highlight_error
+  )
   message <- strip_trailing_newline(message)
 
   if (!nzchar(message)) {

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -104,11 +104,8 @@ cnd_backtrace_on_error <- function(cnd) {
   cnd[["rlang"]]$internal$backtrace_on_error
 }
 
-cnd_message_format <- function(cnd,
-                               ...,
-                               alert = FALSE,
-                               error_highlight = FALSE) {
-  lines <- cnd_message_lines(cnd, ..., error_highlight = error_highlight)
+cnd_message_format <- function(cnd, ..., alert = FALSE) {
+  lines <- cnd_message_lines(cnd, ...)
   if (is_string(lines, "")) {
     return("")
   }
@@ -214,8 +211,7 @@ cnd_message_format_prefixed <- function(cnd,
                                         ...,
                                         parent = FALSE,
                                         alert = NULL,
-                                        warning = FALSE,
-                                        error_highlight = FALSE) {
+                                        warning = FALSE) {
   type <- cnd_type(cnd)
 
   if (is_null(alert)) {
@@ -228,14 +224,10 @@ cnd_message_format_prefixed <- function(cnd,
     prefix <- col_yellow(capitalise(type))
   }
 
-  call <- format_error_call(cnd$call, highlight = error_highlight)
+  # FIXME
+  call <- format_error_call(cnd$call)
 
-  message <- cnd_message_format(
-    cnd,
-    ...,
-    alert = alert,
-    error_highlight = error_highlight
-  )
+  message <- cnd_message_format(cnd, ..., alert = alert)
   message <- strip_trailing_newline(message)
 
   if (!nzchar(message)) {

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -107,8 +107,8 @@ cnd_backtrace_on_error <- function(cnd) {
 cnd_message_format <- function(cnd,
                                ...,
                                alert = FALSE,
-                               highlight_error = FALSE) {
-  lines <- cnd_message_lines(cnd, ..., highlight_error = highlight_error)
+                               error_highlight = FALSE) {
+  lines <- cnd_message_lines(cnd, ..., error_highlight = error_highlight)
   if (is_string(lines, "")) {
     return("")
   }
@@ -215,7 +215,7 @@ cnd_message_format_prefixed <- function(cnd,
                                         parent = FALSE,
                                         alert = NULL,
                                         warning = FALSE,
-                                        highlight_error = FALSE) {
+                                        error_highlight = FALSE) {
   type <- cnd_type(cnd)
 
   if (is_null(alert)) {
@@ -228,13 +228,13 @@ cnd_message_format_prefixed <- function(cnd,
     prefix <- col_yellow(capitalise(type))
   }
 
-  call <- format_error_call(cnd$call, highlight = highlight_error)
+  call <- format_error_call(cnd$call, highlight = error_highlight)
 
   message <- cnd_message_format(
     cnd,
     ...,
     alert = alert,
-    highlight_error = highlight_error
+    error_highlight = error_highlight
   )
   message <- strip_trailing_newline(message)
 

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -261,7 +261,6 @@ validate_signal_args <- function(message,
                                  call,
                                  subclass,
                                  fn,
-                                 header = NULL,
                                  env = caller_env()) {
   local_error_call("caller")
 
@@ -270,24 +269,24 @@ validate_signal_args <- function(message,
   }
   check_required(class, call = env)
 
-  if (!is_null(header) && !is_null(message)) {
-    check_exclusive(header, message, .error_call = env)
-  }
-
   if (!is_missing(call)) {
     if (!is_null(call) && !is_environment(call) && !is_call(call)) {
       stop_input_type(call, "a call or environment", arg = "call", call = env)
     }
   }
 
-  if (is_null(message)) {
-    if (is_null(class) && is_null(header)) {
-      abort("Either `message` or `class` must be supplied.", call = env)
-    }
+  if (is_null(message) && is_null(class)) {
+    abort("Either `message` or `class` must be supplied.", call = env)
   }
 
   message <- message %||% ""
-  check_character(message, call = env)
+  if (is_function(message)) {
+    if (!"..." %in% names(formals(message))) {
+      abort("`cnd_header()` methods must take `...`.", call = env)
+    }
+  } else {
+    check_character(message, call = env)
+  }
 
   if (!is_null(class)) {
     check_character(class, call = env)

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -261,6 +261,7 @@ validate_signal_args <- function(message,
                                  call,
                                  subclass,
                                  fn,
+                                 header = NULL,
                                  env = caller_env()) {
   local_error_call("caller")
 
@@ -269,6 +270,10 @@ validate_signal_args <- function(message,
   }
   check_required(class, call = env)
 
+  if (!is_null(header) && !is_null(message)) {
+    check_exclusive(header, message, .error_call = env)
+  }
+
   if (!is_missing(call)) {
     if (!is_null(call) && !is_environment(call) && !is_call(call)) {
       stop_input_type(call, "a call or environment", arg = "call", call = env)
@@ -276,13 +281,14 @@ validate_signal_args <- function(message,
   }
 
   if (is_null(message)) {
-    if (is_null(class)) {
+    if (is_null(class) && is_null(header)) {
       abort("Either `message` or `class` must be supplied.", call = env)
     }
-    message <- ""
   }
 
+  message <- message %||% ""
   check_character(message, call = env)
+
   if (!is_null(class)) {
     check_character(class, call = env)
   }

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -401,7 +401,7 @@ format.rlang_error <- function(x,
     backtrace = backtrace,
     simplify = simplify,
     drop = drop,
-    highlight_error = TRUE
+    error_highlight = TRUE
   )
 
   # Recommend printing the full backtrace if called from `last_error()`
@@ -471,7 +471,7 @@ cnd_format <- function(x,
                        prefix = TRUE,
                        alert = NULL,
                        drop = FALSE,
-                       highlight_error = FALSE) {
+                       error_highlight = FALSE) {
   simplify <- arg_match_simplify(simplify)
   alert <- alert %||% is_error(x)
 
@@ -484,13 +484,13 @@ cnd_format <- function(x,
     message <- cnd_message_format_prefixed(
       x,
       alert = alert,
-      highlight_error = highlight_error
+      error_highlight = error_highlight
     )
   } else {
     message <- cnd_message_format(
       x,
       alert = alert,
-      highlight_error = highlight_error
+      error_highlight = error_highlight
     )
   }
 
@@ -565,7 +565,7 @@ cnd_format <- function(x,
     message <- cnd_message_format_prefixed(
       x,
       parent = TRUE,
-      highlight_error = highlight_error
+      error_highlight = error_highlight
     )
     out <- paste_line(out, message)
 

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -526,7 +526,6 @@ cnd_format <- function(x,
     out <<- paste_line(out, "---")
 
     out <<- paste_trace(
-      pending_trace$cnd,
       out,
       pending_trace$trace,
       simplify = simplify,
@@ -580,12 +579,11 @@ cnd_format <- function(x,
 can_paste_trace <- function(backtrace, trace) {
   backtrace && is_trace(trace) && trace_length(trace)
 }
-paste_trace <- function(cnd, x, trace, simplify, ...) {
+paste_trace <- function(x, trace, simplify, ...) {
   trace_lines <- format(
     trace,
     ...,
-    simplify = simplify,
-    check_arg = cnd[["check_arg"]]
+    simplify = simplify
   )
   paste_line(x, bold("Backtrace:"), trace_lines)
 }

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -350,8 +350,12 @@ cnd_type <- function(cnd) {
 #'
 #' @export
 cnd_inherits <- function(cnd, class) {
+  cnd_some(cnd, inherits, class)
+}
+
+cnd_some <- function(cnd, fn, ...) {
   while (is_condition(cnd)) {
-    if (inherits(cnd, class)) {
+    if (fn(cnd, ...)) {
       return(TRUE)
     }
 
@@ -486,41 +490,85 @@ cnd_format <- function(x,
   )
 
   trace <- x$trace
+  last_trace <- NULL
+  pending_trace <- NULL
+
+  # This flushes backtraces lazily so that chained error messages
+  # accumulate before displaying a backtrace
+  push_trace <- function(cnd, trace) {
+    if (!can_paste_trace(backtrace, trace)) {
+      return()
+    }
+
+    if (is_same_trace()) {
+      return()
+    }
+
+    flush_trace()
+    pending_trace <<- list(cnd = cnd, trace = trace)
+  }
+
+  flush_trace <- function() {
+    if (is_null(pending_trace)) {
+      return()
+    }
+
+    out <<- paste_line(out, "---")
+
+    out <<- paste_trace(
+      pending_trace$cnd,
+      out,
+      pending_trace$trace,
+      simplify = simplify,
+      ...,
+      drop = drop
+    )
+
+    if (!is_null(parent)) {
+      out <<- paste_line(out, "---")
+    }
+
+    last_trace <<- pending_trace$trace
+    pending_trace <<- NULL
+  }
+
+  is_same_trace <- function() {
+    compare <- if (is_null(pending_trace)) last_trace else pending_trace$trace
+
+    # NOTE: Should we detect trace subsets as well?
+    identical(
+      format(trace, simplify = simplify, drop = drop),
+      format(compare, simplify = simplify, drop = drop)
+    )
+  }
+
+  push_trace(x, trace)
 
   while (!is_null(parent)) {
     x <- parent
     parent <- parent$parent
+    trace <- x$trace
 
-    chained_trace <- x$trace
-
-    # NOTE: Should we detect trace subsets as well?
-    if (can_paste_trace(backtrace, chained_trace) &&
-        !identical(
-          format(trace, simplify = simplify),
-          format(chained_trace, simplify = simplify)
-        )) {
-      out <- paste_trace(out, trace, simplify, ...)
-      out <- paste_line(out, "---")
-      trace <- chained_trace
+    if (!is_null(trace) && !is_same_trace()) {
+      flush_trace()
     }
 
     message <- cnd_message_format_prefixed(x, parent = TRUE)
     out <- paste_line(out, message)
+
+    push_trace(x, trace)
   }
 
-  if (can_paste_trace(backtrace, trace)) {
-    out <- paste_trace(out, trace, simplify, ..., drop = drop)
-  }
-
+  flush_trace()
   out
 }
 
 can_paste_trace <- function(backtrace, trace) {
   backtrace && is_trace(trace) && trace_length(trace)
 }
-paste_trace <- function(x, trace, simplify, ...) {
+paste_trace <- function(cnd, x, trace, simplify, ...) {
   trace_lines <- format(trace, ..., simplify = simplify)
-  paste_line(x, "---", bold("Backtrace:"), trace_lines)
+  paste_line(x, bold("Backtrace:"), trace_lines)
 }
 
 cnd_type_header <- function(cnd) {

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -567,7 +567,12 @@ can_paste_trace <- function(backtrace, trace) {
   backtrace && is_trace(trace) && trace_length(trace)
 }
 paste_trace <- function(cnd, x, trace, simplify, ...) {
-  trace_lines <- format(trace, ..., simplify = simplify)
+  trace_lines <- format(
+    trace,
+    ...,
+    simplify = simplify,
+    check_arg = cnd[["check_arg"]]
+  )
   paste_line(x, bold("Backtrace:"), trace_lines)
 }
 

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -400,7 +400,8 @@ format.rlang_error <- function(x,
     ...,
     backtrace = backtrace,
     simplify = simplify,
-    drop = drop
+    drop = drop,
+    highlight_error = TRUE
   )
 
   # Recommend printing the full backtrace if called from `last_error()`
@@ -469,7 +470,8 @@ cnd_format <- function(x,
                        simplify = c("branch", "none"),
                        prefix = TRUE,
                        alert = NULL,
-                       drop = FALSE) {
+                       drop = FALSE,
+                       highlight_error = FALSE) {
   simplify <- arg_match_simplify(simplify)
   alert <- alert %||% is_error(x)
 
@@ -479,9 +481,17 @@ cnd_format <- function(x,
 
   header <- cnd_type_header(x)
   if (prefix) {
-    message <- cnd_message_format_prefixed(x, alert = alert)
+    message <- cnd_message_format_prefixed(
+      x,
+      alert = alert,
+      highlight_error = highlight_error
+    )
   } else {
-    message <- cnd_message_format(x, alert = alert)
+    message <- cnd_message_format(
+      x,
+      alert = alert,
+      highlight_error = highlight_error
+    )
   }
 
   out <- paste_line(
@@ -553,7 +563,11 @@ cnd_format <- function(x,
       flush_trace()
     }
 
-    message <- cnd_message_format_prefixed(x, parent = TRUE)
+    message <- cnd_message_format_prefixed(
+      x,
+      parent = TRUE,
+      highlight_error = highlight_error
+    )
     out <- paste_line(out, message)
 
     push_trace(x, trace)

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -395,13 +395,15 @@ format.rlang_error <- function(x,
   drop <- x$rlang$internal$trace_drop %||% drop
 
   simplify <- arg_match_simplify(simplify)
-  out <- cnd_format(
-    x,
-    ...,
-    backtrace = backtrace,
-    simplify = simplify,
-    drop = drop,
-    error_highlight = TRUE
+
+  with_error_arg_highlight(
+    out <- cnd_format(
+      x,
+      ...,
+      backtrace = backtrace,
+      simplify = simplify,
+      drop = drop
+    )
   )
 
   # Recommend printing the full backtrace if called from `last_error()`
@@ -470,8 +472,7 @@ cnd_format <- function(x,
                        simplify = c("branch", "none"),
                        prefix = TRUE,
                        alert = NULL,
-                       drop = FALSE,
-                       error_highlight = FALSE) {
+                       drop = FALSE) {
   simplify <- arg_match_simplify(simplify)
   alert <- alert %||% is_error(x)
 
@@ -481,17 +482,9 @@ cnd_format <- function(x,
 
   header <- cnd_type_header(x)
   if (prefix) {
-    message <- cnd_message_format_prefixed(
-      x,
-      alert = alert,
-      error_highlight = error_highlight
-    )
+    message <- cnd_message_format_prefixed(x, alert = alert)
   } else {
-    message <- cnd_message_format(
-      x,
-      alert = alert,
-      error_highlight = error_highlight
-    )
+    message <- cnd_message_format(x, alert = alert)
   }
 
   out <- paste_line(
@@ -562,11 +555,7 @@ cnd_format <- function(x,
       flush_trace()
     }
 
-    message <- cnd_message_format_prefixed(
-      x,
-      parent = TRUE,
-      error_highlight = error_highlight
-    )
+    message <- cnd_message_format_prefixed(x, parent = TRUE)
     out <- paste_line(out, message)
 
     push_trace(x, trace)

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -215,10 +215,16 @@ format_envvar <- function(x) .rlang_cli_format_inline(x, "envvar", "`%s`")
 format_field  <- function(x) .rlang_cli_format_inline(x, "field", NULL)
 
 format_error_arg_highlight <- function(x, quote = TRUE) {
+  if (is_true(peek_option("rlang:::trace_test_highlight"))) {
+    return(paste0("<<ARG ", x, ">>"))
+  }
   out <- if (quote) format_arg(x) else x
   style_bold(cli::col_br_magenta(out))
 }
 format_error_call_highlight <- function(x, quote = TRUE) {
+  if (is_true(peek_option("rlang:::trace_test_highlight"))) {
+    return(paste0("<<CALL ", x, ">>"))
+  }
   out <- if (quote) format_code(x) else x
   style_bold(cli::col_br_blue(out))
 }

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -214,6 +214,15 @@ format_var    <- function(x) .rlang_cli_format_inline(x, "var", "`%s`")
 format_envvar <- function(x) .rlang_cli_format_inline(x, "envvar", "`%s`")
 format_field  <- function(x) .rlang_cli_format_inline(x, "field", NULL)
 
+format_error_arg_highlight <- function(x, quote = TRUE) {
+  out <- if (quote) format_arg(x) else x
+  style_bold(cli::col_br_magenta(out))
+}
+format_error_call_highlight <- function(x, quote = TRUE) {
+  out <- if (quote) format_code(x) else x
+  style_bold(cli::col_br_blue(out))
+}
+
 format_cls <- function(x) {
   fallback <- function(x) sprintf("<%s>", paste0(x, collapse = "/"))
   .rlang_cli_format_inline(x, "cls", fallback)

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -202,7 +202,7 @@ stop_input_type <- function(x,
                             ...,
                             arg = rlang::caller_arg(x),
                             call = rlang::caller_env()) {
-  cnd_message <- function(cnd, ...) {
+  message <- function(cnd, ...) {
     # From compat-cli.R
     format_arg <- rlang::env_get(
       nm = "format_arg",
@@ -222,7 +222,7 @@ stop_input_type <- function(x,
     )
   }
 
-  rlang::abort(header = cnd_message, ..., call = call, check_arg = arg)
+  rlang::abort(message, ..., call = call, check_arg = arg)
 }
 
 # nocov end

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -202,25 +202,23 @@ stop_input_type <- function(x,
                             ...,
                             arg = rlang::caller_arg(x),
                             call = rlang::caller_env()) {
-  message <- function(cnd, ...) {
-    # From compat-cli.R
-    format_arg <- rlang::env_get(
-      nm = "format_arg",
-      last = topenv(),
-      default = NULL,
-      inherit = TRUE
-    )
-    if (!is.function(format_arg)) {
-      format_arg <- function(x) sprintf("`%s`", x)
-    }
-
-    sprintf(
-      "%s must be %s, not %s.",
-      format_arg(arg),
-      what,
-      obj_type_friendly(x)
-    )
+  # From compat-cli.R
+  format_arg <- rlang::env_get(
+    nm = "format_arg",
+    last = topenv(),
+    default = NULL,
+    inherit = TRUE
+  )
+  if (!is.function(format_arg)) {
+    format_arg <- function(x) sprintf("`%s`", x)
   }
+
+  message <- sprintf(
+    "%s must be %s, not %s.",
+    format_arg(arg),
+    what,
+    obj_type_friendly(x)
+  )
 
   rlang::abort(message, ..., call = call, arg = arg)
 }

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -218,7 +218,7 @@ stop_input_type <- function(x,
     what,
     obj_type_friendly(x)
   )
-  rlang::abort(message, ..., call = call)
+  rlang::abort(message, ..., call = call, check_arg = arg)
 }
 
 # nocov end

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -202,23 +202,29 @@ stop_input_type <- function(x,
                             ...,
                             arg = rlang::caller_arg(x),
                             call = rlang::caller_env()) {
-  # From compat-cli.R
-  format_arg <- rlang::env_get(
-    nm = "format_arg",
-    last = topenv(),
-    default = NULL
-  )
-  if (!is.function(format_arg)) {
-    format_arg <- function(x) sprintf("`%s`", x)
+  cnd_message <- function(cnd, ..., highlight_error = FALSE) {
+    formatter <- if (highlight_error) "format_error_arg_highlight" else "format_arg"
+
+    # From compat-cli.R
+    format_arg <- rlang::env_get(
+      nm = formatter,
+      last = topenv(),
+      default = NULL,
+      inherit = TRUE
+    )
+    if (!is.function(format_arg)) {
+      format_arg <- function(x) sprintf("`%s`", x)
+    }
+
+    sprintf(
+      "%s must be %s, not %s.",
+      format_arg(arg),
+      what,
+      obj_type_friendly(x)
+    )
   }
 
-  message <- sprintf(
-    "%s must be %s, not %s.",
-    format_arg(arg),
-    what,
-    obj_type_friendly(x)
-  )
-  rlang::abort(message, ..., call = call, check_arg = arg)
+  rlang::abort(header = cnd_message, ..., call = call, check_arg = arg)
 }
 
 # nocov end

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -202,12 +202,10 @@ stop_input_type <- function(x,
                             ...,
                             arg = rlang::caller_arg(x),
                             call = rlang::caller_env()) {
-  cnd_message <- function(cnd, ..., error_highlight = FALSE) {
-    formatter <- if (error_highlight) "format_error_arg_highlight" else "format_arg"
-
+  cnd_message <- function(cnd, ...) {
     # From compat-cli.R
     format_arg <- rlang::env_get(
-      nm = formatter,
+      nm = "format_arg",
       last = topenv(),
       default = NULL,
       inherit = TRUE

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -222,7 +222,7 @@ stop_input_type <- function(x,
     )
   }
 
-  rlang::abort(message, ..., call = call, check_arg = arg)
+  rlang::abort(message, ..., call = call, arg = arg)
 }
 
 # nocov end

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -202,8 +202,8 @@ stop_input_type <- function(x,
                             ...,
                             arg = rlang::caller_arg(x),
                             call = rlang::caller_env()) {
-  cnd_message <- function(cnd, ..., highlight_error = FALSE) {
-    formatter <- if (highlight_error) "format_error_arg_highlight" else "format_arg"
+  cnd_message <- function(cnd, ..., error_highlight = FALSE) {
+    formatter <- if (error_highlight) "format_error_arg_highlight" else "format_arg"
 
     # From compat-cli.R
     format_arg <- rlang::env_get(

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -1019,8 +1019,10 @@ call_deparse_highlight <- function(call, arg) {
     is_string(arg) || is_null(arg)
   )
 
+  local_error_highlight()
+
   if (!is_symbol(call[[1]]) || call_print_fine_type(call) != "call") {
-    return(format_error_call_highlight(as_label(call), quote = FALSE))
+    return(format_code_unquoted(as_label(call)))
   }
 
   names <- names(call)
@@ -1029,15 +1031,15 @@ call_deparse_highlight <- function(call, arg) {
     call <- call[c(1, match(arg, names))]
 
     args_list <- sprintf("%s = %s", arg, as_label(call[[arg]]))
-    args_list <- format_error_arg_highlight(args_list, quote = FALSE)
+    args_list <- format_arg_unquoted(args_list)
   } else {
     args_list <- args_deparse(node_cdr(call))
     args_list <- substring(args_list, 2, nchar(args_list) - 1)
   }
 
   fn <- sym_text(call[[1]])
-  open <- format_error_call_highlight(sprintf("%s(", fn), quote = FALSE)
-  close <- format_error_call_highlight(")", quote = FALSE)
+  open <- format_code_unquoted(sprintf("%s(", fn))
+  close <- format_code_unquoted(")")
 
   paste0(open, args_list, close)
 }

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -1012,3 +1012,31 @@ as_name <- function(x) {
   }
   as_string(x)
 }
+
+call_deparse_highlight <- function(call,
+                                   arg,
+                                   default = as_label(call)) {
+  stopifnot(is_call(call), is_string(arg))
+
+  names <- names(call)
+  if (!arg %in% names) {
+    return(default)
+  }
+
+  if (!is_symbol(call[[1]]) || call_print_fine_type(call) != "call") {
+    return(default)
+  }
+
+  # Simply remove other arguments for now
+  call <- call[c(1, match(arg, names))]
+
+  fn <- sym_text(call[[1]])
+  open <- format_error_call_highlight(sprintf("%s(", fn), quote = FALSE)
+  close <- format_error_call_highlight(")", quote = FALSE)
+
+  arg_value <- as_label(call[[arg]])
+  arg_passing <- sprintf("%s = %s", arg, arg_value)
+  arg_passing <- format_error_arg_highlight(arg_passing, quote = FALSE)
+
+  paste0(open, arg_passing, close)
+}

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -1016,6 +1016,10 @@ as_name <- function(x) {
 call_deparse_highlight <- function(call,
                                    arg,
                                    default = as_label(call)) {
+  if (is_null(arg)) {
+    return(format_error_call_highlight(default, quote = FALSE))
+  }
+
   stopifnot(is_call(call), is_string(arg))
 
   names <- names(call)

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -1014,10 +1014,11 @@ as_name <- function(x) {
 }
 
 call_deparse_highlight <- function(call, arg) {
-  stopifnot(
-    is_call(call),
-    is_string(arg) || is_null(arg)
-  )
+  stopifnot(is_call(call))
+
+  if (!is_string(arg)) {
+    arg <- NULL
+  }
 
   local_error_highlight()
 

--- a/R/env-special.R
+++ b/R/env-special.R
@@ -203,7 +203,13 @@ ns_exports <- function(ns) getNamespaceExports(ns)
 ns_imports <- function(ns) getNamespaceImports(ns)
 
 ns_exports_has <- function(ns, name) {
-  if (is_reference(ns, base_ns_env)) {
+  if (is_string(ns)) {
+    if (!is_installed(ns)) {
+      return(FALSE)
+    }
+    ns <- ns_env(ns)
+  }
+  if (is_reference(ns, ns_env("base"))) {
     exports <- base_pkg_env
   } else {
     exports <- ns$.__NAMESPACE__.$exports

--- a/R/trace.R
+++ b/R/trace.R
@@ -1057,3 +1057,63 @@ is_trace <- function(x) {
 #' @name rlib_trace_spec
 #' @keywords internal
 NULL
+
+local_error_highlight <- function(frame = caller_env()) {
+  if (!has_cli_start_app) {
+    return()
+  }
+
+  if (is_true(peek_option("rlang:::trace_test_highlight"))) {
+    theme <- theme_error_highlight_test
+  } else {
+    theme <- theme_error_highlight
+  }
+
+  cli::start_app(theme, .envir = frame)
+}
+
+on_load({
+  theme_error_highlight <- local({
+    if (ns_exports_has("cli", "builtin_theme")) {
+      cli_theme <- cli::builtin_theme()
+    } else {
+      cli_theme <- list()
+    }
+
+    arg_theme <- list(
+      "color" = "br_magenta",
+      "font-weight" = "bold"
+    )
+    code_theme <- list(
+      "color" = "br_blue",
+      "font-weight" = "bold"
+    )
+
+    list(
+      "span.arg" = utils::modifyList(
+        cli_theme[["span.arg"]] %||% list(),
+        arg_theme
+      ),
+      "span.code" = utils::modifyList(
+        cli_theme[["span.code"]] %||% list(),
+        code_theme
+      ),
+      "span.arg-unquoted" = arg_theme,
+      "span.code-unquoted" = code_theme
+    )
+  })
+})
+
+theme_error_highlight_test <- list(
+  "span.arg" = list(before = "<<ARG `", after = "`>>"),
+  "span.code" = list(before = "<<CALL `", after = "`>>"),
+  "span.arg-unquoted" = list(before = "<<ARG ", after = ">>"),
+  "span.code-unquoted" = list(before = "<<CALL ", after = ">>")
+)
+
+format_arg_unquoted <- function(x) {
+  .rlang_cli_format_inline(x, "arg-unquoted", "%s")
+}
+format_code_unquoted <- function(x) {
+  .rlang_cli_format_inline(x, "code-unquoted", "%s")
+}

--- a/R/trace.R
+++ b/R/trace.R
@@ -807,7 +807,11 @@ trace_call_text <- function(call,
     }
   }
 
-  text <- as_label(call)
+  if (error_frame && !is_null(check_arg)) {
+    text <- call_deparse_highlight(call, check_arg)
+  } else {
+    text <- as_label(call)
+  }
 
   if (is_string(scope, "global")) {
     text <- paste0("global ", text)

--- a/R/trace.R
+++ b/R/trace.R
@@ -1088,6 +1088,7 @@ with_error_highlight <- function(expr) {
 # Used for highlighting `.arg` spans in error messages without
 # affecting `.code` spans
 with_error_arg_highlight <- function(expr) {
+  local_options("rlang:::error_highlight" = TRUE)
   local_error_highlight(code = FALSE)
   expr
 }
@@ -1128,10 +1129,10 @@ on_load({
 })
 
 theme_error_highlight_test <- list(
-  "span.arg" = list(before = "<<ARG `", after = "`>>"),
-  "span.code" = list(before = "<<CALL `", after = "`>>"),
-  "span.arg-unquoted" = list(before = "<<ARG ", after = ">>"),
-  "span.code-unquoted" = list(before = "<<CALL ", after = ">>")
+  "span.arg" = list(before = "<<ARG ", after = ">>"),
+  "span.code" = list(before = "<<CALL ", after = ">>"),
+  "span.arg-unquoted" = list(before = "<<ARG ", after = ">>", transform = NULL),
+  "span.code-unquoted" = list(before = "<<CALL ", after = ">>", transform = NULL)
 )
 
 theme_error_arg_highlight_test <- theme_error_highlight_test

--- a/R/trace.R
+++ b/R/trace.R
@@ -128,7 +128,7 @@ trace_back <- function(top = NULL, bottom = NULL) {
   error_frame <- peek_option("rlang:::error_frame")
   if (!is_null(error_frame)) {
     trace[["error_frame"]] <- FALSE
-    i <- detect_index(frames, identical, error_frame, .right = TRUE)
+    i <- detect_index(frames, identical, error_frame)
     if (i) {
       trace[["error_frame"]][[i]] <- TRUE
       check_arg <- peek_option("rlang:::check_arg")

--- a/R/trace.R
+++ b/R/trace.R
@@ -109,7 +109,6 @@ trace_back <- function(top = NULL, bottom = NULL) {
   calls <- map(calls, call_zap_inline)
 
   context <- empty_trace_context()
-
   if (length(calls)) {
     context_data <- map2(calls, seq_along(calls), call_trace_context)
     context$namespace <- do.call(base::c, map(context_data, `[[`, "namespace"))
@@ -118,7 +117,6 @@ trace_back <- function(top = NULL, bottom = NULL) {
   context <- new_data_frame(context)
 
   parents <- normalise_parents(parents)
-
   trace <- new_trace(
     calls,
     parents,
@@ -126,6 +124,16 @@ trace_back <- function(top = NULL, bottom = NULL) {
     scope = context$scope,
     visible = is_visible
   )
+
+  error_frame <- peek_option("rlang:::error_frame")
+  if (!is_null(error_frame)) {
+    trace[["error_frame"]] <- FALSE
+    i <- detect_index(frames, identical, error_frame, .right = TRUE)
+    if (i) {
+      trace[["error_frame"]][[i]] <- TRUE
+    }
+  }
+
   trace <- add_winch_trace(trace)
   trace <- trace_trim_env(trace, frames, top)
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -131,12 +131,12 @@ trace_back <- function(top = NULL, bottom = NULL) {
     i <- detect_index(frames, identical, error_frame)
     if (i) {
       trace[["error_frame"]][[i]] <- TRUE
-      check_arg <- peek_option("rlang:::check_arg")
-      if (!is_null(check_arg)) {
-        if (is_null(trace[["check_arg"]])) {
-          trace[["check_arg"]] <- list(NULL)
+      error_arg <- peek_option("rlang:::error_arg")
+      if (!is_null(error_arg)) {
+        if (is_null(trace[["error_arg"]])) {
+          trace[["error_arg"]] <- list(NULL)
         }
-        trace[["check_arg"]][[i]] <- check_arg
+        trace[["error_arg"]][[i]] <- error_arg
 
         # Match arguments so we can fully highlight the faulty input in
         # the backtrace. Preserve srcrefs from original frame call.
@@ -720,7 +720,7 @@ trace_as_tree <- function(trace,
   root_children[[1]] <- intersect(root_children[[1]], trace$id)
 
   params <- intersect(
-    c("call", "namespace", "scope", "error_frame", "check_arg"),
+    c("call", "namespace", "scope", "error_frame", "error_arg"),
     names(trace)
   )
   trace$call_text <- chr(!!!pmap(trace[params], trace_call_text))
@@ -809,7 +809,7 @@ trace_call_text <- function(call,
                             namespace,
                             scope,
                             error_frame = FALSE,
-                            check_arg = NULL) {
+                            error_arg = NULL) {
   if (is_call(call) && is_symbol(call[[1]])) {
     if (scope %in% c("::", ":::") && !is_na(namespace)) {
       call[[1]] <- call(scope, sym(namespace), call[[1]])
@@ -817,7 +817,7 @@ trace_call_text <- function(call,
   }
 
   if (error_frame) {
-    text <- call_deparse_highlight(call, check_arg)
+    text <- call_deparse_highlight(call, error_arg)
   } else {
     text <- as_label(call)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,6 +169,7 @@ pad_spaces <- function(x, left = TRUE) {
 on_load({
   has_cli <- is_installed("cli")
   has_cli_format <- is_installed("cli", version = "3.0.0")
+  has_cli_start_app <- is_installed("cli", version = "2.0.0")
 })
 
 info <- function() {

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -69,7 +69,11 @@ If a message is not supplied, it is expected that the message is
 generated \strong{lazily} through \code{\link[=cnd_header]{cnd_header()}} and \code{\link[=cnd_body]{cnd_body()}}
 methods. In that case, \code{class} must be supplied. Only \code{inform()}
 allows empty messages as it is occasionally useful to build user
-output incrementally.}
+output incrementally.
+
+If a function, it is stored in the \code{header} field of the error
+condition. This acts as a \code{\link[=cnd_header]{cnd_header()}} method that is invoked
+lazily when the error message is displayed.}
 
 \item{class}{Subclass of the condition.}
 

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -222,3 +222,27 @@
       Error in `g()`:
       ! `my_arg` must be a character vector, not a number.
 
+# arg_match() backtrace highlights call and arg
+
+    Code
+      print_highlighted_trace(err)
+    Output
+      <error/rlang_error>
+      Error in <<CALL h()>>:
+      ! <<ARG my_arg>> must be one of "foo" or "bar", not "f".
+      i Did you mean "foo"?
+      ---
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(f("f"))
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang (local) f("f")
+       10.   \-rlang (local) g(x)
+       11.     \-rlang (local) <<CALL h(>><<ARG my_arg = x>><<CALL )>>
+

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -228,8 +228,8 @@
       print_highlighted_trace(err)
     Output
       <error/rlang_error>
-      Error in <<CALL h()>>:
-      ! <<ARG my_arg>> must be one of "foo" or "bar", not "f".
+      Error in <<CALL `h()`>>:
+      ! <<ARG `my_arg`>> must be one of "foo" or "bar", not "f".
       i Did you mean "foo"?
       ---
       Backtrace:

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -229,7 +229,7 @@
     Output
       <error/rlang_error>
       Error in <<CALL `h()`>>:
-      ! <<ARG `my_arg`>> must be one of "foo" or "bar", not "f".
+      ! `my_arg` must be one of "foo" or "bar", not "f".
       i Did you mean "foo"?
       ---
       Backtrace:

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -1162,7 +1162,7 @@
 # must pass character `body` when `message` is > 1
 
     Code
-      err(abort("foo", body = function(cnd) c(i = "bar")))
+      err(abort("foo", body = function(cnd, ...) c(i = "bar")))
     Output
       <error/rlang_error>
       Error:
@@ -1180,7 +1180,7 @@
 # must pass character `body` when `message` is > 1 (non-cli case)
 
     Code
-      err(abort("foo", body = function(cnd) c(i = "bar")))
+      err(abort("foo", body = function(cnd, ...) c(i = "bar")))
     Output
       <error/rlang_error>
       Error:
@@ -1206,7 +1206,8 @@
       i bar
       i baz
     Code
-      err(abort("foo", body = function(cnd) c(i = "bar"), footer = function(cnd) c(i = "baz")))
+      err(abort("foo", body = function(cnd, ...) c(i = "bar"), footer = function(cnd,
+        ...) c(i = "baz")))
     Output
       <error/rlang_error>
       Error in `f()`:
@@ -1225,7 +1226,8 @@
       i bar
       i baz
     Code
-      err(abort("foo", body = function(cnd) c(i = "bar"), footer = function(cnd) c(i = "baz")))
+      err(abort("foo", body = function(cnd, ...) c(i = "bar"), footer = function(cnd,
+        ...) c(i = "baz")))
     Output
       <error/rlang_error>
       Error in `f()`:

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -1321,3 +1321,14 @@
         1. base::print(expect_error(my_verb(add(1, ""))))
        16. rlang (local) add(1, "")
 
+# can supply header method via `message`
+
+    Code
+      abort(~"foo")
+    Error <rlang_error>
+      foo
+    Code
+      abort(function(cnd, ...) "foo")
+    Error <rlang_error>
+      foo
+

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -486,3 +486,12 @@
       foo
       bar
 
+# arguments are highlighted but code spans are not
+
+    Code
+      with_error_arg_highlight(print(err))
+    Output
+      <error/rlang_error>
+      Error:
+      ! <<ARG `arg1`>> - `code` - <<ARG `arg2`>>
+

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -957,7 +957,7 @@
       print(err)
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
-      [1m[33mError[39m in [1m[94m[1m[1m`1 + ""`[39m[1m:[22m
+      [1m[33mError[39m in [1m[1m[1m[94m`1 + ""`[39m[1m:[22m
       [33m![39m non-numeric argument to binary operator
       ---
       [1mBacktrace:[22m
@@ -970,7 +970,7 @@
       summary(err)
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
-      [1m[33mError[39m in [1m[94m[1m[1m`1 + ""`[39m[1m:[22m
+      [1m[33mError[39m in [1m[1m[1m[94m`1 + ""`[39m[1m:[22m
       [33m![39m non-numeric argument to binary operator
       ---
       [1mBacktrace:[22m
@@ -1281,8 +1281,8 @@
       print_highlighted_trace(parent)
     Output
       <error/rlang_error>
-      Error in <<CALL h()>>:
-      ! <<ARG x>> must be a single string, not a number.
+      Error in <<CALL `h()`>>:
+      ! <<ARG `x`>> must be a single string, not a number.
       ---
       Backtrace:
            x
@@ -1301,10 +1301,10 @@
       print_highlighted_trace(child)
     Output
       <error/rlang_error>
-      Error in <<CALL wrapper()>>:
+      Error in <<CALL `wrapper()`>>:
       ! Tilt.
-      Caused by error in <<CALL h()>>:
-      ! <<ARG x>> must be a single string, not a number.
+      Caused by error in <<CALL `h()`>>:
+      ! <<ARG `x`>> must be a single string, not a number.
       ---
       Backtrace:
            x
@@ -1333,7 +1333,7 @@
       print_highlighted_trace(argless)
     Output
       <error/rlang_error>
-      Error in <<CALL h()>>:
+      Error in <<CALL `h()`>>:
       ! foo
       ---
       Backtrace:
@@ -1357,7 +1357,7 @@
       print_highlighted_trace(err)
     Output
       <error/rlang_error>
-      Error in <<CALL h()>>:
+      Error in <<CALL `h()`>>:
       ! foo
       ---
       Backtrace:

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1390,3 +1390,26 @@
        17.     \-rlang (local) g(x)
        18.       \-rlang (local) <<CALL h(>><<ARG x = x>><<CALL )>>
 
+# error calls and args are highlighted (no highlighted arg)
+
+    Code
+      print_highlighted_trace(argless)
+    Output
+      <error/rlang_error>
+      Error in <<CALL h()>>:
+      ! foo
+      ---
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(f())
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang (local) f()
+       10.   \-rlang (local) g()
+       11.     \-rlang (local) <<CALL h(>><<CALL )>>
+

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1290,6 +1290,19 @@
       Backtrace:
            x
         1. +-rlang:::catch_error(f())
+
+# error calls and args are highlighted
+
+    Code
+      print_highlighted_trace(parent)
+    Output
+      <error/rlang_error>
+      Error in <<CALL h()>>:
+      ! <<ARG x>> must be a single string, not a number.
+      ---
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(f(1))
         2. | \-rlang::catch_cnd(expr, "error")
         3. |   +-rlang::eval_bare(...)
         4. |   +-base::tryCatch(...)
@@ -1344,4 +1357,36 @@
         8. rlang (local) f()
         9. rlang (local) g()
        10. rlang (local) h()
+        9. \-rlang (local) f(1)
+       10.   \-rlang (local) g(x)
+       11.     \-rlang (local) <<CALL h(>><<ARG x = x>><<CALL )>>
+    Code
+      print_highlighted_trace(child)
+    Output
+      <error/rlang_error>
+      Error in <<CALL wrapper()>>:
+      ! Tilt.
+      Caused by error in <<CALL h()>>:
+      ! <<ARG x>> must be a single string, not a number.
+      ---
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(wrapper())
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang (local) wrapper()
+       10.   +-rlang::try_fetch(f(1), error = function(cnd) abort("Tilt.", parent = cnd))
+       11.   | +-base::tryCatch(...)
+       12.   | | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
+       13.   | |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+       14.   | |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
+       15.   | \-base::withCallingHandlers(...)
+       16.   \-rlang (local) f(1)
+       17.     \-rlang (local) g(x)
+       18.       \-rlang (local) <<CALL h(>><<ARG x = x>><<CALL )>>
 

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -957,7 +957,7 @@
       print(err)
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
-      [1m[33mError[39m in [1m[1m`1 + ""`:[22m
+      [1m[33mError[39m in [1m[94m[1m[1m`1 + ""`[39m[1m:[22m
       [33m![39m non-numeric argument to binary operator
       ---
       [1mBacktrace:[22m
@@ -970,7 +970,7 @@
       summary(err)
     Output
       [1m[1m[1m[34m<error/rlang_error>[39m[22m
-      [1m[33mError[39m in [1m[1m`1 + ""`:[22m
+      [1m[33mError[39m in [1m[94m[1m[1m`1 + ""`[39m[1m:[22m
       [33m![39m non-numeric argument to binary operator
       ---
       [1mBacktrace:[22m

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1413,3 +1413,27 @@
        10.   \-rlang (local) g()
        11.     \-rlang (local) <<CALL h(>><<CALL )>>
 
+# frame is detected from the left
+
+    Code
+      # If detected from the right, `evalq()`is highlighted instead of `h()`
+      print_highlighted_trace(err)
+    Output
+      <error/rlang_error>
+      Error in <<CALL h()>>:
+      ! foo
+      ---
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(f())
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang (local) f()
+       10.   \-rlang (local) g()
+       11.     \-rlang (local) <<CALL h(>><<CALL )>>
+

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1282,7 +1282,7 @@
     Output
       <error/rlang_error>
       Error in <<CALL `h()`>>:
-      ! <<ARG `x`>> must be a single string, not a number.
+      ! `x` must be a single string, not a number.
       ---
       Backtrace:
            x
@@ -1304,7 +1304,7 @@
       Error in <<CALL `wrapper()`>>:
       ! Tilt.
       Caused by error in <<CALL `h()`>>:
-      ! <<ARG `x`>> must be a single string, not a number.
+      ! `x` must be a single string, not a number.
       ---
       Backtrace:
            x

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1374,3 +1374,26 @@
        10.   \-rlang (local) g()
        11.     \-rlang (local) <<CALL h(>><<CALL )>>
 
+# arg is defensively checked
+
+    Code
+      print_highlighted_trace(err)
+    Output
+      <error/rlang_error>
+      Error in <<CALL `h()`>>:
+      ! foo
+      ---
+      Backtrace:
+           x
+        1. +-rlang:::catch_error(f())
+        2. | \-rlang::catch_cnd(expr, "error")
+        3. |   +-rlang::eval_bare(...)
+        4. |   +-base::tryCatch(...)
+        5. |   | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
+        6. |   |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
+        7. |   |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
+        8. |   \-base::force(expr)
+        9. \-rlang (local) f()
+       10.   \-rlang (local) g()
+       11.     \-rlang (local) <<CALL h(>><<CALL )>>
+

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1275,22 +1275,6 @@
        22. rlang (local) g(n)
        23. rlang (local) h(n)
 
-# collapse is deprecated
-
-    Code
-      print(err, simplify = "collapse", srcrefs = FALSE)
-    Warning <deprecatedWarning>
-      `"collapse"` is deprecated as of rlang 1.1.0.
-      Please use `"none"` instead.
-    Output
-      <error/rlang_error>
-      Error in `h()`:
-      ! foo
-      ---
-      Backtrace:
-           x
-        1. +-rlang:::catch_error(f())
-
 # error calls and args are highlighted
 
     Code
@@ -1310,53 +1294,6 @@
         6. |   |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
         7. |   |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
         8. |   \-base::force(expr)
-        9. \-rlang (local) f()
-       10.   \-rlang (local) g()
-       11.     \-rlang (local) h()
-       12.       \-rlang::abort("foo")
-
-# focal trace highlighting is not affected by hidden frames
-
-    Code
-      # Full
-      print(trace, simplify = "none", dir = dir, srcrefs = srcrefs)
-    Output
-           x
-        1. +-rlang::catch_cnd(f())
-        2. | +-rlang::eval_bare(...)
-        3. | +-base::tryCatch(...)
-        4. | | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
-        5. | |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
-        6. | |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
-        7. | \-base::force(expr)
-        8. +-rlang (local) f()
-        9. | \-rlang (local) g()
-       10. |   \-rlang (local) h()
-       11. |     \-rlang::inject(rlang::abort("foo", call = !!environment()), global_env())
-       12. \-rlang::abort("foo", call = `<env>`)
-    Code
-      # Focused
-      print_focused_trace(trace, dir = dir, srcrefs = srcrefs)
-    Output
-           x
-        1. +-rlang::catch_cnd(f())
-        2. | <<+-rlang::eval_bare(...)>>
-        3. | <<+-base::tryCatch(...)>>
-        4. | <<| \-base (local) tryCatchList(expr, classes, parentenv, handlers)>>
-        5. | <<|   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])>>
-        6. | <<|     \-base (local) doTryCatch(return(expr), name, parentenv, handler)>>
-        7. | <<\-base::force(expr)>>
-        8. \-rlang (local) f()
-        9.   \-rlang (local) g()
-       10.     \-rlang (local) h()
-    Code
-      # Branch
-      print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
-    Output
-        1. rlang::catch_cnd(f())
-        8. rlang (local) f()
-        9. rlang (local) g()
-       10. rlang (local) h()
         9. \-rlang (local) f(1)
        10.   \-rlang (local) g(x)
        11.     \-rlang (local) <<CALL h(>><<ARG x = x>><<CALL )>>

--- a/tests/testthat/fixtures/error-backtrace-conditionMessage.R
+++ b/tests/testthat/fixtures/error-backtrace-conditionMessage.R
@@ -9,7 +9,7 @@ if (nzchar(Sys.getenv("rlang_interactive"))) {
 }
 options(rlang_trace_format_srcrefs = FALSE)
 
-cnd_header.foobar_error <- function(c) {
+cnd_header.foobar_error <- function(c, ...) {
   "dispatched!"
 }
 

--- a/tests/testthat/helper-trace.R
+++ b/tests/testthat/helper-trace.R
@@ -18,6 +18,14 @@ print_focused_trace <- function(trace, ...) {
   )
 }
 
+print_highlighted_trace <- function(x, ...) {
+  local_options(
+    "rlang_trace_format_srcrefs" = FALSE,
+    "rlang:::trace_test_highlight" = TRUE
+  )
+  print(x, ..., simplify = "none", drop = TRUE)
+}
+
 expect_trace_length <- function(x, n) {
   expect_equal(trace_length(x), n)
 }

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -310,3 +310,14 @@ test_that("arg_match() mentions correct call if wrong type is supplied (#1388)",
     (expect_error(g(1)))
   })
 })
+
+test_that("arg_match() backtrace highlights call and arg", {
+  f <- function(x) g(x)
+  g <- function(x) h(x)
+  h <- function(my_arg = c("foo", "bar")) arg_match(my_arg)
+  err <- catch_error(f("f"))
+
+  expect_snapshot({
+    print_highlighted_trace(err)
+  })
+})

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -597,7 +597,7 @@ test_that("setting `.internal` adds footer bullet (fallback)", {
 test_that("must pass character `body` when `message` is > 1", {
   expect_snapshot({
     # This is ok because `message` is length 1
-    err(abort("foo", body = function(cnd) c("i" = "bar")))
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
 
     # This is an internal error
     err(abort(c("foo", "bar"), body = function() "baz"))
@@ -608,7 +608,7 @@ test_that("must pass character `body` when `message` is > 1 (non-cli case)", {
   local_use_cli(format = FALSE)
   expect_snapshot({
     # This is ok because `message` is length 1
-    err(abort("foo", body = function(cnd) c("i" = "bar")))
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
 
     # This is an internal error
     err(abort(c("foo", "bar"), body = function() "baz"))
@@ -619,7 +619,7 @@ test_that("can supply `footer`", {
   local_error_call(call("f"))
   expect_snapshot({
     err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
-    err(abort("foo", body = function(cnd) c("i" = "bar"), footer = function(cnd) c("i" = "baz")))
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
   })
 })
 
@@ -628,7 +628,7 @@ test_that("can supply `footer` (non-cli case)", {
   local_error_call(call("f"))
   expect_snapshot({
     err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
-    err(abort("foo", body = function(cnd) c("i" = "bar"), footer = function(cnd) c("i" = "baz")))
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
   })
 })
 

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -858,3 +858,19 @@ test_that("backtrace_on_error = 'collapse' is deprecated.", {
   expect_warning(peek_backtrace_on_error(), "deprecated")
   expect_equal(peek_option("rlang_backtrace_on_error"), "none")
 })
+
+test_that("can supply header method via `message`", {
+  expect_snapshot(error = TRUE, {
+    abort(~ "foo")
+    abort(function(cnd, ...) "foo")
+  })
+
+  msg <- function(cnd, ...) "foo"
+  cnd <- catch_error(abort(msg))
+  expect_identical(cnd$header, msg)
+
+  expect_error(
+    abort(function(cnd) "foo"),
+    "must take"
+  )
+})

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -532,3 +532,20 @@ test_that("`cnd_message(prefix = TRUE)` propagates warning style across parent e
   expect_false(grepl("\033\\[1mCaused by error", msg_warning))
   expect_true(grepl("\033\\[1mCaused by error", msg_error))
 })
+
+test_that("arguments are highlighted but code spans are not", {
+  local_options("rlang:::trace_test_highlight" = TRUE)
+
+  err <- error_cnd(header = function(cnd) sprintf(
+    "%s - %s - %s",
+    format_arg("arg1"),
+    format_code("code"),
+    format_arg("arg2")
+  ))
+
+  expect_snapshot({
+    with_error_arg_highlight(
+      print(err)
+    )
+  })
+})

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -47,7 +47,7 @@ test_that("rlang_error.print() calls cnd_message() methods", {
 test_that("Overlapping backtraces are printed separately", {
   # Test low-level error can use conditionMessage()
   local_bindings(.env = global_env(),
-    cnd_header.foobar = function(c) c$foobar_msg
+    cnd_header.foobar = function(c, ...) c$foobar_msg
   )
 
   f <- function() g()

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -686,3 +686,15 @@ test_that("error calls and args are highlighted", {
     print_highlighted_trace(child)
   })
 })
+
+test_that("error calls and args are highlighted (no highlighted arg)", {
+  f <- function() g()
+  g <- function() h()
+  h <- function() abort("foo")
+
+  argless <- catch_error(f())
+
+  expect_snapshot({
+    print_highlighted_trace(argless)
+  })
+})

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -670,29 +670,19 @@ test_that("parallel '|' branches are correctly emphasised", {
   expect_snapshot_trace(err)
 })
 
-test_that("collapse is deprecated", {
-  # Classed deprecation warning
-  skip_if_not_installed("base", "3.6.0")
+test_that("error calls and args are highlighted", {
+  f <- function(x) g(x)
+  g <- function(x) h(x)
+  h <- function(x) check_string(x)
+  wrapper <- function() {
+    try_fetch(f(1), error = function(cnd) abort("Tilt.", parent = cnd))
+  }
 
-  local_lifecycle_warnings()
-
-  f <- function() g()
-  g <- function() h()
-  h <- function() abort("foo")
-  err <- catch_error(f())
+  parent <- catch_error(f(1))
+  child <- catch_error(wrapper())
 
   expect_snapshot({
-    print(err, simplify = "collapse", srcrefs = FALSE)
+    print_highlighted_trace(parent)
+    print_highlighted_trace(child)
   })
-})
-
-test_that("focal trace highlighting is not affected by hidden frames", {
-  f <- function() g()
-  g <- function() h()
-  h <- function() {
-    inject(rlang::abort("foo", call = !!environment()), global_env())
-  }
-  err <- catch_cnd(f())
-
-  expect_snapshot_trace(err$trace)
 })

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -710,3 +710,14 @@ test_that("frame is detected from the left", {
     print_highlighted_trace(err)
   })
 })
+
+test_that("arg is defensively checked", {
+  f <- function() g()
+  g <- function() h()
+  h <- function() abort("foo", arg = env())
+  err <- catch_error(f())
+
+  expect_snapshot({
+    print_highlighted_trace(err)
+  })
+})

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -698,3 +698,15 @@ test_that("error calls and args are highlighted (no highlighted arg)", {
     print_highlighted_trace(argless)
   })
 })
+
+test_that("frame is detected from the left", {
+  f <- function() g()
+  g <- function() h()
+  h <- function() identity(evalq(identity(abort("foo"))))
+  err <- catch_error(f())
+
+  expect_snapshot({
+    "If detected from the right, `evalq()`is highlighted instead of `h()`"
+    print_highlighted_trace(err)
+  })
+})


### PR DESCRIPTION
* When `call` is a frame environment, the corresponding function call is now highlighted in the backtrace.

* When a function argument for that function call is stored in the `arg` condition field, this argument is highlighted in the backtrace.

* A special cli theme is registered when printing the backtrace to highlight the calls and arguments. Calls are highlighted in bold bright blue, and args in bold bright magenta.

* The cli theme is only applied at print time. This means that input checking functions must format the error message lazily. To support this, `abort()` now accepts a `cnd_header()` method via the `message` argument.

* `arg_match()` and the internal checking functions (implemented via `stop_input_type()` from compat-friendly-type-of.R) now support this.

Before:

```r
check_string <- function(x, call = caller_env(), arg = caller_arg(x)) {
  if (!is_string(x)) {
    cli::cli_abort("{.arg {arg}} must be a string.", call = call)
  }
}
```

After:

```r
check_string <- function(x, call = caller_env(), arg = caller_arg(x)) {
  if (!is_string(x)) {
    msg <- \(...) cli::format_inline("{.arg {arg}} must be a string.")
    abort(msg, call = call, arg = arg)
  }
}
```

If we eventually decide to format all calls and arguments in the same highlighted style unconditionally, then we'll no longer need that laziness. In that case, the calls and args would be highlighted in the error message as well. With the current setup, these use the default cli theme:

<img width="562" alt="Screenshot 2022-06-17 at 13 40 35" src="https://user-images.githubusercontent.com/4465050/174291517-c5232a0f-352d-4970-9fce-eb469ac4ff59.png">