### PR TITLE
Use prettyunits to format bytes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rlang (development version)
 
+* The `rlib_bytes` class now uses prettyunits to format bytes. The
+  bytes are now represented with decimal prefixes instead of binary
+  prefixes.
+
 * Supplying a frame environment to the `call` argument of `abort()`
   now causes the corresponding function call in the backtrace to be
   highlighted.

--- a/R/bytes.R
+++ b/R/bytes.R
@@ -106,7 +106,7 @@ parse_bytes <- function(x) {
   stopifnot(is_character(x))
 
   pos <- regexpr(
-    "^(?<size>[[:digit:].]+)\\s*(?<unit>[KMGTPEZY]?)i?[Bb]?$",
+    "^(?<size>[[:digit:].]+)\\s*(?<unit>[kKMGTPEZY]?)i?[Bb]?$",
     x,
     perl = TRUE
   )
@@ -116,16 +116,18 @@ parse_bytes <- function(x) {
   new_bytes(unname(as.numeric(m$size) * byte_units[m$unit]))
 }
 
+# TODO: Add support for decimal prefixes
 byte_units <- c(
   'B' = 1,
-  'K' = 1024,
-  'M' = 1024 ^ 2,
-  'G' = 1024 ^ 3,
-  'T' = 1024 ^ 4,
-  'P' = 1024 ^ 5,
-  'E' = 1024 ^ 6,
-  'Z' = 1024 ^ 7,
-  'Y' = 1024 ^ 8
+  'k' = 1000,
+  'K' = 1000,
+  'M' = 1000 ^ 2,
+  'G' = 1000 ^ 3,
+  'T' = 1000 ^ 4,
+  'P' = 1000 ^ 5,
+  'E' = 1000 ^ 6,
+  'Z' = 1000 ^ 7,
+  'Y' = 1000 ^ 8
 )
 
 captures <- function(x, m) {
@@ -184,19 +186,6 @@ auto_name_seq <- function(names) {
 format.rlib_bytes <- function(x, ...) {
   check_dots_used()
   format_bytes$pretty_bytes(unclass(x))
-}
-
-tolerance <- sqrt(.Machine$double.eps)
-
-find_unit <- function(x, units) {
-  if (is.na(x) || is.nan(x) || x <= 0 || is.infinite(x)) {
-    return(NA_character_)
-  }
-  epsilon <- 1 - (x * (1 / units))
-
-  out <- which(epsilon < tolerance)
-  out <- out[length(out)]
-  names(out)
 }
 
 #' @export

--- a/R/bytes.R
+++ b/R/bytes.R
@@ -14,7 +14,7 @@
 #' Note: A `bytes()` constructor will be exported soon.
 #'
 #' @details
-#' These memory sizes are always assumed to be base 1024, rather than 1000.
+#' These memory sizes are always assumed to be base 1000, rather than 1024.
 #'
 #' @param x A numeric or character vector. Character representations can use
 #'   shorthand sizes (see examples).
@@ -181,41 +181,9 @@ auto_name_seq <- function(names) {
 
 # Adapted from https://github.com/gaborcsardi/prettyunits
 #' @export
-format.rlib_bytes <- function(x,
-                              ...,
-                              digits = 3,
-                              scientific = FALSE,
-                              drop0trailing = TRUE) {
+format.rlib_bytes <- function(x, ...) {
   check_dots_used()
-
-  nms <- names(x)
-  bytes <- unclass(x)
-
-  unit <- map_chr(x, find_unit, byte_units)
-  res <- round(bytes / byte_units[unit], digits = digits)
-
-  ## Zero bytes
-  res[bytes == 0] <- 0
-  unit[bytes == 0] <- "B"
-
-  ## NA and NaN bytes
-  res[is.na(bytes)] <- NA_real_
-  res[is.nan(bytes)] <- NaN
-  unit[is.na(bytes)] <- ""            # Includes NaN as well
-
-  # Append an extra B to each unit
-  large_units <- unit %in% names(byte_units)[-1]
-  unit[large_units] <- paste0(unit[large_units], "B")
-
-  res <- format(
-    res,
-    scientific = scientific,
-    digits = digits,
-    drop0trailing = drop0trailing,
-    ...
-  )
-
-  stats::setNames(paste0(res, unit), nms)
+  format_bytes$pretty_bytes(unclass(x))
 }
 
 tolerance <- sqrt(.Machine$double.eps)

--- a/R/compat-sizes.R
+++ b/R/compat-sizes.R
@@ -1,0 +1,118 @@
+# nocov start - compat-sizes.R
+# Latest version: https://github.com/r-lib/prettyunits/blob/main/R/sizes.R
+
+format_bytes <- local({
+
+  pretty_bytes <- function(bytes, style = c("default", "nopad", "6")) {
+
+    style <- switch(
+      match.arg(style),
+      "default" = pretty_bytes_default,
+      "nopad" = pretty_bytes_nopad,
+      "6" = pretty_bytes_6
+    )
+
+    style(bytes)
+  }
+
+  compute_bytes <- function(bytes, smallest_unit = "B") {
+    units0 <- c("B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB")
+
+    stopifnot(
+      is.numeric(bytes),
+      is.character(smallest_unit),
+      length(smallest_unit) == 1,
+      !is.na(smallest_unit),
+      smallest_unit %in% units0
+    )
+
+    limits <- c(1000, 999950 * 1000 ^ (seq_len(length(units0) - 2) - 1))
+    low <- match(smallest_unit, units0)
+    units <- units0[low:length(units0)]
+    limits <- limits[low:length(limits)]
+
+    neg <- bytes < 0 & !is.na(bytes)
+    bytes <- abs(bytes)
+
+    mat <- matrix(
+      rep(bytes, each = length(limits)),
+      nrow = length(limits),
+      ncol = length(bytes)
+    )
+    mat2 <- matrix(mat < limits, nrow  = length(limits), ncol = length(bytes))
+    exponent <- length(limits) - colSums(mat2) + low - 1L
+    res <- bytes / 1000 ^ exponent
+    unit <- units[exponent - low + 2L]
+
+    ## Zero bytes
+    res[bytes == 0] <- 0
+    unit[bytes == 0] <- units[1]
+
+    ## NA and NaN bytes
+    res[is.na(bytes)] <- NA_real_
+    res[is.nan(bytes)] <- NaN
+    unit[is.na(bytes)] <- units0[low]     # Includes NaN as well
+
+    data.frame(
+      stringsAsFactors = FALSE,
+      amount = res,
+      unit = unit,
+      negative = neg
+    )
+  }
+
+  pretty_bytes_default <- function(bytes) {
+    szs <- compute_bytes(bytes)
+    amt <- szs$amount
+
+    ## String. For fractions we always show two fraction digits
+    res <- character(length(amt))
+    int <- is.na(amt) | amt == as.integer(amt)
+    res[int] <- format(
+      ifelse(szs$negative[int], -1, 1) * amt[int],
+      scientific = FALSE
+    )
+    res[!int] <- sprintf("%.2f", ifelse(szs$negative[!int], -1, 1) * amt[!int])
+
+    format(paste(res, szs$unit), justify = "right")
+  }
+
+  pretty_bytes_nopad <- function(bytes) {
+    sub("^\\s+", "", pretty_bytes_default(bytes))
+  }
+
+  pretty_bytes_6 <- function(bytes) {
+    szs <- compute_bytes(bytes, smallest_unit = "kB")
+    amt <- szs$amount
+
+    na   <- is.na(amt)
+    nan  <- is.nan(amt)
+    neg  <- !na & !nan & szs$negative
+    l10  <- !na & !nan & !neg & amt < 10
+    l100 <- !na & !nan & !neg & amt >= 10 & amt < 100
+    b100 <- !na & !nan & !neg & amt >= 100
+
+    szs$unit[neg] <- "kB"
+
+    famt <- character(length(amt))
+    famt[na] <- " NA"
+    famt[nan] <- "NaN"
+    famt[neg] <- "< 0"
+    famt[l10] <- sprintf("%.1f", amt[l10])
+    famt[l100] <- sprintf(" %.0f", amt[l100])
+    famt[b100] <- sprintf("%.0f", amt[b100])
+
+    paste0(famt, " ", szs$unit)
+  }
+
+  structure(
+    list(
+      .internal     = environment(),
+      pretty_bytes  = pretty_bytes,
+      compute_bytes = compute_bytes
+    ),
+    class = c("standalone_bytes", "standalone")
+  )
+})
+
+# nocov end

--- a/man/bytes-class.Rd
+++ b/man/bytes-class.Rd
@@ -28,7 +28,7 @@ representing bytes.
 Note: A \code{bytes()} constructor will be exported soon.
 }
 \details{
-These memory sizes are always assumed to be base 1024, rather than 1000.
+These memory sizes are always assumed to be base 1000, rather than 1024.
 }
 \examples{
 parse_bytes("1")

--- a/tests/testthat/_snaps/bytes.md
+++ b/tests/testthat/_snaps/bytes.md
@@ -1,3 +1,10 @@
+# format.rlib_bytes() works with vectors
+
+    Code
+      print(as_bytes(c(NA, 1, 2^13, 2^20, NaN, 2^15)))
+    Output
+      [1]     NA B      1 B  8.19 kB  1.05 MB    NaN B 32.77 kB
+
 # print method disambiguates edge cases
 
     Code
@@ -12,5 +19,5 @@
       print(bytes2(NA, NA))
     Output
       <rlib:bytes>
-      [1] NA NA
+      [1] NA B NA B
 

--- a/tests/testthat/_snaps/dots.md
+++ b/tests/testthat/_snaps/dots.md
@@ -58,13 +58,13 @@
       x <- as.list(1:100)
       with_memory_prof(out <- list2(!!!x))
     Output
-      [1] 0B
+      [1] 0 B
     Code
       expect_equal(out, as.list(x))
       x <- 1:100 + 0L
       with_memory_prof(out <- list2(!!!x))
     Output
-      [1] 848B
+      [1] 848 B
     Code
       expect_equal(out, as.list(x))
 

--- a/tests/testthat/test-bytes.R
+++ b/tests/testthat/test-bytes.R
@@ -25,10 +25,10 @@ test_that("as_bytes() accepts bench_byte input unchanged", {
 
 test_that("parse_bytes() parses character input", {
   expect_equal(unclass(parse_bytes("1")), 1)
-  expect_equal(unclass(parse_bytes("1K")), 1024)
-  expect_equal(unclass(parse_bytes("1M")), 1024 * 1024)
-  expect_equal(unclass(parse_bytes("10M")), 10 * 1024 * 1024)
-  expect_equal(unclass(parse_bytes("1G")), 1024 * 1024 * 1024)
+  expect_equal(unclass(parse_bytes("1K")), 1000)
+  expect_equal(unclass(parse_bytes("1M")), 1000 * 1000)
+  expect_equal(unclass(parse_bytes("10M")), 10 * 1000 * 1000)
+  expect_equal(unclass(parse_bytes("1G")), 1000 * 1000 * 1000)
 })
 
 test_that("format.rlib_bytes() formats bytes under 1024 as whole numbers", {
@@ -113,7 +113,7 @@ test_that("Ops.rlib_bytes() works with arithmetic operators", {
   expect_equal(x * 100, bytes2(c(10000, 20000, 30000)))
   expect_equal(x / 2, bytes2(c(50, 100, 150)))
   expect_equal(x ^ 2, bytes2(c(10000, 40000, 90000)))
-  expect_equal(bytes2("1Mb") + "1024Kb", bytes2("2Mb"))
+  expect_equal(bytes2("1Mb") + "1000Kb", bytes2("2Mb"))
 })
 
 test_that("Ops.rlib_bytes() errors for other binary operators", {

--- a/tests/testthat/test-bytes.R
+++ b/tests/testthat/test-bytes.R
@@ -32,31 +32,30 @@ test_that("parse_bytes() parses character input", {
 })
 
 test_that("format.rlib_bytes() formats bytes under 1024 as whole numbers", {
-  expect_equal(format(bytes2(0)), "0B")
-  expect_equal(format(bytes2(1)), "1B")
-  expect_equal(format(bytes2(1023)), "1023B")
+  expect_equal(format(bytes2(0)), "0 B")
+  expect_equal(format(bytes2(1)), "1 B")
+  expect_equal(format(bytes2(1023)), "1.02 kB")
 })
 
 test_that("format.rlib_bytes() formats bytes 1024 and up as abbreviated numbers", {
-  expect_equal(format(bytes2(1024)), "1KB")
-  expect_equal(format(bytes2(1025)), "1KB")
-  expect_equal(format(bytes2(2^16)), "64KB")
-  expect_equal(format(bytes2(2^24)), "16MB")
-  expect_equal(format(bytes2(2^24 + 555555)), "16.5MB")
-  expect_equal(format(bytes2(2^32)), "4GB")
-  expect_equal(format(bytes2(2^48)), "256TB")
-  expect_equal(format(bytes2(2^64)), "16EB")
+  expect_equal(format(bytes2(1024)), "1.02 kB")
+  expect_equal(format(bytes2(1025)), "1.02 kB")
+  expect_equal(format(bytes2(2^16)), "65.54 kB")
+  expect_equal(format(bytes2(2^24)), "16.78 MB")
+  expect_equal(format(bytes2(2^24 + 555555)), "17.33 MB")
+  expect_equal(format(bytes2(2^32)), "4.29 GB")
+  expect_equal(format(bytes2(2^48)), "281.47 TB")
+  expect_equal(format(bytes2(2^64)), "18.45 EB")
 })
 
 test_that("format.rlib_bytes() handles NA and NaN", {
-  expect_equal(format(bytes2(NA)), "NA")
-  expect_equal(format(bytes2(NaN)), "NaN")
+  expect_equal(format(bytes2(NA)), "NA B")
+  expect_equal(format(bytes2(NaN)), "NaN B")
 })
 
 test_that("format.rlib_bytes() works with vectors", {
-  expect_equal(
-    format(as_bytes(c(NA, 1, 2^13, 2^20, NaN, 2^15)), trim = TRUE),
-    c("NA", "1B", "8KB", "1MB", "NaN", "32KB")
+  expect_snapshot(
+    print(as_bytes(c(NA, 1, 2^13, 2^20, NaN, 2^15)))
   )
   expect_equal(
     format(as_bytes(numeric())),


### PR DESCRIPTION
It would be nice to provide a global option to format bytes with binary prefixes. This requires https://github.com/r-lib/prettyunits/issues/29.