### PR TITLE
Add missing curly braces to caller_arg() example

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -1063,7 +1063,7 @@ NULL
 #'
 #' @examples
 #' arg_checker <- function(x, arg = caller_arg(x), call = caller_env()) {
-#'   cli::cli_abort("{.arg arg} must be a thingy.", call = call)
+#'   cli::cli_abort("{.arg {arg}} must be a thingy.", call = call)
 #' }
 #'
 #' my_function <- function(my_arg) {

--- a/man/caller_arg.Rd
+++ b/man/caller_arg.Rd
@@ -21,7 +21,7 @@ in the cli package.
 }
 \examples{
 arg_checker <- function(x, arg = caller_arg(x), call = caller_env()) {
-  cli::cli_abort("{.arg arg} must be a thingy.", call = call)
+  cli::cli_abort("{.arg {arg}} must be a thingy.", call = call)
 }
 
 my_function <- function(my_arg) {


### PR DESCRIPTION
This fixes the example in the caller_arg() documentation which was not evaluating `arg` as it was missing a set of curly braces.