### PR TITLE
missing is_dictionaryish from pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -315,7 +315,7 @@ reference:
       - names2
       - has_name
       - is_named
-	  - is_dictionaryish
+      - is_dictionaryish
       - zap_srcref
 
   - subtitle: Vectors

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -315,6 +315,7 @@ reference:
       - names2
       - has_name
       - is_named
+	  - is_dictionaryish
       - zap_srcref
 
   - subtitle: Vectors


### PR DESCRIPTION
Maybe this omission was (once) intentional (hinted-at by the undoing here: afc195846209f84015b3871ded3f9dc99af8d2ee).

If not intentional, this adds it to the pkgdown site.