### PR TITLE
Increment version number to 1.0.4.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rlang
-Version: 1.0.4
+Version: 1.0.4.9000
 Title: Functions for Base Types and Core R and 'Tidyverse' Features
 Description: A toolbox for working with base types, core R features
   like the condition system, and core 'Tidyverse' features like tidy

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rlang (development version)
+
 # rlang 1.0.4
 
 * `is_installed()` no longer throws an error with irregular package

--- a/src/version.c
+++ b/src/version.c
@@ -1,7 +1,7 @@
 #define R_NO_REMAP
 #include <Rinternals.h>
 
-const char* rlang_version = "1.0.4";
+const char* rlang_version = "1.0.4.9000";
 
 /**
  * This file records the expected package version in the shared


### PR DESCRIPTION
Just as a reminder, not sure if you had any intermediate changes between the HEAD of `main` and CRAN actually accepting 1.0.4