### PR TITLE
Fix returning invisibly

### DIFF
--- a/R/arg.R
+++ b/R/arg.R
@@ -181,7 +181,7 @@ check_required <- function(x,
                            arg = caller_arg(x),
                            call = caller_env()) {
   if (!missing(x)) {
-    invisible(return(TRUE))
+    return(invisible(TRUE))
   }
 
   arg_expr <- substitute(x)


### PR DESCRIPTION
Hi, I just randomly stumbled upon this. I believe the intention was to return invisibly, however, that is not what R does:
```
f = function() invisible(return(5))
f()
## [1] 5
f = function() return(invisible(5))
f()
##
```
`invisible` is a builtin that evaluates its arguments eagerly, and `return` uses a non-local jump to get out of the function, skipping the visibility change.