### PR TITLE
Fix `has_crayon()` performance cost

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -1382,7 +1382,7 @@ format_onerror_backtrace <- function(cnd, opt = peek_backtrace_on_error()) {
       } else {
         last_error <- style_rlang_run("last_error()")
       }
-      reminder <- silver(paste0("Run `", last_error, "` to see where the error occurred."))
+      reminder <- col_silver(paste0("Run `", last_error, "` to see where the error occurred."))
     } else {
       reminder <- NULL
     }

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -392,9 +392,9 @@ message_freq <- function(message, frequency, type) {
   }
 
   if (is_string(frequency, "regularly")) {
-    info <- silver("This %s is displayed once every 8 hours.")
+    info <- col_silver("This %s is displayed once every 8 hours.")
   } else {
-    info <- silver("This %s is displayed once per session.")
+    info <- col_silver("This %s is displayed once per session.")
   }
   sprintf(info, type)
 }

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -416,12 +416,12 @@ format.rlang_error <- function(x,
       hidden <- sprintf(hidden, n_hidden)
 
       last_trace <- style_rlang_run("last_trace(drop = FALSE)")
-      reminder <- silver(sprintf("Run %s to see %s.", last_trace, hidden))
+      reminder <- col_silver(sprintf("Run %s to see %s.", last_trace, hidden))
 
       out <- paste_line(out, reminder)
     } else if (simplify == "branch") {
       last_trace <- style_rlang_run("last_trace()")
-      reminder <- silver(paste0("Run `", last_trace, "` to see the full context."))
+      reminder <- col_silver(paste0("Run `", last_trace, "` to see the full context."))
       out <- paste_line(out, reminder)
     }
   }
@@ -584,7 +584,7 @@ paste_trace <- function(x, trace, simplify, ...) {
     ...,
     simplify = simplify
   )
-  paste_line(x, bold("Backtrace:"), trace_lines)
+  paste_line(x, style_bold("Backtrace:"), trace_lines)
 }
 
 cnd_type_header <- function(cnd) {
@@ -595,7 +595,7 @@ cnd_type_header <- function(cnd) {
     class <- c(type, class)
   }
 
-  bold(format_cls(class))
+  style_bold(format_cls(class))
 }
 
 testthat_print_cnd <- function(x, ...) {

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -7,6 +7,12 @@
 #
 # Changelog:
 #
+# 2022-08-16:
+#
+# * Added `has_ansi()`. This checks that cli is installed and that
+#   `cli::num_ansi_colors()` is greater than 1.
+#
+#
 # 2022-05-23:
 #
 # * Added compat for `style_hyperlink()`.
@@ -90,49 +96,49 @@ ansi_alert  <- function() col_yellow(symbol_alert())
 #' @param x A string.
 #'
 #' @noRd
-col_black              <- function(x) if (.rlang_cli_has_ansi()) cli::col_black(x) else x
-col_blue               <- function(x) if (.rlang_cli_has_ansi()) cli::col_blue(x) else x
-col_cyan               <- function(x) if (.rlang_cli_has_ansi()) cli::col_cyan(x) else x
-col_green              <- function(x) if (.rlang_cli_has_ansi()) cli::col_green(x) else x
-col_magenta            <- function(x) if (.rlang_cli_has_ansi()) cli::col_magenta(x) else x
-col_red                <- function(x) if (.rlang_cli_has_ansi()) cli::col_red(x) else x
-col_white              <- function(x) if (.rlang_cli_has_ansi()) cli::col_white(x) else x
-col_yellow             <- function(x) if (.rlang_cli_has_ansi()) cli::col_yellow(x) else x
-col_grey               <- function(x) if (.rlang_cli_has_ansi()) cli::col_grey(x) else x
-col_silver             <- function(x) if (.rlang_cli_has_ansi()) cli::col_silver(x) else x
-col_none               <- function(x) if (.rlang_cli_has_ansi()) cli::col_none(x) else x
+col_black              <- function(x) if (has_ansi()) cli::col_black(x) else x
+col_blue               <- function(x) if (has_ansi()) cli::col_blue(x) else x
+col_cyan               <- function(x) if (has_ansi()) cli::col_cyan(x) else x
+col_green              <- function(x) if (has_ansi()) cli::col_green(x) else x
+col_magenta            <- function(x) if (has_ansi()) cli::col_magenta(x) else x
+col_red                <- function(x) if (has_ansi()) cli::col_red(x) else x
+col_white              <- function(x) if (has_ansi()) cli::col_white(x) else x
+col_yellow             <- function(x) if (has_ansi()) cli::col_yellow(x) else x
+col_grey               <- function(x) if (has_ansi()) cli::col_grey(x) else x
+col_silver             <- function(x) if (has_ansi()) cli::col_silver(x) else x
+col_none               <- function(x) if (has_ansi()) cli::col_none(x) else x
 
-bg_black               <- function(x) if (.rlang_cli_has_ansi()) cli::bg_black(x) else x
-bg_blue                <- function(x) if (.rlang_cli_has_ansi()) cli::bg_blue(x) else x
-bg_cyan                <- function(x) if (.rlang_cli_has_ansi()) cli::bg_cyan(x) else x
-bg_green               <- function(x) if (.rlang_cli_has_ansi()) cli::bg_green(x) else x
-bg_magenta             <- function(x) if (.rlang_cli_has_ansi()) cli::bg_magenta(x) else x
-bg_red                 <- function(x) if (.rlang_cli_has_ansi()) cli::bg_red(x) else x
-bg_white               <- function(x) if (.rlang_cli_has_ansi()) cli::bg_white(x) else x
-bg_yellow              <- function(x) if (.rlang_cli_has_ansi()) cli::bg_yellow(x) else x
-bg_none                <- function(x) if (.rlang_cli_has_ansi()) cli::bg_none(x) else x
+bg_black               <- function(x) if (has_ansi()) cli::bg_black(x) else x
+bg_blue                <- function(x) if (has_ansi()) cli::bg_blue(x) else x
+bg_cyan                <- function(x) if (has_ansi()) cli::bg_cyan(x) else x
+bg_green               <- function(x) if (has_ansi()) cli::bg_green(x) else x
+bg_magenta             <- function(x) if (has_ansi()) cli::bg_magenta(x) else x
+bg_red                 <- function(x) if (has_ansi()) cli::bg_red(x) else x
+bg_white               <- function(x) if (has_ansi()) cli::bg_white(x) else x
+bg_yellow              <- function(x) if (has_ansi()) cli::bg_yellow(x) else x
+bg_none                <- function(x) if (has_ansi()) cli::bg_none(x) else x
 
-style_dim              <- function(x) if (.rlang_cli_has_ansi()) cli::style_dim(x) else x
-style_blurred          <- function(x) if (.rlang_cli_has_ansi()) cli::style_blurred(x) else x
-style_bold             <- function(x) if (.rlang_cli_has_ansi()) cli::style_bold(x) else x
-style_hidden           <- function(x) if (.rlang_cli_has_ansi()) cli::style_hidden(x) else x
-style_inverse          <- function(x) if (.rlang_cli_has_ansi()) cli::style_inverse(x) else x
-style_italic           <- function(x) if (.rlang_cli_has_ansi()) cli::style_italic(x) else x
-style_strikethrough    <- function(x) if (.rlang_cli_has_ansi()) cli::style_strikethrough(x) else x
-style_underline        <- function(x) if (.rlang_cli_has_ansi()) cli::style_underline(x) else x
+style_dim              <- function(x) if (has_ansi()) cli::style_dim(x) else x
+style_blurred          <- function(x) if (has_ansi()) cli::style_blurred(x) else x
+style_bold             <- function(x) if (has_ansi()) cli::style_bold(x) else x
+style_hidden           <- function(x) if (has_ansi()) cli::style_hidden(x) else x
+style_inverse          <- function(x) if (has_ansi()) cli::style_inverse(x) else x
+style_italic           <- function(x) if (has_ansi()) cli::style_italic(x) else x
+style_strikethrough    <- function(x) if (has_ansi()) cli::style_strikethrough(x) else x
+style_underline        <- function(x) if (has_ansi()) cli::style_underline(x) else x
 
-style_no_dim           <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_dim(x) else x
-style_no_blurred       <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_blurred(x) else x
-style_no_bold          <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_bold(x) else x
-style_no_hidden        <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_hidden(x) else x
-style_no_inverse       <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_inverse(x) else x
-style_no_italic        <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_italic(x) else x
-style_no_strikethrough <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_strikethrough(x) else x
-style_no_underline     <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_underline(x) else x
+style_no_dim           <- function(x) if (has_ansi()) cli::style_no_dim(x) else x
+style_no_blurred       <- function(x) if (has_ansi()) cli::style_no_blurred(x) else x
+style_no_bold          <- function(x) if (has_ansi()) cli::style_no_bold(x) else x
+style_no_hidden        <- function(x) if (has_ansi()) cli::style_no_hidden(x) else x
+style_no_inverse       <- function(x) if (has_ansi()) cli::style_no_inverse(x) else x
+style_no_italic        <- function(x) if (has_ansi()) cli::style_no_italic(x) else x
+style_no_strikethrough <- function(x) if (has_ansi()) cli::style_no_strikethrough(x) else x
+style_no_underline     <- function(x) if (has_ansi()) cli::style_no_underline(x) else x
 
-style_reset            <- function(x) if (.rlang_cli_has_ansi()) cli::style_reset(x) else x
-style_no_colour        <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_color(x) else x
-style_no_bg_colour     <- function(x) if (.rlang_cli_has_ansi()) cli::style_no_bg_color(x) else x
+style_reset            <- function(x) if (has_ansi()) cli::style_reset(x) else x
+style_no_colour        <- function(x) if (has_ansi()) cli::style_no_color(x) else x
+style_no_bg_colour     <- function(x) if (has_ansi()) cli::style_no_bg_color(x) else x
 
 CLI_SUPPORT_HYPERLINK <- "2.2.0"
 CLI_SUPPORT_HYPERLINK_PARAMS <- "3.1.1"
@@ -363,7 +369,7 @@ format_message <- function(x) {
   out
 }
 
-.rlang_cli_has_ansi <- function() {
+has_ansi <- function() {
   .rlang_cli_has_cli() && cli::num_ansi_colors() > 1
 }
 

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -12,6 +12,8 @@
 # * Added `has_ansi()`. This checks that cli is installed and that
 #   `cli::num_ansi_colors()` is greater than 1.
 #
+# * `col_` and `style_` functions now consistently return bare strings.
+#
 #
 # 2022-05-23:
 #
@@ -96,49 +98,49 @@ ansi_alert  <- function() col_yellow(symbol_alert())
 #' @param x A string.
 #'
 #' @noRd
-col_black              <- function(x) if (.rlang_cli_has_cli()) cli::col_black(x) else x
-col_blue               <- function(x) if (.rlang_cli_has_cli()) cli::col_blue(x) else x
-col_cyan               <- function(x) if (.rlang_cli_has_cli()) cli::col_cyan(x) else x
-col_green              <- function(x) if (.rlang_cli_has_cli()) cli::col_green(x) else x
-col_magenta            <- function(x) if (.rlang_cli_has_cli()) cli::col_magenta(x) else x
-col_red                <- function(x) if (.rlang_cli_has_cli()) cli::col_red(x) else x
-col_white              <- function(x) if (.rlang_cli_has_cli()) cli::col_white(x) else x
-col_yellow             <- function(x) if (.rlang_cli_has_cli()) cli::col_yellow(x) else x
-col_grey               <- function(x) if (.rlang_cli_has_cli()) cli::col_grey(x) else x
-col_silver             <- function(x) if (.rlang_cli_has_cli()) cli::col_silver(x) else x
-col_none               <- function(x) if (.rlang_cli_has_cli()) cli::col_none(x) else x
+col_black              <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_black(x)) else x
+col_blue               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_blue(x)) else x
+col_cyan               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_cyan(x)) else x
+col_green              <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_green(x)) else x
+col_magenta            <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_magenta(x)) else x
+col_red                <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_red(x)) else x
+col_white              <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_white(x)) else x
+col_yellow             <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_yellow(x)) else x
+col_grey               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_grey(x)) else x
+col_silver             <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_silver(x)) else x
+col_none               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_none(x)) else x
 
-bg_black               <- function(x) if (.rlang_cli_has_cli()) cli::bg_black(x) else x
-bg_blue                <- function(x) if (.rlang_cli_has_cli()) cli::bg_blue(x) else x
-bg_cyan                <- function(x) if (.rlang_cli_has_cli()) cli::bg_cyan(x) else x
-bg_green               <- function(x) if (.rlang_cli_has_cli()) cli::bg_green(x) else x
-bg_magenta             <- function(x) if (.rlang_cli_has_cli()) cli::bg_magenta(x) else x
-bg_red                 <- function(x) if (.rlang_cli_has_cli()) cli::bg_red(x) else x
-bg_white               <- function(x) if (.rlang_cli_has_cli()) cli::bg_white(x) else x
-bg_yellow              <- function(x) if (.rlang_cli_has_cli()) cli::bg_yellow(x) else x
-bg_none                <- function(x) if (.rlang_cli_has_cli()) cli::bg_none(x) else x
+bg_black               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_black(x)) else x
+bg_blue                <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_blue(x)) else x
+bg_cyan                <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_cyan(x)) else x
+bg_green               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_green(x)) else x
+bg_magenta             <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_magenta(x)) else x
+bg_red                 <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_red(x)) else x
+bg_white               <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_white(x)) else x
+bg_yellow              <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_yellow(x)) else x
+bg_none                <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_none(x)) else x
 
-style_dim              <- function(x) if (.rlang_cli_has_cli()) cli::style_dim(x) else x
-style_blurred          <- function(x) if (.rlang_cli_has_cli()) cli::style_blurred(x) else x
-style_bold             <- function(x) if (.rlang_cli_has_cli()) cli::style_bold(x) else x
-style_hidden           <- function(x) if (.rlang_cli_has_cli()) cli::style_hidden(x) else x
-style_inverse          <- function(x) if (.rlang_cli_has_cli()) cli::style_inverse(x) else x
-style_italic           <- function(x) if (.rlang_cli_has_cli()) cli::style_italic(x) else x
-style_strikethrough    <- function(x) if (.rlang_cli_has_cli()) cli::style_strikethrough(x) else x
-style_underline        <- function(x) if (.rlang_cli_has_cli()) cli::style_underline(x) else x
+style_dim              <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_dim(x)) else x
+style_blurred          <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_blurred(x)) else x
+style_bold             <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_bold(x)) else x
+style_hidden           <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_hidden(x)) else x
+style_inverse          <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_inverse(x)) else x
+style_italic           <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_italic(x)) else x
+style_strikethrough    <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_strikethrough(x)) else x
+style_underline        <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_underline(x)) else x
 
-style_no_dim           <- function(x) if (.rlang_cli_has_cli()) cli::style_no_dim(x) else x
-style_no_blurred       <- function(x) if (.rlang_cli_has_cli()) cli::style_no_blurred(x) else x
-style_no_bold          <- function(x) if (.rlang_cli_has_cli()) cli::style_no_bold(x) else x
-style_no_hidden        <- function(x) if (.rlang_cli_has_cli()) cli::style_no_hidden(x) else x
-style_no_inverse       <- function(x) if (.rlang_cli_has_cli()) cli::style_no_inverse(x) else x
-style_no_italic        <- function(x) if (.rlang_cli_has_cli()) cli::style_no_italic(x) else x
-style_no_strikethrough <- function(x) if (.rlang_cli_has_cli()) cli::style_no_strikethrough(x) else x
-style_no_underline     <- function(x) if (.rlang_cli_has_cli()) cli::style_no_underline(x) else x
+style_no_dim           <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_dim(x)) else x
+style_no_blurred       <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_blurred(x)) else x
+style_no_bold          <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_bold(x)) else x
+style_no_hidden        <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_hidden(x)) else x
+style_no_inverse       <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_inverse(x)) else x
+style_no_italic        <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_italic(x)) else x
+style_no_strikethrough <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_strikethrough(x)) else x
+style_no_underline     <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_underline(x)) else x
 
-style_reset            <- function(x) if (.rlang_cli_has_cli()) cli::style_reset(x) else x
-style_no_colour        <- function(x) if (.rlang_cli_has_cli()) cli::style_no_color(x) else x
-style_no_bg_colour     <- function(x) if (.rlang_cli_has_cli()) cli::style_no_bg_color(x) else x
+style_reset            <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_reset(x)) else x
+style_no_colour        <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_color(x)) else x
+style_no_bg_colour     <- function(x) if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_bg_color(x)) else x
 
 CLI_SUPPORT_HYPERLINK <- "2.2.0"
 CLI_SUPPORT_HYPERLINK_PARAMS <- "3.1.1"
@@ -457,5 +459,9 @@ cli_escape <- function(x) {
   stop(sprintf("Internal error in rlang shims: Unknown function `%s()`.", fn))
 }
 
+.rlang_cli_unstructure <- function(x) {
+  attributes(x) <- NULL
+  x
+}
 
 # nocov end

--- a/R/compat-cli.R
+++ b/R/compat-cli.R
@@ -96,49 +96,49 @@ ansi_alert  <- function() col_yellow(symbol_alert())
 #' @param x A string.
 #'
 #' @noRd
-col_black              <- function(x) if (has_ansi()) cli::col_black(x) else x
-col_blue               <- function(x) if (has_ansi()) cli::col_blue(x) else x
-col_cyan               <- function(x) if (has_ansi()) cli::col_cyan(x) else x
-col_green              <- function(x) if (has_ansi()) cli::col_green(x) else x
-col_magenta            <- function(x) if (has_ansi()) cli::col_magenta(x) else x
-col_red                <- function(x) if (has_ansi()) cli::col_red(x) else x
-col_white              <- function(x) if (has_ansi()) cli::col_white(x) else x
-col_yellow             <- function(x) if (has_ansi()) cli::col_yellow(x) else x
-col_grey               <- function(x) if (has_ansi()) cli::col_grey(x) else x
-col_silver             <- function(x) if (has_ansi()) cli::col_silver(x) else x
-col_none               <- function(x) if (has_ansi()) cli::col_none(x) else x
+col_black              <- function(x) if (.rlang_cli_has_cli()) cli::col_black(x) else x
+col_blue               <- function(x) if (.rlang_cli_has_cli()) cli::col_blue(x) else x
+col_cyan               <- function(x) if (.rlang_cli_has_cli()) cli::col_cyan(x) else x
+col_green              <- function(x) if (.rlang_cli_has_cli()) cli::col_green(x) else x
+col_magenta            <- function(x) if (.rlang_cli_has_cli()) cli::col_magenta(x) else x
+col_red                <- function(x) if (.rlang_cli_has_cli()) cli::col_red(x) else x
+col_white              <- function(x) if (.rlang_cli_has_cli()) cli::col_white(x) else x
+col_yellow             <- function(x) if (.rlang_cli_has_cli()) cli::col_yellow(x) else x
+col_grey               <- function(x) if (.rlang_cli_has_cli()) cli::col_grey(x) else x
+col_silver             <- function(x) if (.rlang_cli_has_cli()) cli::col_silver(x) else x
+col_none               <- function(x) if (.rlang_cli_has_cli()) cli::col_none(x) else x
 
-bg_black               <- function(x) if (has_ansi()) cli::bg_black(x) else x
-bg_blue                <- function(x) if (has_ansi()) cli::bg_blue(x) else x
-bg_cyan                <- function(x) if (has_ansi()) cli::bg_cyan(x) else x
-bg_green               <- function(x) if (has_ansi()) cli::bg_green(x) else x
-bg_magenta             <- function(x) if (has_ansi()) cli::bg_magenta(x) else x
-bg_red                 <- function(x) if (has_ansi()) cli::bg_red(x) else x
-bg_white               <- function(x) if (has_ansi()) cli::bg_white(x) else x
-bg_yellow              <- function(x) if (has_ansi()) cli::bg_yellow(x) else x
-bg_none                <- function(x) if (has_ansi()) cli::bg_none(x) else x
+bg_black               <- function(x) if (.rlang_cli_has_cli()) cli::bg_black(x) else x
+bg_blue                <- function(x) if (.rlang_cli_has_cli()) cli::bg_blue(x) else x
+bg_cyan                <- function(x) if (.rlang_cli_has_cli()) cli::bg_cyan(x) else x
+bg_green               <- function(x) if (.rlang_cli_has_cli()) cli::bg_green(x) else x
+bg_magenta             <- function(x) if (.rlang_cli_has_cli()) cli::bg_magenta(x) else x
+bg_red                 <- function(x) if (.rlang_cli_has_cli()) cli::bg_red(x) else x
+bg_white               <- function(x) if (.rlang_cli_has_cli()) cli::bg_white(x) else x
+bg_yellow              <- function(x) if (.rlang_cli_has_cli()) cli::bg_yellow(x) else x
+bg_none                <- function(x) if (.rlang_cli_has_cli()) cli::bg_none(x) else x
 
-style_dim              <- function(x) if (has_ansi()) cli::style_dim(x) else x
-style_blurred          <- function(x) if (has_ansi()) cli::style_blurred(x) else x
-style_bold             <- function(x) if (has_ansi()) cli::style_bold(x) else x
-style_hidden           <- function(x) if (has_ansi()) cli::style_hidden(x) else x
-style_inverse          <- function(x) if (has_ansi()) cli::style_inverse(x) else x
-style_italic           <- function(x) if (has_ansi()) cli::style_italic(x) else x
-style_strikethrough    <- function(x) if (has_ansi()) cli::style_strikethrough(x) else x
-style_underline        <- function(x) if (has_ansi()) cli::style_underline(x) else x
+style_dim              <- function(x) if (.rlang_cli_has_cli()) cli::style_dim(x) else x
+style_blurred          <- function(x) if (.rlang_cli_has_cli()) cli::style_blurred(x) else x
+style_bold             <- function(x) if (.rlang_cli_has_cli()) cli::style_bold(x) else x
+style_hidden           <- function(x) if (.rlang_cli_has_cli()) cli::style_hidden(x) else x
+style_inverse          <- function(x) if (.rlang_cli_has_cli()) cli::style_inverse(x) else x
+style_italic           <- function(x) if (.rlang_cli_has_cli()) cli::style_italic(x) else x
+style_strikethrough    <- function(x) if (.rlang_cli_has_cli()) cli::style_strikethrough(x) else x
+style_underline        <- function(x) if (.rlang_cli_has_cli()) cli::style_underline(x) else x
 
-style_no_dim           <- function(x) if (has_ansi()) cli::style_no_dim(x) else x
-style_no_blurred       <- function(x) if (has_ansi()) cli::style_no_blurred(x) else x
-style_no_bold          <- function(x) if (has_ansi()) cli::style_no_bold(x) else x
-style_no_hidden        <- function(x) if (has_ansi()) cli::style_no_hidden(x) else x
-style_no_inverse       <- function(x) if (has_ansi()) cli::style_no_inverse(x) else x
-style_no_italic        <- function(x) if (has_ansi()) cli::style_no_italic(x) else x
-style_no_strikethrough <- function(x) if (has_ansi()) cli::style_no_strikethrough(x) else x
-style_no_underline     <- function(x) if (has_ansi()) cli::style_no_underline(x) else x
+style_no_dim           <- function(x) if (.rlang_cli_has_cli()) cli::style_no_dim(x) else x
+style_no_blurred       <- function(x) if (.rlang_cli_has_cli()) cli::style_no_blurred(x) else x
+style_no_bold          <- function(x) if (.rlang_cli_has_cli()) cli::style_no_bold(x) else x
+style_no_hidden        <- function(x) if (.rlang_cli_has_cli()) cli::style_no_hidden(x) else x
+style_no_inverse       <- function(x) if (.rlang_cli_has_cli()) cli::style_no_inverse(x) else x
+style_no_italic        <- function(x) if (.rlang_cli_has_cli()) cli::style_no_italic(x) else x
+style_no_strikethrough <- function(x) if (.rlang_cli_has_cli()) cli::style_no_strikethrough(x) else x
+style_no_underline     <- function(x) if (.rlang_cli_has_cli()) cli::style_no_underline(x) else x
 
-style_reset            <- function(x) if (has_ansi()) cli::style_reset(x) else x
-style_no_colour        <- function(x) if (has_ansi()) cli::style_no_color(x) else x
-style_no_bg_colour     <- function(x) if (has_ansi()) cli::style_no_bg_color(x) else x
+style_reset            <- function(x) if (.rlang_cli_has_cli()) cli::style_reset(x) else x
+style_no_colour        <- function(x) if (.rlang_cli_has_cli()) cli::style_no_color(x) else x
+style_no_bg_colour     <- function(x) if (.rlang_cli_has_cli()) cli::style_no_bg_color(x) else x
 
 CLI_SUPPORT_HYPERLINK <- "2.2.0"
 CLI_SUPPORT_HYPERLINK_PARAMS <- "3.1.1"

--- a/R/env.R
+++ b/R/env.R
@@ -662,7 +662,7 @@ env_print <- function(env = caller_env()) {
 
   header <- format_cls(sprintf("environment: %s", env_label(env)))
   cat_line(
-    bold(paste0(header, locked)),
+    style_bold(paste0(header, locked)),
     sprintf("Parent: %s", parent)
   )
 

--- a/R/quo.R
+++ b/R/quo.R
@@ -571,7 +571,7 @@ quo_deparse <- function(x, lines = new_quo_deparser()) {
 
 new_quo_deparser <- function(width = peek_option("width"),
                              max_elements = 5L,
-                             crayon = .rlang_cli_has_ansi()) {
+                             crayon = has_ansi()) {
   lines <- new_lines(
     width = width,
     max_elements = max_elements,

--- a/R/quo.R
+++ b/R/quo.R
@@ -493,7 +493,7 @@ quo_squash_impl <- function(x, parent = NULL, warn = FALSE) {
 #' @export
 print.quosure <- function(x, ...) {
   cat_line(.trailing = FALSE,
-    bold("<quosure>"),
+    style_bold("<quosure>"),
     "expr: "
   )
   quo_print(x)
@@ -652,7 +652,7 @@ quo_env_print <- function(env) {
   nm <- env_label(env)
 
   if (!is_reference(env, global_env()) && !is_reference(env, empty_env())) {
-    nm <- blue(nm)
+    nm <- col_blue(nm)
   }
 
   cat_line(nm)

--- a/R/quo.R
+++ b/R/quo.R
@@ -571,7 +571,7 @@ quo_deparse <- function(x, lines = new_quo_deparser()) {
 
 new_quo_deparser <- function(width = peek_option("width"),
                              max_elements = 5L,
-                             crayon = has_crayon()) {
+                             crayon = .rlang_cli_has_ansi()) {
   lines <- new_lines(
     width = width,
     max_elements = max_elements,

--- a/R/trace.R
+++ b/R/trace.R
@@ -766,7 +766,7 @@ trace_as_tree <- function(trace,
     trace$node_type <- rep_len("main", nrow(trace))
   }
 
-  if (has_crayon()) {
+  if (.rlang_cli_has_ansi()) {
     # Detect runs of namespaces/global
     ns <- trace$namespace
     ns <- ifelse(is.na(ns) & trace$scope == "global", "global", ns)

--- a/R/trace.R
+++ b/R/trace.R
@@ -766,7 +766,7 @@ trace_as_tree <- function(trace,
     trace$node_type <- rep_len("main", nrow(trace))
   }
 
-  if (.rlang_cli_has_ansi()) {
+  if (has_ansi()) {
     # Detect runs of namespaces/global
     ns <- trace$namespace
     ns <- ifelse(is.na(ns) & trace$scope == "global", "global", ns)

--- a/R/trace.R
+++ b/R/trace.R
@@ -508,7 +508,7 @@ cli_branch <- function(tree,
   indices <- paste0(" ", indices, ". ")
   padding <- spaces(nchar(indices[[1]]))
 
-  lines <- paste0(silver(indices), lines)
+  lines <- paste0(col_silver(indices), lines)
 
   src_locs <- tree$src_loc
   src_locs <- map_if(src_locs, nzchar, ~ paste0(padding, "  at ", .x))

--- a/R/utils-cli-tree.R
+++ b/R/utils-cli-tree.R
@@ -97,7 +97,7 @@ cli_tree <- function(data,
     root_padding <- spaces(nchar(indices[[1]]))
     indices <- c(root_padding, indices)
 
-    res <- paste0(silver(indices), res)
+    res <- paste0(col_silver(indices), res)
   }
 
   res

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,18 +37,6 @@ paste_line <- function(..., .trailing = FALSE) {
   }
 }
 
-red       <- function(x) if (has_cli) unstructure(cli::col_red(x))         else x
-blue      <- function(x) if (has_cli) unstructure(cli::col_blue(x))        else x
-green     <- function(x) if (has_cli) unstructure(cli::col_green(x))       else x
-yellow    <- function(x) if (has_cli) unstructure(cli::col_yellow(x))      else x
-magenta   <- function(x) if (has_cli) unstructure(cli::col_magenta(x))     else x
-cyan      <- function(x) if (has_cli) unstructure(cli::col_cyan(x))        else x
-silver    <- function(x) if (has_cli) unstructure(cli::col_silver(x))      else x
-blurred   <- function(x) if (has_cli) unstructure(cli::style_blurred(x))   else x
-bold      <- function(x) if (has_cli) unstructure(cli::style_bold(x))      else x
-italic    <- function(x) if (has_cli) unstructure(cli::style_italic(x))    else x
-underline <- function(x) if (has_cli) unstructure(cli::style_underline(x)) else x
-
 open_red     <- function() if (has_ansi()) open_style("red")
 open_blue    <- function() if (has_ansi()) open_style("blue")
 open_green   <- function() if (has_ansi()) open_style("green")
@@ -170,15 +158,15 @@ on_load({
 
 info <- function() {
   i <- if (has_cli) cli::symbol$info else "i"
-  blue(i)
+  col_blue(i)
 }
 cross <- function() {
   x <- if (has_cli) cli::symbol$cross else "x"
-  red(x)
+  col_red(x)
 }
 tick <- function() {
   x <- if (has_cli) cli::symbol$tick else "v"
-  green(x)
+  col_green(x)
 }
 bullet <- function() {
   x <- if (has_cli) cli::symbol$bullet else "*"
@@ -199,7 +187,7 @@ style_dim_soft <- function(x) {
   if (cli::num_ansi_colors() >= 256) {
     crayon::make_style(grDevices::grey(0.6), colors =  256)(x)
   } else {
-    silver(x)
+    col_silver(x)
   }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,36 +37,32 @@ paste_line <- function(..., .trailing = FALSE) {
   }
 }
 
-has_crayon <- function() {
-  is_installed("crayon") && crayon::has_color()
-}
+red       <- function(x) if (has_cli) unstructure(cli::col_red(x))         else x
+blue      <- function(x) if (has_cli) unstructure(cli::col_blue(x))        else x
+green     <- function(x) if (has_cli) unstructure(cli::col_green(x))       else x
+yellow    <- function(x) if (has_cli) unstructure(cli::col_yellow(x))      else x
+magenta   <- function(x) if (has_cli) unstructure(cli::col_magenta(x))     else x
+cyan      <- function(x) if (has_cli) unstructure(cli::col_cyan(x))        else x
+silver    <- function(x) if (has_cli) unstructure(cli::col_silver(x))      else x
+blurred   <- function(x) if (has_cli) unstructure(cli::style_blurred(x))   else x
+bold      <- function(x) if (has_cli) unstructure(cli::style_bold(x))      else x
+italic    <- function(x) if (has_cli) unstructure(cli::style_italic(x))    else x
+underline <- function(x) if (has_cli) unstructure(cli::style_underline(x)) else x
 
-red       <- function(x) if (has_crayon()) crayon::red(x)       else x
-blue      <- function(x) if (has_crayon()) crayon::blue(x)      else x
-green     <- function(x) if (has_crayon()) crayon::green(x)     else x
-yellow    <- function(x) if (has_crayon()) crayon::yellow(x)    else x
-magenta   <- function(x) if (has_crayon()) crayon::magenta(x)   else x
-cyan      <- function(x) if (has_crayon()) crayon::cyan(x)      else x
-blurred   <- function(x) if (has_crayon()) crayon::blurred(x)   else x
-silver    <- function(x) if (has_crayon()) crayon::silver(x)    else x
-bold      <- function(x) if (has_crayon()) crayon::bold(x)      else x
-italic    <- function(x) if (has_crayon()) crayon::italic(x)    else x
-underline <- function(x) if (has_crayon()) crayon::underline(x) else x
+open_red     <- function() if (.rlang_cli_has_ansi()) open_style("red")
+open_blue    <- function() if (.rlang_cli_has_ansi()) open_style("blue")
+open_green   <- function() if (.rlang_cli_has_ansi()) open_style("green")
+open_yellow  <- function() if (.rlang_cli_has_ansi()) open_style("yellow")
+open_magenta <- function() if (.rlang_cli_has_ansi()) open_style("magenta")
+open_cyan    <- function() if (.rlang_cli_has_ansi()) open_style("cyan")
+open_bold    <- function() if (.rlang_cli_has_ansi()) open_style("bold")
+close_colour <- function() if (.rlang_cli_has_ansi()) "\u001b[39m"
+close_italic <- function() if (.rlang_cli_has_ansi()) "\u001b[23m"
+close_bold   <- function() if (.rlang_cli_has_ansi()) close_style("bold")
 
-open_red     <- function() if (has_crayon()) open_style("red")
-open_blue    <- function() if (has_crayon()) open_style("blue")
-open_green   <- function() if (has_crayon()) open_style("green")
-open_yellow  <- function() if (has_crayon()) open_style("yellow")
-open_magenta <- function() if (has_crayon()) open_style("magenta")
-open_cyan    <- function() if (has_crayon()) open_style("cyan")
-open_bold    <- function() if (has_crayon()) open_style("bold")
-close_colour <- function() if (has_crayon()) "\u001b[39m"
-close_italic <- function() if (has_crayon()) "\u001b[23m"
-close_bold   <- function() if (has_crayon()) close_style("bold")
-
-open_yellow_italic   <- function() if (has_crayon()) "\u001b[33m\u001b[3m"
-open_blurred_italic  <- function() if (has_crayon()) "\u001b[2m\u001b[3m"
-close_blurred_italic <- function() if (has_crayon()) "\u001b[23m\u001b[22m"
+open_yellow_italic   <- function() if (.rlang_cli_has_ansi()) "\u001b[33m\u001b[3m"
+open_blurred_italic  <- function() if (.rlang_cli_has_ansi()) "\u001b[2m\u001b[3m"
+close_blurred_italic <- function() if (.rlang_cli_has_ansi()) "\u001b[23m\u001b[22m"
 
 
 open_style <- function(style) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,20 +49,20 @@ bold      <- function(x) if (has_cli) unstructure(cli::style_bold(x))      else 
 italic    <- function(x) if (has_cli) unstructure(cli::style_italic(x))    else x
 underline <- function(x) if (has_cli) unstructure(cli::style_underline(x)) else x
 
-open_red     <- function() if (.rlang_cli_has_ansi()) open_style("red")
-open_blue    <- function() if (.rlang_cli_has_ansi()) open_style("blue")
-open_green   <- function() if (.rlang_cli_has_ansi()) open_style("green")
-open_yellow  <- function() if (.rlang_cli_has_ansi()) open_style("yellow")
-open_magenta <- function() if (.rlang_cli_has_ansi()) open_style("magenta")
-open_cyan    <- function() if (.rlang_cli_has_ansi()) open_style("cyan")
-open_bold    <- function() if (.rlang_cli_has_ansi()) open_style("bold")
-close_colour <- function() if (.rlang_cli_has_ansi()) "\u001b[39m"
-close_italic <- function() if (.rlang_cli_has_ansi()) "\u001b[23m"
-close_bold   <- function() if (.rlang_cli_has_ansi()) close_style("bold")
+open_red     <- function() if (has_ansi()) open_style("red")
+open_blue    <- function() if (has_ansi()) open_style("blue")
+open_green   <- function() if (has_ansi()) open_style("green")
+open_yellow  <- function() if (has_ansi()) open_style("yellow")
+open_magenta <- function() if (has_ansi()) open_style("magenta")
+open_cyan    <- function() if (has_ansi()) open_style("cyan")
+open_bold    <- function() if (has_ansi()) open_style("bold")
+close_colour <- function() if (has_ansi()) "\u001b[39m"
+close_italic <- function() if (has_ansi()) "\u001b[23m"
+close_bold   <- function() if (has_ansi()) close_style("bold")
 
-open_yellow_italic   <- function() if (.rlang_cli_has_ansi()) "\u001b[33m\u001b[3m"
-open_blurred_italic  <- function() if (.rlang_cli_has_ansi()) "\u001b[2m\u001b[3m"
-close_blurred_italic <- function() if (.rlang_cli_has_ansi()) "\u001b[23m\u001b[22m"
+open_yellow_italic   <- function() if (has_ansi()) "\u001b[33m\u001b[3m"
+open_blurred_italic  <- function() if (has_ansi()) "\u001b[2m\u001b[3m"
+close_blurred_italic <- function() if (has_ansi()) "\u001b[23m\u001b[22m"
 
 
 open_style <- function(style) {

--- a/tests/testthat/_snaps/compat-cli.md
+++ b/tests/testthat/_snaps/compat-cli.md
@@ -484,198 +484,159 @@
     Code
       col_black("foo")
     Output
-      <cli_ansi_string>
-      [1] [30mfoo[39m
+      [1] "\033[30mfoo\033[39m"
     Code
       col_blue("foo")
     Output
-      <cli_ansi_string>
-      [1] [34mfoo[39m
+      [1] "\033[34mfoo\033[39m"
     Code
       col_cyan("foo")
     Output
-      <cli_ansi_string>
-      [1] [36mfoo[39m
+      [1] "\033[36mfoo\033[39m"
     Code
       col_green("foo")
     Output
-      <cli_ansi_string>
-      [1] [32mfoo[39m
+      [1] "\033[32mfoo\033[39m"
     Code
       col_magenta("foo")
     Output
-      <cli_ansi_string>
-      [1] [35mfoo[39m
+      [1] "\033[35mfoo\033[39m"
     Code
       col_red("foo")
     Output
-      <cli_ansi_string>
-      [1] [31mfoo[39m
+      [1] "\033[31mfoo\033[39m"
     Code
       col_white("foo")
     Output
-      <cli_ansi_string>
-      [1] [37mfoo[39m
+      [1] "\033[37mfoo\033[39m"
     Code
       col_yellow("foo")
     Output
-      <cli_ansi_string>
-      [1] [33mfoo[39m
+      [1] "\033[33mfoo\033[39m"
     Code
       col_grey("foo")
     Output
-      <cli_ansi_string>
-      [1] [90mfoo[39m
+      [1] "\033[90mfoo\033[39m"
     Code
       col_silver("foo")
     Output
-      <cli_ansi_string>
-      [1] [90mfoo[39m
+      [1] "\033[90mfoo\033[39m"
     Code
       col_none("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[27m[28m[29m[49mfoo[39m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[27m\033[28m\033[29m\033[49mfoo\033[39m"
     Code
       bg_black("foo")
     Output
-      <cli_ansi_string>
-      [1] [40mfoo[49m
+      [1] "\033[40mfoo\033[49m"
     Code
       bg_blue("foo")
     Output
-      <cli_ansi_string>
-      [1] [44mfoo[49m
+      [1] "\033[44mfoo\033[49m"
     Code
       bg_cyan("foo")
     Output
-      <cli_ansi_string>
-      [1] [46mfoo[49m
+      [1] "\033[46mfoo\033[49m"
     Code
       bg_green("foo")
     Output
-      <cli_ansi_string>
-      [1] [42mfoo[49m
+      [1] "\033[42mfoo\033[49m"
     Code
       bg_magenta("foo")
     Output
-      <cli_ansi_string>
-      [1] [45mfoo[49m
+      [1] "\033[45mfoo\033[49m"
     Code
       bg_red("foo")
     Output
-      <cli_ansi_string>
-      [1] [41mfoo[49m
+      [1] "\033[41mfoo\033[49m"
     Code
       bg_white("foo")
     Output
-      <cli_ansi_string>
-      [1] [47mfoo[49m
+      [1] "\033[47mfoo\033[49m"
     Code
       bg_yellow("foo")
     Output
-      <cli_ansi_string>
-      [1] [43mfoo[49m
+      [1] "\033[43mfoo\033[49m"
     Code
       bg_none("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[27m[28m[29m[39mfoo[49m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[27m\033[28m\033[29m\033[39mfoo\033[49m"
     Code
       style_dim("foo")
     Output
-      <cli_ansi_string>
-      [1] [2mfoo[22m
+      [1] "\033[2mfoo\033[22m"
     Code
       style_blurred("foo")
     Output
-      <cli_ansi_string>
-      [1] [2mfoo[22m
+      [1] "\033[2mfoo\033[22m"
     Code
       style_bold("foo")
     Output
-      <cli_ansi_string>
-      [1] [1mfoo[22m
+      [1] "\033[1mfoo\033[22m"
     Code
       style_hidden("foo")
     Output
-      <cli_ansi_string>
-      [1] [8mfoo[28m
+      [1] "\033[8mfoo\033[28m"
     Code
       style_inverse("foo")
     Output
-      <cli_ansi_string>
-      [1] [7mfoo[27m
+      [1] "\033[7mfoo\033[27m"
     Code
       style_italic("foo")
     Output
-      <cli_ansi_string>
-      [1] [3mfoo[23m
+      [1] "\033[3mfoo\033[23m"
     Code
       style_strikethrough("foo")
     Output
-      <cli_ansi_string>
-      [1] [9mfoo[29m
+      [1] "\033[9mfoo\033[29m"
     Code
       style_underline("foo")
     Output
-      <cli_ansi_string>
-      [1] [4mfoo[24m
+      [1] "\033[4mfoo\033[24m"
     Code
       style_no_dim("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[23m[24m[27m[28m[29m[39m[49mfoo[22m
+      [1] "\033[0m\033[23m\033[24m\033[27m\033[28m\033[29m\033[39m\033[49mfoo\033[22m"
     Code
       style_no_blurred("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[23m[24m[27m[28m[29m[39m[49mfoo[22m
+      [1] "\033[0m\033[23m\033[24m\033[27m\033[28m\033[29m\033[39m\033[49mfoo\033[22m"
     Code
       style_no_bold("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[23m[24m[27m[28m[29m[39m[49mfoo[22m
+      [1] "\033[0m\033[23m\033[24m\033[27m\033[28m\033[29m\033[39m\033[49mfoo\033[22m"
     Code
       style_no_hidden("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[27m[29m[39m[49mfoo[28m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[27m\033[29m\033[39m\033[49mfoo\033[28m"
     Code
       style_no_inverse("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[28m[29m[39m[49mfoo[27m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[28m\033[29m\033[39m\033[49mfoo\033[27m"
     Code
       style_no_italic("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[24m[27m[28m[29m[39m[49mfoo[23m
+      [1] "\033[0m\033[22m\033[24m\033[27m\033[28m\033[29m\033[39m\033[49mfoo\033[23m"
     Code
       style_no_strikethrough("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[27m[28m[39m[49mfoo[29m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[27m\033[28m\033[39m\033[49mfoo\033[29m"
     Code
       style_no_underline("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[27m[28m[29m[39m[49mfoo[24m
+      [1] "\033[0m\033[22m\033[23m\033[27m\033[28m\033[29m\033[39m\033[49mfoo\033[24m"
     Code
       style_reset("foo")
     Output
-      <cli_ansi_string>
-      [1] [0mfoo[0m[22m[23m[24m[27m[28m[29m[39m[49m
+      [1] "\033[0mfoo\033[0m\033[22m\033[23m\033[24m\033[27m\033[28m\033[29m\033[39m\033[49m"
     Code
       style_no_colour("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[27m[28m[29m[49mfoo[39m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[27m\033[28m\033[29m\033[49mfoo\033[39m"
     Code
       style_no_bg_colour("foo")
     Output
-      <cli_ansi_string>
-      [1] [0m[22m[23m[24m[27m[28m[29m[39mfoo[49m
+      [1] "\033[0m\033[22m\033[23m\033[24m\033[27m\033[28m\033[29m\033[39mfoo\033[49m"
 
 # can create symbols with cli [plain]
 
@@ -817,23 +778,19 @@
     Code
       ansi_info()
     Output
-      <cli_ansi_string>
-      [1] [34mi[39m
+      [1] "\033[34mi\033[39m"
     Code
       ansi_cross()
     Output
-      <cli_ansi_string>
-      [1] [31mx[39m
+      [1] "\033[31mx\033[39m"
     Code
       ansi_tick()
     Output
-      <cli_ansi_string>
-      [1] [32mv[39m
+      [1] "\033[32mv\033[39m"
     Code
       ansi_bullet()
     Output
-      <cli_ansi_string>
-      [1] [36m*[39m
+      [1] "\033[36m*\033[39m"
     Code
       ansi_arrow()
     Output
@@ -841,8 +798,7 @@
     Code
       ansi_alert()
     Output
-      <cli_ansi_string>
-      [1] [33m![39m
+      [1] "\033[33m!\033[39m"
 
 # can create ANSI symbols with cli [unicode]
 
@@ -876,23 +832,19 @@
     Code
       ansi_info()
     Output
-      <cli_ansi_string>
-      [1] [34mℹ[39m
+      [1] "\033[34mℹ\033[39m"
     Code
       ansi_cross()
     Output
-      <cli_ansi_string>
-      [1] [31m✖[39m
+      [1] "\033[31m✖\033[39m"
     Code
       ansi_tick()
     Output
-      <cli_ansi_string>
-      [1] [32m✔[39m
+      [1] "\033[32m✔\033[39m"
     Code
       ansi_bullet()
     Output
-      <cli_ansi_string>
-      [1] [36m•[39m
+      [1] "\033[36m•\033[39m"
     Code
       ansi_arrow()
     Output
@@ -900,8 +852,7 @@
     Code
       ansi_alert()
     Output
-      <cli_ansi_string>
-      [1] [33m![39m
+      [1] "\033[33m!\033[39m"
 
 # can format messages [plain]
 

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -31,7 +31,7 @@ test_that("line_push() handles the nchar(line) == boundary case", {
 
 test_that("line_push() strips ANSI codes before computing overflow", {
   local_options(crayon.enabled = TRUE)
-  if (!.rlang_cli_has_ansi()) {
+  if (!has_ansi()) {
     skip("test needs cli")
   }
   expect_identical(length(line_push("foo", open_blue(), width = 3L)), 2L)

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -31,8 +31,8 @@ test_that("line_push() handles the nchar(line) == boundary case", {
 
 test_that("line_push() strips ANSI codes before computing overflow", {
   local_options(crayon.enabled = TRUE)
-  if (!has_crayon()) {
-    skip("test needs crayon")
+  if (!.rlang_cli_has_ansi()) {
+    skip("test needs cli")
   }
   expect_identical(length(line_push("foo", open_blue(), width = 3L)), 2L)
   expect_identical(length(line_push("foo", open_blue(), width = 3L, has_colour = TRUE)), 1L)


### PR DESCRIPTION
Closes #1444.

The old `rlang:::blue()` function took 200µs on my machine, vs 12µs for `rlang:::col_blue()` from `compat-cli.R`.