### PR TITLE
Propagate names through `r_lgl_which()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # rlang (development version)
 
+* The C API function `r_lgl_which()` now propagates the names of the input
+  (#1471).
+
 * The `pkg_version_info()` function now allows `==` for package
   version comparison (#1469, @kryekuzhinieri).
-
 
 # rlang 1.0.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * The `pkg_version_info()` function now allows `==` for package
   version comparison (#1469, @kryekuzhinieri).
 
+
 # rlang 1.0.5
 
 * Fixed backtrace display with calls containing long lists of

--- a/src/rlang/vec-lgl.c
+++ b/src/rlang/vec-lgl.c
@@ -26,8 +26,10 @@ r_ssize r_lgl_sum(r_obj* x, bool na_true) {
 }
 
 r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
-  if (r_typeof(x) != R_TYPE_logical) {
-    r_stop_internal("Expected logical vector.");
+  const enum r_type type = r_typeof(x);
+
+  if (type != R_TYPE_logical) {
+    r_stop_unexpected_type(type);
   }
 
   const r_ssize n = r_length(x);

--- a/src/rlang/vec-lgl.c
+++ b/src/rlang/vec-lgl.c
@@ -27,31 +27,62 @@ r_ssize r_lgl_sum(r_obj* x, bool na_true) {
 
 r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
   if (r_typeof(x) != R_TYPE_logical) {
-    r_abort("Internal error: Expected logical vector in `r_lgl_which()`");
+    r_stop_internal("Expected logical vector.");
   }
 
-  r_ssize n = r_length(x);
-  const int* p_x = r_lgl_cbegin(x);
+  const r_ssize n = r_length(x);
+  const int* v_x = r_lgl_cbegin(x);
 
-  r_ssize which_n = r_lgl_sum(x, na_propagate);
+  r_obj* names = r_names(x);
+  const bool has_names = names != r_null;
+  r_obj* const* v_names = NULL;
+  if (has_names) {
+    v_names = r_chr_cbegin(names);
+  }
+
+  const r_ssize which_n = r_lgl_sum(x, na_propagate);
 
   if (which_n > INT_MAX) {
-    r_abort("Internal error: Can't fit result of `r_lgl_which()` in an integer vector");
+    r_stop_internal("Can't fit result in an integer vector.");
   }
 
   r_obj* which = KEEP(r_alloc_integer(which_n));
-  int* p_which = r_int_begin(which);
+  int* v_which = r_int_begin(which);
 
-  for (int i = 0; i < n; ++i) {
-    int elt = p_x[i];
+  r_obj* which_names = r_null;
+  if (has_names) {
+    which_names = r_alloc_character(which_n);
+    r_attrib_poke_names(which, which_names);
+  }
 
-    if (elt) {
-      if (na_propagate && elt == r_globals.na_lgl) {
-        *p_which = r_globals.na_int;
-        ++p_which;
-      } else if (elt != r_globals.na_lgl) {
-        *p_which = i + 1;
-        ++p_which;
+  r_ssize j = 0;
+
+  if (na_propagate) {
+    for (r_ssize i = 0; i < n; ++i) {
+      const int elt = v_x[i];
+
+      if (elt != 0) {
+        v_which[j] = (elt == r_globals.na_lgl) ? r_globals.na_int : i + 1;
+
+        if (has_names) {
+          r_chr_poke(which_names, j, v_names[i]);
+        }
+
+        ++j;
+      }
+    }
+  } else {
+    for (r_ssize i = 0; i < n; ++i) {
+      const int elt = v_x[i];
+
+      if (elt == 1) {
+        v_which[j] = i + 1;
+
+        if (has_names) {
+          r_chr_poke(which_names, j, v_names[i]);
+        }
+
+        ++j;
       }
     }
   }

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -416,6 +416,15 @@ test_that("r_lgl_which() handles empty vectors", {
   expect_identical(r_lgl_which(lgl(), FALSE), int())
 })
 
+test_that("r_lgl_which() propagates names", {
+  x <- c(a = TRUE, b = FALSE, c = NA)
+  expect_named(r_lgl_which(x, na_propagate = TRUE), c("a", "c"))
+  expect_named(r_lgl_which(x, na_propagate = FALSE), "a")
+
+  # Unnamed if input is unnamed
+  expect_named(r_lgl_which(TRUE, na_propagate = TRUE), NULL)
+})
+
 test_that("r_lgl_which() handles `NA` when propagation is disabled (#750)", {
   expect_identical(r_lgl_which(lgl(TRUE, FALSE, NA), FALSE), int(1))
   expect_identical(r_lgl_which(lgl(TRUE, FALSE, NA, TRUE), FALSE), int(1, 4))
@@ -559,7 +568,7 @@ test_that("can put again after del", {
 
   # Used to fail because we deleted whole bucket instead of just a
   # node when this node appeared first in the bucket
-  
+
   dict <- new_dict(3L)
   dict_put(dict, chr_get("1"), NULL)
   dict_put(dict, chr_get("foo"), NULL)


### PR DESCRIPTION
- Cleaned up the style in `r_lgl_which()`
- Lifted the `na_propagate` branch out of the for loop
- Simplified the if condition, especially in the `na_propagate = FALSE` case
- Added in support for propagating names

I don't think this has much performance impact when there aren't names. In fact, it looks like moving the `na_propagate` branch out of the loop and simplifying the if condition has made things slightly faster in the `na_propagate = FALSE` case.

``` r
devtools::load_all()
#> ℹ Loading rlang

# Uniform mix
x <- sample(c(TRUE, FALSE, NA), size = 2e6, replace = TRUE)

bench::mark(
  r_lgl_which(x, na_propagate = TRUE),
  r_lgl_which(x, na_propagate = FALSE),
  iterations = 500,
  check = FALSE
)

# Main
#> # A tibble: 2 × 6
#>   expression                                min   median
#>   <bch:expr>                           <bch:tm> <bch:tm>
#> 1 r_lgl_which(x, na_propagate = TRUE)   10.34ms   12.5ms
#> 2 r_lgl_which(x, na_propagate = FALSE)   9.44ms   10.5ms
#> # … with 3 more variables: `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>

# This PR
#> # A tibble: 2 × 6
#>   expression                                min   median
#>   <bch:expr>                           <bch:tm> <bch:tm>
#> 1 r_lgl_which(x, na_propagate = TRUE)    9.67ms  12.02ms
#> 2 r_lgl_which(x, na_propagate = FALSE)   6.13ms   6.71ms
#> # … with 3 more variables: `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>

# Mostly `TRUE`
x <- sample(c(rep(TRUE, 100), FALSE, NA), size = 2e6, replace = TRUE)

bench::mark(
  r_lgl_which(x, na_propagate = TRUE),
  r_lgl_which(x, na_propagate = FALSE),
  iterations = 500,
  check = FALSE
)

# Main
#> # A tibble: 2 × 6
#>   expression                                min   median
#>   <bch:expr>                           <bch:tm> <bch:tm>
#> 1 r_lgl_which(x, na_propagate = TRUE)    3.88ms   4.82ms
#> 2 r_lgl_which(x, na_propagate = FALSE)   3.34ms   3.98ms
#> # … with 3 more variables: `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>

# This PR
#> # A tibble: 2 × 6
#>   expression                                min   median
#>   <bch:expr>                           <bch:tm> <bch:tm>
#> 1 r_lgl_which(x, na_propagate = TRUE)    4.16ms   4.83ms
#> 2 r_lgl_which(x, na_propagate = FALSE)   2.75ms   3.31ms
#> # … with 3 more variables: `itr/sec` <dbl>,
#> #   mem_alloc <bch:byt>, `gc/sec` <dbl>
```