### PR TITLE
Avoid extra work in the good case in `try_catch()`

### DIFF
--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -185,10 +185,10 @@ try_fetch <- function(expr, ...) {
   frame <- environment()
 
   catch <- value <- NULL
-  delayedAssign("catch", return(value), frame, frame)
 
   throw <- function(x) {
     value <<- x
+    delayedAssign("catch", return(value), frame, frame)
     catch
   }
 


### PR DESCRIPTION
Should be as lean as possible.

I wonder if `try_catch()` could be implemented entirely from C via `R_tryCatch()` or `R_tryCatchError()`, or perhaps with new entry points. It seems that it's currently constructing R code of the form `tryCatch(withCallingHandlers(...))` (or just `withCallingHandlers(...)` in some cases), which is very slow.