### PR TITLE
Performance improvement `r_lgl_which()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* The C API function `r_lgl_which()` is now faster for large inputs (#1487, @mgirlich).
+
 * Fixed an issue that caused a failure about a missing `is_character`
   function when rlang is installed alongside an old version of vctrs (#1482).
 

--- a/src/rlang/vec-lgl.c
+++ b/src/rlang/vec-lgl.c
@@ -25,6 +25,45 @@ r_ssize r_lgl_sum(r_obj* x, bool na_true) {
   return sum;
 }
 
+static r_ssize lgl_sum_guess(r_obj* x, bool na_true) {
+  if (r_typeof(x) != R_TYPE_logical) {
+    r_abort("Internal error: Excepted logical vector in `lgl_sum_guess()`");
+  }
+
+  r_ssize n = r_length(x);
+  r_ssize jump_size = n > 200 ? n / 200 : 1;
+
+  r_ssize sum = 0;
+  const int* p_x = r_lgl_cbegin(x);
+  for (r_ssize i = 0; i < n; i += jump_size) {
+    // This can't overflow since `sum` is necessarily smaller or equal
+    // to the vector length expressed in `r_ssize`.
+    int x_i = p_x[i];
+
+    if (na_true && x_i) {
+      sum += 1;
+    } else if (x_i == 1) {
+      sum += 1;
+    }
+  }
+
+  if (jump_size == 1) {
+    return sum;
+  }
+
+  // prefer to overestimate so that `r_lgl_which()` avoids expensive resizing
+  if (sum == 0) {
+    return jump_size;
+  }
+
+  r_ssize guess = 1.2 * sum * jump_size;
+  if (guess > n) {
+    guess = n;
+  }
+
+  return guess;
+}
+
 r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
   const enum r_type type = r_typeof(x);
 
@@ -42,13 +81,15 @@ r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
     v_names = r_chr_cbegin(names);
   }
 
-  const r_ssize which_n = r_lgl_sum(x, na_propagate);
+  r_ssize which_n = lgl_sum_guess(x, na_propagate);
 
   if (which_n > INT_MAX) {
     r_stop_internal("Can't fit result in an integer vector.");
   }
 
-  r_obj* which = KEEP(r_alloc_integer(which_n));
+  r_keep_loc pi;
+  r_obj* which = r_alloc_integer(which_n);
+  KEEP_HERE(which, &pi);
   int* v_which = r_int_begin(which);
 
   r_obj* which_names = r_null;
@@ -57,6 +98,7 @@ r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
     r_attrib_poke_names(which, which_names);
   }
 
+  r_ssize which_n_actual = 0;
   r_ssize j = 0;
 
   if (na_propagate) {
@@ -64,6 +106,20 @@ r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
       const int elt = v_x[i];
 
       if (elt != 0) {
+        ++which_n_actual;
+
+        if (which_n_actual > which_n) {
+          which_n = which_n * 1.3;
+          which = r_vec_resize(which, which_n);
+          KEEP_AT(which, pi);
+          v_which = r_int_begin(which) + which_n_actual - 1;
+
+          if (has_names) {
+            which_names = r_vec_resize(which_names, which_n);
+            r_attrib_poke_names(which, which_names);
+          }
+        }
+
         v_which[j] = (elt == r_globals.na_lgl) ? r_globals.na_int : i + 1;
 
         if (has_names) {
@@ -78,6 +134,20 @@ r_obj* r_lgl_which(r_obj* x, bool na_propagate) {
       const int elt = v_x[i];
 
       if (elt == 1) {
+        ++which_n_actual;
+
+        if (which_n_actual > which_n) {
+          which_n = which_n * 1.3;
+          which = r_vec_resize(which, which_n);
+          KEEP_AT(which, pi);
+          v_which = r_int_begin(which) + which_n_actual - 1;
+
+          if (has_names) {
+            which_names = r_vec_resize(which_names, which_n);
+            r_attrib_poke_names(which, which_names);
+          }
+        }
+
         v_which[j] = i + 1;
 
         if (has_names) {


### PR DESCRIPTION
Originally incorrectly created in https://github.com/r-lib/vctrs/pull/1594.

``` r
set.seed(1)

r_lgl_which <- function(x, na_propagate) {
  stopifnot(rlang::is_logical(x), rlang::is_bool(na_propagate))
  .Call(rlang:::ffi_test_lgl_which, x, na_propagate)
}

n <- 100e6
all_true <- vctrs::vec_rep(TRUE, n)
all_false <- vctrs::vec_rep(FALSE, n)
true_90 <- runif(n) < 0.9
true_50 <- runif(n) < 0.5
true_10 <- runif(n) < 0.1
true_1 <- runif(n) < 0.01

bench::mark(
  all_true = r_lgl_which(all_true, FALSE),
  all_false = r_lgl_which(all_false, FALSE),
  true_90 = r_lgl_which(true_90, FALSE),
  true_50 = r_lgl_which(true_50, FALSE),
  true_10 = r_lgl_which(true_10, FALSE),
  true_1 = r_lgl_which(true_1, FALSE),
  check = FALSE,
  min_iterations = 10
)
# Current dev
#> # A tibble: 6 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 all_true    142.8ms  148.5ms      5.08  381.47MB    3.38 
#> 2 all_false    91.1ms   96.1ms     10.5    39.26KB    0    
#> 3 true_90     222.9ms  237.5ms      3.97  343.32MB    0.992
#> 4 true_50     548.3ms  629.6ms      1.65  190.73MB    0.413
#> 5 true_10     210.5ms  224.6ms      4.45   38.14MB    0    
#> 6 true_1      106.5ms  109.1ms      9.14    3.82MB    0

# This PR
#> # A tibble: 6 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 all_true    113.6ms  118.2ms      6.47  381.47MB    2.77 
#> 2 all_false    53.3ms   54.7ms     17.8     1.95MB    0    
#> 3 true_90     203.6ms  207.5ms      4.82  381.47MB    2.06 
#> 4 true_50     518.9ms  538.7ms      1.82  199.13MB    0.454
#> 5 true_10     170.1ms  181.8ms      5.52   54.93MB    0.613
#> 6 true_1       67.7ms   71.4ms     14.1     9.13MB    0
```

<sup>Created on 2022-09-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Currently, this PR is only a proof of concept. It uses some magic numbers I just came up with without any testing at all. Maybe it would also make sense to not have a fixed jump size to avoid some very bad estimates, e.g. a vector of length `200 * n` where every second element is true would break the estimate.

I haven't yet added tests. Ideally, a test would force resizing of the vector but to construct such an input depends on the details of the implementation.