### PR TITLE
Add `min` and `max` to number checkers

### DIFF
--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -92,38 +92,47 @@ obj_type_friendly <- function(x, value = TRUE) {
           "`-Inf`"
         }
       }
+      str_encode <- function(x, width = 30, ...) {
+        if (nchar(x) > width) {
+          x <- substr(x, 1, width - 3)
+          x <- paste0(x, "...")
+        }
+        encodeString(x, ...)
+      }
 
       if (value) {
         if (is.numeric(x) && is.infinite(x)) {
           return(show_infinites(x))
         }
+
         if (is.numeric(x) || is.complex(x)) {
           number <- as.character(round(x, 2))
           what <- if (is.complex(x)) "the complex number" else "the number"
           return(paste(what, number))
         }
+
         return(switch(
           typeof(x),
           logical = if (x) "`TRUE`" else "`FALSE`",
           character = {
             what <- if (nzchar(x)) "the string" else "the empty string"
-            paste(what, encodeString(x, quote = "\""))
+            paste(what, str_encode(x, quote = "\""))
           },
           raw = paste("the raw value", as.character(x)),
           .rlang_stop_unexpected_typeof(x)
         ))
-      } else {
-        return(switch(
-          typeof(x),
-          logical = "a logical value",
-          integer = "an integer",
-          double = if (is.infinite(x)) show_infinites(x) else "a number",
-          complex = "a complex number",
-          character = if (nzchar(x)) "a string" else "\"\"",
-          raw = "a raw value",
-          .rlang_stop_unexpected_typeof(x)
-        ))
       }
+
+      return(switch(
+        typeof(x),
+        logical = "a logical value",
+        integer = "an integer",
+        double = if (is.infinite(x)) show_infinites(x) else "a number",
+        complex = "a complex number",
+        character = if (nzchar(x)) "a string" else "\"\"",
+        raw = "a raw value",
+        .rlang_stop_unexpected_typeof(x)
+      ))
     }
 
     if (length(x) == 0) {

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -106,8 +106,11 @@ obj_type_friendly <- function(x, value = TRUE) {
         return(switch(
           typeof(x),
           logical = if (x) "`TRUE`" else "`FALSE`",
-          character = encodeString(x, quote = "\""),
-          raw = "a raw value",
+          character = {
+            what <- if (nzchar(x)) "the string" else "the empty string"
+            paste(what, encodeString(x, quote = "\""))
+          },
+          raw = paste("the raw value", as.character(x)),
           .rlang_stop_unexpected_typeof(x)
         ))
       } else {

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -94,14 +94,13 @@ obj_type_friendly <- function(x, value = TRUE) {
       }
 
       if (value) {
+        if (is.numeric(x) && is.infinite(x)) {
+          return(show_infinites(x))
+        }
         if (is.numeric(x) || is.complex(x)) {
-          if (is.infinite(x)) {
-            return(show_infinites(x))
-          } else {
-            number <- as.character(round(x, 2))
-            what <- if (is.complex(x)) "the complex number" else "the number"
-            return(paste(what, number))
-          }
+          number <- as.character(round(x, 2))
+          what <- if (is.complex(x)) "the complex number" else "the number"
+          return(paste(what, number))
         }
         return(switch(
           typeof(x),

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -7,7 +7,7 @@
 # - `obj_type_friendly(value = TRUE)` now shows numeric scalars
 #   literally.
 # - `stop_friendly_type()` now takes `show_value`, passed to
-#   `obj_type_friendly()` as `value` argument.
+#   `obj_type_friendly()` as the `value` argument.
 #
 # 2022-10-03:
 # - Added `allow_na` and `allow_null` arguments.
@@ -41,7 +41,7 @@
 #' Return English-friendly type
 #' @param x Any R object.
 #' @param value Whether to describe the value of `x`. Special values
-#'   like `NA` or `""` are always described
+#'   like `NA` or `""` are always described.
 #' @param length Whether to mention the length of vectors and lists.
 #' @return A string describing the type. Starts with an indefinite
 #'   article, e.g. "an integer vector".

--- a/R/compat-obj-type.R
+++ b/R/compat-obj-type.R
@@ -98,7 +98,9 @@ obj_type_friendly <- function(x, value = TRUE) {
           if (is.infinite(x)) {
             return(show_infinites(x))
           } else {
-            return(as.character(round(x, 2)))
+            number <- as.character(round(x, 2))
+            what <- if (is.complex(x)) "the complex number" else "the number"
+            return(paste(what, number))
           }
         }
         return(switch(

--- a/R/compat-types-check.R
+++ b/R/compat-types-check.R
@@ -197,7 +197,7 @@ check_number_whole <- function(x,
     what <- "a whole number"
   }
 
-  .stop <- function(x, ...) stop_input_type(
+  .stop <- function(x, what, ...) stop_input_type(
     x,
     what,
     ...,
@@ -217,11 +217,11 @@ check_number_whole <- function(x,
     if (is_number) {
       if (x < min) {
         what <- sprintf("%s larger than %s", what, min)
-        .stop(x, ...)
+        .stop(x, what, ...)
       }
       if (x > max) {
         what <- sprintf("%s smaller than %s", what, max)
-        .stop(x, ...)
+        .stop(x, what, ...)
       }
       return(invisible(NULL))
     }
@@ -236,7 +236,7 @@ check_number_whole <- function(x,
     }
   }
 
-  .stop(x, ..., value = FALSE)
+  .stop(x, what, ..., value = FALSE)
 }
 
 is_number <- function(x,

--- a/R/compat-types-check.R
+++ b/R/compat-types-check.R
@@ -217,14 +217,15 @@ check_number_whole <- function(x,
     if (is_number) {
       if (min > -Inf && max < Inf) {
         what <- sprintf("a number between %s and %s", min, max)
-        .stop(x, what, ...)
+      } else {
+        what <- NULL
       }
       if (x < min) {
-        what <- sprintf("a number larger than %s", min)
+        what <- what %||% sprintf("a number larger than %s", min)
         .stop(x, what, ...)
       }
       if (x > max) {
-        what <- sprintf("a number smaller than %s", max)
+        what <- what %||% sprintf("a number smaller than %s", max)
         .stop(x, what, ...)
       }
       return(invisible(NULL))

--- a/R/compat-types-check.R
+++ b/R/compat-types-check.R
@@ -215,6 +215,10 @@ check_number_whole <- function(x,
     )
 
     if (is_number) {
+      if (min > -Inf && max < Inf) {
+        what <- sprintf("%s between %s and %s", what, min, max)
+        .stop(x, what, ...)
+      }
       if (x < min) {
         what <- sprintf("%s larger than %s", what, min)
         .stop(x, what, ...)
@@ -236,7 +240,7 @@ check_number_whole <- function(x,
     }
   }
 
-  .stop(x, what, ..., value = FALSE)
+  .stop(x, what, ...)
 }
 
 is_number <- function(x,

--- a/R/compat-types-check.R
+++ b/R/compat-types-check.R
@@ -216,15 +216,15 @@ check_number_whole <- function(x,
 
     if (is_number) {
       if (min > -Inf && max < Inf) {
-        what <- sprintf("%s between %s and %s", what, min, max)
+        what <- sprintf("a number between %s and %s", min, max)
         .stop(x, what, ...)
       }
       if (x < min) {
-        what <- sprintf("%s larger than %s", what, min)
+        what <- sprintf("a number larger than %s", min)
         .stop(x, what, ...)
       }
       if (x > max) {
-        what <- sprintf("%s smaller than %s", what, max)
+        what <- sprintf("a number smaller than %s", max)
         .stop(x, what, ...)
       }
       return(invisible(NULL))

--- a/R/fn.R
+++ b/R/fn.R
@@ -670,6 +670,6 @@ as_predicate_friendly_type_of <- function(x) {
   if (is_na(x)) {
     "a missing value"
   } else {
-    obj_type_friendly(x, length = TRUE)
+    obj_type_friendly(x)
   }
 }

--- a/R/lifecycle-deprecated.R
+++ b/R/lifecycle-deprecated.R
@@ -458,7 +458,7 @@ env_as_list <- function(x) {
   set_names(x, .Call(ffi_unescape_character, names_x))
 }
 vec_as_list <- function(x) {
-  coerce_type_vec(x, obj_type_friendly(list(), value = FALSE),
+  coerce_type_vec(x, vec_type_friendly(list()),
     logical = ,
     integer = ,
     double = ,
@@ -471,28 +471,28 @@ vec_as_list <- function(x) {
 }
 
 legacy_as_logical <- function(x) {
-  coerce_type_vec(x, obj_type_friendly(lgl(), value = FALSE),
+  coerce_type_vec(x, vec_type_friendly(lgl()),
     logical = { attributes(x) <- NULL; x },
     integer = as_base_type(x, as.logical),
     double = as_integerish_type(x, as.logical, lgl())
   )
 }
 legacy_as_integer <- function(x) {
-  coerce_type_vec(x, obj_type_friendly(int(), value = FALSE),
+  coerce_type_vec(x, vec_type_friendly(int()),
     logical = as_base_type(x, as.integer),
     integer = { attributes(x) <- NULL; x },
     double = as_integerish_type(x, as.integer, int(), value = FALSE)
   )
 }
 legacy_as_double <- function(x) {
-  coerce_type_vec(x, obj_type_friendly(dbl(), value = FALSE),
+  coerce_type_vec(x, vec_type_friendly(dbl()),
     logical = ,
     integer = as_base_type(x, as.double),
     double = { attributes(x) <- NULL; x }
   )
 }
 legacy_as_complex <- function(x) {
-  coerce_type_vec(x, obj_type_friendly(cpl(), value = FALSE),
+  coerce_type_vec(x, vec_type_friendly(cpl()),
     logical = ,
     integer = ,
     double = as_base_type(x, as.complex),
@@ -505,7 +505,7 @@ legacy_as_character <- function(x, encoding = NULL) {
   }
   coerce_type_vec(
     x,
-    obj_type_friendly(chr(), value = FALSE),
+    vec_type_friendly(chr()),
     string = ,
     character = {
       attributes(x) <- NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -5,7 +5,13 @@ abort_coercion <- function(x,
                            x_type = NULL,
                            arg = NULL,
                            call = caller_env()) {
-  x_type <- x_type %||% obj_type_friendly(x, value = TRUE)
+  if (is_null(x_type)) {
+    if (is_vector(x)) {
+      x_type <- vec_type_friendly(x)
+    } else {
+      x_type <- obj_type_friendly(x)
+    }
+  }
 
   if (is_null(arg)) {
     msg <- sprintf("Can't convert %s to %s.", x_type, to_type)

--- a/src/internal/cnd.c
+++ b/src/internal/cnd.c
@@ -202,12 +202,12 @@ r_obj* new_condition_names(r_obj* data) {
   return nms;
 }
 
-const char* rlang_obj_type_friendly_full(r_obj* x, bool value, bool length) {
-  r_obj* out_obj = KEEP(r_eval_with_xyz(obj_type_friendly_call,
-                                        x,
-                                        r_lgl(value),
-                                        r_lgl(length),
-                                        rlang_ns_env));
+// `length` is no longer a valid argument
+const char* rlang_obj_type_friendly_full(r_obj* x, bool value, bool _length) {
+  r_obj* out_obj = KEEP(r_eval_with_xy(obj_type_friendly_call,
+                                       x,
+                                       r_lgl(value),
+                                       rlang_ns_env));
 
   if (!r_is_string(out_obj)) {
     r_stop_unexpected_type(r_typeof(out_obj));
@@ -227,7 +227,7 @@ void rlang_init_cnd(r_obj* ns) {
   format_arg_call = r_parse("format_arg(x)");
   r_preserve(format_arg_call);
 
-  obj_type_friendly_call = r_parse("obj_type_friendly(x, y, z)");
+  obj_type_friendly_call = r_parse("obj_type_friendly(x, y)");
   r_preserve(obj_type_friendly_call);
 }
 

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `arg_match()`:
-      ! `arg` must be a symbol, not "foo".
+      ! `arg` must be a symbol, not the string "foo".
 
 # can match multiple arguments
 

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -124,7 +124,7 @@
     Output
       <error/rlang_error>
       Error in `arg_match()`:
-      ! `arg` must be a symbol, not a string.
+      ! `arg` must be a symbol, not "foo".
 
 # can match multiple arguments
 
@@ -219,7 +219,7 @@
     Output
       <error/rlang_error>
       Error in `g()`:
-      ! `my_arg` must be a character vector, not a number.
+      ! `my_arg` must be a character vector, not 1.
 
 # arg_match() backtrace highlights call and arg
 

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -219,7 +219,7 @@
     Output
       <error/rlang_error>
       Error in `g()`:
-      ! `my_arg` must be a character vector, not 1.
+      ! `my_arg` must be a character vector, not the number 1.
 
 # arg_match() backtrace highlights call and arg
 

--- a/tests/testthat/_snaps/cnd-signal.md
+++ b/tests/testthat/_snaps/cnd-signal.md
@@ -47,7 +47,7 @@
     Output
       <error/rlang_error>
       Error in `warn()`:
-      ! `.frequency` must be a valid name, not 1.
+      ! `.frequency` must be a valid name, not the number 1.
 
 # signal functions check inputs
 

--- a/tests/testthat/_snaps/cnd-signal.md
+++ b/tests/testthat/_snaps/cnd-signal.md
@@ -47,7 +47,7 @@
     Output
       <error/rlang_error>
       Error in `warn()`:
-      ! `.frequency` must be a valid name, not an integer.
+      ! `.frequency` must be a valid name, not 1.
 
 # signal functions check inputs
 

--- a/tests/testthat/_snaps/cnd.md
+++ b/tests/testthat/_snaps/cnd.md
@@ -497,7 +497,7 @@
     Output
       <error/rlang_error>
       Error in `message_cnd()`:
-      ! `message` must be a character vector, not a number.
+      ! `message` must be a character vector, not 1.
 
 # picks up cli format flag
 

--- a/tests/testthat/_snaps/cnd.md
+++ b/tests/testthat/_snaps/cnd.md
@@ -497,7 +497,7 @@
     Output
       <error/rlang_error>
       Error in `message_cnd()`:
-      ! `message` must be a character vector, not 1.
+      ! `message` must be a character vector, not the number 1.
 
 # picks up cli format flag
 

--- a/tests/testthat/_snaps/compat-types-check.md
+++ b/tests/testthat/_snaps/compat-types-check.md
@@ -219,6 +219,12 @@
       <error/rlang_error>
       Error in `checker()`:
       ! `foo` must be a whole number larger than 0, not -1.
+    Code
+      err(checker(10, min = 1, max = 5, check_number_whole))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a whole number between 1 and 5, not 10.
 
 # `check_number_decimal()` checks
 

--- a/tests/testthat/_snaps/compat-types-check.md
+++ b/tests/testthat/_snaps/compat-types-check.md
@@ -212,19 +212,19 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a whole number smaller than 0, not 1.
+      ! `foo` must be a number smaller than 0, not 1.
     Code
       err(checker(-1, min = 0, check_number_whole))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a whole number larger than 0, not -1.
+      ! `foo` must be a number larger than 0, not -1.
     Code
       err(checker(10, min = 1, max = 5, check_number_whole))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a whole number between 1 and 5, not 10.
+      ! `foo` must be a number between 1 and 5, not 10.
 
 # `check_number_decimal()` checks
 

--- a/tests/testthat/_snaps/compat-types-check.md
+++ b/tests/testthat/_snaps/compat-types-check.md
@@ -44,7 +44,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a single string, not "".
+      ! `foo` must be a single string, not the empty string "".
     Code
       err(checker(, check_string))
     Output
@@ -95,7 +95,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a valid name, not "".
+      ! `foo` must be a valid name, not the empty string "".
     Code
       err(checker(, check_name))
     Output
@@ -314,7 +314,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a symbol, not "foo".
+      ! `foo` must be a symbol, not the string "foo".
     Code
       err(checker(quote(foo()), check_symbol))
     Output

--- a/tests/testthat/_snaps/compat-types-check.md
+++ b/tests/testthat/_snaps/compat-types-check.md
@@ -44,7 +44,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a single string, not `""`.
+      ! `foo` must be a single string, not "".
     Code
       err(checker(, check_string))
     Output
@@ -95,7 +95,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a valid name, not `""`.
+      ! `foo` must be a valid name, not "".
     Code
       err(checker(, check_name))
     Output
@@ -207,6 +207,18 @@
       <error/rlang_error>
       Error in `checker()`:
       ! `foo` must be a whole number, not `-Inf`.
+    Code
+      err(checker(1, max = 0, check_number_whole))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a whole number smaller than 0, not 1.
+    Code
+      err(checker(-1, min = 0, check_number_whole))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a whole number larger than 0, not -1.
 
 # `check_number_decimal()` checks
 
@@ -296,7 +308,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a symbol, not a string.
+      ! `foo` must be a symbol, not "foo".
     Code
       err(checker(quote(foo()), check_symbol))
     Output

--- a/tests/testthat/_snaps/compat-types-check.md
+++ b/tests/testthat/_snaps/compat-types-check.md
@@ -35,7 +35,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be `TRUE` or `FALSE`, not 1.
+      ! `foo` must be `TRUE` or `FALSE`, not the number 1.
 
 # `check_string()` checks
 
@@ -86,7 +86,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a single string, not 1.
+      ! `foo` must be a single string, not the number 1.
 
 # `check_name()` checks
 
@@ -143,7 +143,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a valid name, not 1.
+      ! `foo` must be a valid name, not the number 1.
 
 # `check_number_whole()` checks
 
@@ -194,7 +194,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a whole number, not 10.5.
+      ! `foo` must be a whole number, not the number 10.5.
     Code
       err(checker(Inf, check_number_whole))
     Output
@@ -212,19 +212,19 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a number smaller than 0, not 1.
+      ! `foo` must be a number smaller than 0, not the number 1.
     Code
       err(checker(-1, min = 0, check_number_whole))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a number larger than 0, not -1.
+      ! `foo` must be a number larger than 0, not the number -1.
     Code
       err(checker(10, min = 1, max = 5, check_number_whole))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a number between 1 and 5, not 10.
+      ! `foo` must be a number between 1 and 5, not the number 10.
 
 # `check_number_decimal()` checks
 
@@ -407,7 +407,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a character vector or `NA`, not 1.
+      ! `foo` must be a character vector or `NA`, not the number 1.
     Code
       err(checker(list("foo", "bar"), check_character, allow_na = TRUE, allow_null = TRUE))
     Output

--- a/tests/testthat/_snaps/compat-types-check.md
+++ b/tests/testthat/_snaps/compat-types-check.md
@@ -35,7 +35,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be `TRUE` or `FALSE`, not a number.
+      ! `foo` must be `TRUE` or `FALSE`, not 1.
 
 # `check_string()` checks
 
@@ -86,7 +86,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a single string, not a number.
+      ! `foo` must be a single string, not 1.
 
 # `check_name()` checks
 
@@ -143,7 +143,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a valid name, not a number.
+      ! `foo` must be a valid name, not 1.
 
 # `check_number_whole()` checks
 
@@ -194,7 +194,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a whole number, not a number.
+      ! `foo` must be a whole number, not 10.5.
     Code
       err(checker(Inf, check_number_whole))
     Output
@@ -389,7 +389,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a character vector or `NA`, not a number.
+      ! `foo` must be a character vector or `NA`, not 1.
     Code
       err(checker(list("foo", "bar"), check_character, allow_na = TRUE, allow_null = TRUE))
     Output

--- a/tests/testthat/_snaps/eval-tidy.md
+++ b/tests/testthat/_snaps/eval-tidy.md
@@ -36,7 +36,7 @@
     Output
       <error/rlang_error>
       Error in `.data[[2]]`:
-      ! Must subset the data pronoun with a string, not a number.
+      ! Must subset the data pronoun with a string, not 2.
     Code
       g <- (function(data) h(.data["foo"], data = data))
       (expect_error(f(mtcars)))

--- a/tests/testthat/_snaps/eval-tidy.md
+++ b/tests/testthat/_snaps/eval-tidy.md
@@ -36,7 +36,7 @@
     Output
       <error/rlang_error>
       Error in `.data[[2]]`:
-      ! Must subset the data pronoun with a string, not 2.
+      ! Must subset the data pronoun with a string, not the number 2.
     Code
       g <- (function(data) h(.data["foo"], data = data))
       (expect_error(f(mtcars)))

--- a/tests/testthat/_snaps/fn.md
+++ b/tests/testthat/_snaps/fn.md
@@ -5,25 +5,25 @@
     Output
       <error/rlang_error>
       Error:
-      ! Can't convert `1`, a number, to a function.
+      ! Can't convert `1`, a double vector, to a function.
     Code
       (expect_error(as_function(1, arg = "foo")))
     Output
       <error/rlang_error>
       Error:
-      ! Can't convert `foo`, a number, to a function.
+      ! Can't convert `foo`, a double vector, to a function.
     Code
       (expect_error(my_function(1 + 2)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      ! Can't convert `my_arg`, a number, to a function.
+      ! Can't convert `my_arg`, a double vector, to a function.
     Code
       (expect_error(my_function(1)))
     Output
       <error/rlang_error>
       Error in `my_function()`:
-      ! Can't convert `my_arg`, a number, to a function.
+      ! Can't convert `my_arg`, a double vector, to a function.
     Code
       (expect_error(my_function(a ~ b)))
     Output
@@ -38,17 +38,17 @@
     Output
       <error/rlang_error>
       Error in `fn_fmls()`:
-      ! `fn` must be an R function, not a number.
+      ! `fn` must be an R function, not 1.
     Code
       (expect_error(fn_body(1)))
     Output
       <error/rlang_error>
       Error in `fn_body()`:
-      ! `fn` must be an R function, not a number.
+      ! `fn` must be an R function, not 1.
     Code
       (expect_error(fn_env(1)))
     Output
       <error/rlang_error>
       Error in `fn_env()`:
-      ! `fn` must be a function, not a number.
+      ! `fn` must be a function, not 1.
 

--- a/tests/testthat/_snaps/fn.md
+++ b/tests/testthat/_snaps/fn.md
@@ -38,17 +38,17 @@
     Output
       <error/rlang_error>
       Error in `fn_fmls()`:
-      ! `fn` must be an R function, not 1.
+      ! `fn` must be an R function, not the number 1.
     Code
       (expect_error(fn_body(1)))
     Output
       <error/rlang_error>
       Error in `fn_body()`:
-      ! `fn` must be an R function, not 1.
+      ! `fn` must be an R function, not the number 1.
     Code
       (expect_error(fn_env(1)))
     Output
       <error/rlang_error>
       Error in `fn_env()`:
-      ! `fn` must be a function, not 1.
+      ! `fn` must be a function, not the number 1.
 

--- a/tests/testthat/_snaps/friendly-type.md
+++ b/tests/testthat/_snaps/friendly-type.md
@@ -1,0 +1,9 @@
+# obj_type_friendly() handles NULL
+
+    Code
+      (expect_error(friendly_types(NULL)))
+    Output
+      <error/rlang_error>
+      Error in `vec_type_friendly()`:
+      ! `x` must be a vector.
+

--- a/tests/testthat/_snaps/s3.md
+++ b/tests/testthat/_snaps/s3.md
@@ -5,7 +5,7 @@
     Output
       <error/rlang_error>
       Error in `.p()`:
-      ! Predicate functions must return a single `TRUE` or `FALSE`, not 10
+      ! Predicate functions must return a single `TRUE` or `FALSE`, not the number 10
     Code
       (expect_error(as_box_if(NULL, ~ c(TRUE, FALSE))))
     Output

--- a/tests/testthat/_snaps/s3.md
+++ b/tests/testthat/_snaps/s3.md
@@ -1,0 +1,15 @@
+# as_box_if() ensures boxed value if predicate returns TRUE
+
+    Code
+      (expect_error(as_box_if(NULL, ~10)))
+    Output
+      <error/rlang_error>
+      Error in `.p()`:
+      ! Predicate functions must return a single `TRUE` or `FALSE`, not 10
+    Code
+      (expect_error(as_box_if(NULL, ~ c(TRUE, FALSE))))
+    Output
+      <error/rlang_error>
+      Error in `.p()`:
+      ! Predicate functions must return a single `TRUE` or `FALSE`, not a logical vector
+

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -178,7 +178,7 @@
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      ! `action` must be an R function or `NULL`, not "identity".
+      ! `action` must be an R function or `NULL`, not the string "identity".
     Code
       err(check_installed("foo", action = identity))
     Output

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -178,7 +178,7 @@
     Output
       <error/rlang_error>
       Error in `check_installed()`:
-      ! `action` must be an R function or `NULL`, not a string.
+      ! `action` must be an R function or `NULL`, not "identity".
     Code
       err(check_installed("foo", action = identity))
     Output

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1282,7 +1282,7 @@
     Output
       <error/rlang_error>
       Error in <<CALL `h()`>>:
-      ! `x` must be a single string, not a number.
+      ! `x` must be a single string, not 1.
       ---
       Backtrace:
            x
@@ -1304,7 +1304,7 @@
       Error in <<CALL `wrapper()`>>:
       ! Tilt.
       Caused by error in <<CALL `h()`>>:
-      ! `x` must be a single string, not a number.
+      ! `x` must be a single string, not 1.
       ---
       Backtrace:
            x
@@ -1404,7 +1404,7 @@
     Output
       <error/rlang_error>
       Error in <<CALL `rlang:::as_string()`>>:
-      ! Can't convert a number to a string.
+      ! Can't convert a double vector to a string.
       ---
       Backtrace:
            x

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -1282,7 +1282,7 @@
     Output
       <error/rlang_error>
       Error in <<CALL `h()`>>:
-      ! `x` must be a single string, not 1.
+      ! `x` must be a single string, not the number 1.
       ---
       Backtrace:
            x
@@ -1304,7 +1304,7 @@
       Error in <<CALL `wrapper()`>>:
       ! Tilt.
       Caused by error in <<CALL `h()`>>:
-      ! `x` must be a single string, not 1.
+      ! `x` must be a single string, not the number 1.
       ---
       Backtrace:
            x

--- a/tests/testthat/helper-rlang.R
+++ b/tests/testthat/helper-rlang.R
@@ -129,3 +129,20 @@ import_or_skip <- function(ns, names, env = caller_env()) {
   skip_if_not_installed(ns)
   ns_import_from(ns, names, env = env)
 }
+
+friendly_types <- function(x, vector = TRUE) {
+  out <- c(
+    object = obj_type_friendly(x),
+    object_no_value = obj_type_friendly(x, value = FALSE)
+  )
+
+  if (vector) {
+    out <- c(
+      out,
+      vector = vec_type_friendly(x),
+      vector_length = vec_type_friendly(x, length = TRUE)
+    )
+  }
+
+  out
+}

--- a/tests/testthat/test-compat-types-check.R
+++ b/tests/testthat/test-compat-types-check.R
@@ -58,6 +58,9 @@ test_that("`check_number_whole()` checks", {
   expect_null(check_number_whole(na_int, allow_na = TRUE))
   expect_null(check_number_whole(NULL, allow_null = TRUE))
 
+  check_number_whole(0, max = 0)
+  check_number_whole(0, min = 0)
+
   expect_snapshot({
     err(checker(, check_number_whole))
     err(checker(NA, check_number_whole))
@@ -69,6 +72,8 @@ test_that("`check_number_whole()` checks", {
     err(checker(10.5, check_number_whole))
     err(checker(Inf, check_number_whole))
     err(checker(-Inf, check_number_whole))
+    err(checker(1, max = 0, check_number_whole))
+    err(checker(-1, min = 0, check_number_whole))
   })
 })
 

--- a/tests/testthat/test-compat-types-check.R
+++ b/tests/testthat/test-compat-types-check.R
@@ -74,6 +74,7 @@ test_that("`check_number_whole()` checks", {
     err(checker(-Inf, check_number_whole))
     err(checker(1, max = 0, check_number_whole))
     err(checker(-1, min = 0, check_number_whole))
+    err(checker(10, min = 1, max = 5, check_number_whole))
   })
 })
 

--- a/tests/testthat/test-compat-types-check.R
+++ b/tests/testthat/test-compat-types-check.R
@@ -60,6 +60,7 @@ test_that("`check_number_whole()` checks", {
 
   check_number_whole(0, max = 0)
   check_number_whole(0, min = 0)
+  check_number_whole(1, min = 0, max = 2)
 
   expect_snapshot({
     err(checker(, check_number_whole))

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -1,20 +1,24 @@
 test_that("obj_type_friendly() supports objects", {
-  expect_equal(obj_type_friendly(mtcars), "a <data.frame> object")
-  expect_equal(obj_type_friendly(quo(1)), "a <quosure> object")
+  expect_equal(friendly_types(mtcars), c(
+    object = "a <data.frame> object",
+    object_no_value = "a <data.frame> object",
+    vector = "a data frame",
+    vector_length = "a data frame"
+  ))
+  expect_true(all(
+    friendly_types(quo(1), vector = FALSE) == "a <quosure> object"
+  ))
 })
 
 test_that("obj_type_friendly() supports matrices and arrays (#141)", {
-  expect_equal(obj_type_friendly(list()), "an empty list")
-  expect_equal(obj_type_friendly(matrix(list(1, 2))), "a list matrix")
-  expect_equal(obj_type_friendly(array(list(1, 2, 3), dim = 1:3)), "a list array")
+  expect_true(all(friendly_types(matrix(list(1, 2))) == "a list matrix"))
+  expect_true(all(friendly_types(array(list(1, 2, 3), dim = 1:3)) == "a list array"))
 
-  expect_equal(obj_type_friendly(int()), "an empty integer vector")
-  expect_equal(obj_type_friendly(matrix(1:3)), "an integer matrix")
-  expect_equal(obj_type_friendly(array(1:3, dim = 1:3)), "an integer array")
+  expect_true(all(friendly_types(matrix(1:3)) == "an integer matrix"))
+  expect_true(all(friendly_types(array(1:3, dim = 1:3)) == "an integer array"))
 
-  expect_equal(obj_type_friendly(chr()), "an empty character vector")
-  expect_equal(obj_type_friendly(matrix(letters)), "a character matrix")
-  expect_equal(obj_type_friendly(array(letters[1:3], dim = 1:3)), "a character array")
+  expect_true(all(friendly_types(matrix(letters)) == "a character matrix"))
+  expect_true(all(friendly_types(array(letters[1:3], dim = 1:3)) == "a character array"))
 })
 
 test_that("obj_type_friendly() supports missing arguments", {
@@ -22,45 +26,166 @@ test_that("obj_type_friendly() supports missing arguments", {
 })
 
 test_that("obj_type_friendly() handles scalars", {
-  expect_equal(obj_type_friendly(NA), "`NA`")
-  expect_equal(obj_type_friendly(na_int), "an integer `NA`")
-  expect_equal(obj_type_friendly(na_dbl), "a numeric `NA`")
-  expect_equal(obj_type_friendly(na_cpl), "a complex `NA`")
-  expect_equal(obj_type_friendly(na_chr), "a character `NA`")
+  expect_equal(friendly_types(NA), c(
+    object = "`NA`",
+    object_no_value = "`NA`",
+    vector = "a logical vector",
+    vector_length = "a logical vector of length 1"
+  ))
+  expect_equal(friendly_types(na_int), c(
+    object = "an integer `NA`",
+    object_no_value = "an integer `NA`",
+    vector = "an integer vector",
+    vector_length = "an integer vector of length 1"
+  ))
+  expect_equal(friendly_types(na_dbl), c(
+    object = "a numeric `NA`",
+    object_no_value = "a numeric `NA`",
+    vector = "a double vector",
+    vector_length = "a double vector of length 1"
+  ))
+  expect_equal(friendly_types(na_cpl), c(
+    object = "a complex `NA`",
+    object_no_value = "a complex `NA`",
+    vector = "a complex vector",
+    vector_length = "a complex vector of length 1"
+  ))
+  expect_equal(friendly_types(na_chr), c(
+    object = "a character `NA`",
+    object_no_value = "a character `NA`",
+    vector = "a character vector",
+    vector_length = "a character vector of length 1"
+  ))
 
-  expect_equal(obj_type_friendly(TRUE), "`TRUE`")
-  expect_equal(obj_type_friendly(FALSE), "`FALSE`")
+  expect_equal(friendly_types(TRUE), c(
+    object = "`TRUE`",
+    object_no_value = "a logical value",
+    vector = "a logical vector",
+    vector_length = "a logical vector of length 1"
+  ))
+  expect_equal(friendly_types(FALSE), c(
+    object = "`FALSE`",
+    object_no_value = "a logical value",
+    vector = "a logical vector",
+    vector_length = "a logical vector of length 1"
+  ))
 
-  expect_equal(obj_type_friendly(1L), "an integer")
-  expect_equal(obj_type_friendly(1.0), "a number")
-  expect_equal(obj_type_friendly(1i), "a complex number")
-  expect_equal(obj_type_friendly(as.raw(1)), "a raw value")
+  expect_equal(friendly_types(1L), c(
+    object = "1",
+    object_no_value = "an integer",
+    vector = "an integer vector",
+    vector_length = "an integer vector of length 1"
+  ))
+  expect_equal(friendly_types(1.0), c(
+    object = "1",
+    object_no_value = "a number",
+    vector = "a double vector",
+    vector_length = "a double vector of length 1"
+  ))
+  expect_equal(friendly_types(1i), c(
+    object = "0+1i",
+    object_no_value = "a complex number",
+    vector = "a complex vector",
+    vector_length = "a complex vector of length 1"
+  ))
+  expect_equal(friendly_types(as.raw(1)), c(
+    object = "a raw value",
+    object_no_value = "a raw value",
+    vector = "a raw vector",
+    vector_length = "a raw vector of length 1"
+  ))
 
-  expect_equal(obj_type_friendly("foo"), "a string")
-  expect_equal(obj_type_friendly(""), "`\"\"`")
+  expect_equal(friendly_types("foo"), c(
+    object = "\"foo\"",
+    object_no_value = "a string",
+    vector = "a character vector",
+    vector_length = "a character vector of length 1"
+  ))
+  expect_equal(friendly_types(""), c(
+    object = "\"\"",
+    object_no_value = "\"\"",
+    vector = "a character vector",
+    vector_length = "a character vector of length 1"
+  ))
 
-  expect_equal(obj_type_friendly(list(1)), "a list")
+  expect_equal(friendly_types(list(1)), c(
+    object = "a list",
+    object_no_value = "a list",
+    vector = "a list",
+    vector_length = "a list of length 1"
+  ))
 
-  expect_equal(obj_type_friendly(matrix(NA)), "a logical matrix")
-  expect_equal(obj_type_friendly(matrix(1)), "a double matrix")
+  expect_true(all(friendly_types(matrix(NA)) == "a logical matrix"))
+  expect_true(all(friendly_types(matrix(1)) == "a double matrix"))
 })
 
 test_that("obj_type_friendly() handles empty vectors", {
-  expect_equal(obj_type_friendly(lgl()), "an empty logical vector")
-  expect_equal(obj_type_friendly(int()), "an empty integer vector")
-  expect_equal(obj_type_friendly(dbl()), "an empty numeric vector")
-  expect_equal(obj_type_friendly(cpl()), "an empty complex vector")
-  expect_equal(obj_type_friendly(chr()), "an empty character vector")
-  expect_equal(obj_type_friendly(raw()), "an empty raw vector")
-  expect_equal(obj_type_friendly(list()), "an empty list")
+  expect_equal(friendly_types(lgl()), c(
+    object = "an empty logical vector",
+    object_no_value = "an empty logical vector",
+    vector = "a logical vector",
+    vector_length = "a logical vector of length 0"
+  ))
+  expect_equal(friendly_types(int()), c(
+    object = "an empty integer vector",
+    object_no_value = "an empty integer vector",
+    vector = "an integer vector",
+    vector_length = "an integer vector of length 0"
+  ))
+  expect_equal(friendly_types(dbl()), c(
+    object = "an empty numeric vector",
+    object_no_value = "an empty numeric vector",
+    vector = "a double vector",
+    vector_length = "a double vector of length 0"
+  ))
+  expect_equal(friendly_types(cpl()), c(
+    object = "an empty complex vector",
+    object_no_value = "an empty complex vector",
+    vector = "a complex vector",
+    vector_length = "a complex vector of length 0"
+  ))
+  expect_equal(friendly_types(chr()), c(
+    object = "an empty character vector",
+    object_no_value = "an empty character vector",
+    vector = "a character vector",
+    vector_length = "a character vector of length 0"
+  ))
+  expect_equal(friendly_types(raw()), c(
+    object = "an empty raw vector",
+    object_no_value = "an empty raw vector",
+    vector = "a raw vector",
+    vector_length = "a raw vector of length 0"
+  ))
+  expect_equal(friendly_types(list()), c(
+    object = "an empty list",
+    object_no_value = "an empty list",
+    vector = "a list",
+    vector_length = "a list of length 0"
+  ))
 })
 
 test_that("obj_type_friendly() handles NULL", {
-  expect_equal(obj_type_friendly(NULL), "`NULL`")
+  expect_true(all(friendly_types(NULL, vector = FALSE) == "`NULL`"))
+  expect_snapshot((expect_error(friendly_types(NULL))))
 })
 
 test_that("obj_type_friendly() handles NaN and infinities", {
-  expect_equal(obj_type_friendly(NaN), "`NaN`")
-  expect_equal(obj_type_friendly(Inf), "`Inf`")
-  expect_equal(obj_type_friendly(-Inf), "`-Inf`")
+  expect_equal(friendly_types(NaN), c(
+    object = "`NaN`",
+    object_no_value = "`NaN`",
+    vector = "a double vector",
+    vector_length = "a double vector of length 1"
+  ))
+  expect_equal(friendly_types(Inf), c(
+    object = "`Inf`",
+    object_no_value = "`Inf`",
+    vector = "a double vector",
+    vector_length = "a double vector of length 1"
+  ))
+  expect_equal(friendly_types(-Inf), c(
+    object = "`-Inf`",
+    object_no_value = "`-Inf`",
+    vector = "a double vector",
+    vector_length = "a double vector of length 1"
+  ))
 })

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -188,4 +188,10 @@ test_that("obj_type_friendly() handles NaN and infinities", {
     vector = "a double vector",
     vector_length = "a double vector of length 1"
   ))
+  expect_equal(friendly_types(Inf + 0i), c(
+    object = "the complex number Inf+0i",
+    object_no_value = "a complex number",
+    vector = "a complex vector",
+    vector_length = "a complex vector of length 1"
+  ))
 })

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -195,3 +195,10 @@ test_that("obj_type_friendly() handles NaN and infinities", {
     vector_length = "a complex vector of length 1"
   ))
 })
+
+test_that("long strings are truncated", {
+  expect_equal(
+    obj_type_friendly(strrep("abc", 12)),
+    "the string \"abcabcabcabcabcabcabcabcabc...\""
+  )
+})

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -89,20 +89,20 @@ test_that("obj_type_friendly() handles scalars", {
     vector_length = "a complex vector of length 1"
   ))
   expect_equal(friendly_types(as.raw(1)), c(
-    object = "a raw value",
+    object = "the raw value 01",
     object_no_value = "a raw value",
     vector = "a raw vector",
     vector_length = "a raw vector of length 1"
   ))
 
   expect_equal(friendly_types("foo"), c(
-    object = "\"foo\"",
+    object = "the string \"foo\"",
     object_no_value = "a string",
     vector = "a character vector",
     vector_length = "a character vector of length 1"
   ))
   expect_equal(friendly_types(""), c(
-    object = "\"\"",
+    object = "the empty string \"\"",
     object_no_value = "\"\"",
     vector = "a character vector",
     vector_length = "a character vector of length 1"

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -71,19 +71,19 @@ test_that("obj_type_friendly() handles scalars", {
   ))
 
   expect_equal(friendly_types(1L), c(
-    object = "1",
+    object = "the number 1",
     object_no_value = "an integer",
     vector = "an integer vector",
     vector_length = "an integer vector of length 1"
   ))
   expect_equal(friendly_types(1.0), c(
-    object = "1",
+    object = "the number 1",
     object_no_value = "a number",
     vector = "a double vector",
     vector_length = "a double vector of length 1"
   ))
   expect_equal(friendly_types(1i), c(
-    object = "0+1i",
+    object = "the complex number 0+1i",
     object_no_value = "a complex number",
     vector = "a complex vector",
     vector_length = "a complex vector of length 1"

--- a/tests/testthat/test-s3.R
+++ b/tests/testthat/test-s3.R
@@ -67,7 +67,10 @@ test_that("as_box_if() ensures boxed value if predicate returns TRUE", {
 
   expect_null(as_box_if(NULL, is_vector, "null_box"))
 
-  expect_error(as_box_if(NULL, ~ 10), "Predicate functions must return a single")
+  expect_snapshot({
+    (expect_error(as_box_if(NULL, ~ 10)))
+    (expect_error(as_box_if(NULL, ~ c(TRUE, FALSE))))
+  })
 })
 
 test_that("unboxing a non-boxed value is an error", {

--- a/tests/testthat/test-vec-new.R
+++ b/tests/testthat/test-vec-new.R
@@ -66,8 +66,8 @@ test_that("atomic inputs are implicitly coerced", {
   expect_identical(lgl(10L, FALSE, list(TRUE, 0L, 0)), c(TRUE, FALSE, TRUE, FALSE, FALSE))
   expect_identical(dbl(10L, 10, TRUE, list(10L, 0, TRUE)), c(10, 10, 1, 10, 0, 1))
 
-  expect_error(lgl("foo"), "Can't convert a string to a logical vector")
-  expect_error(chr(10), "Can't convert a number to a character vector")
+  expect_error(lgl("foo"), "Can't convert a character vector to a logical vector")
+  expect_error(chr(10), "Can't convert a double vector to a character vector")
 })
 
 test_that("type errors are handled", {


### PR DESCRIPTION
- Add `min` and `max` to `check_number_whole()` and its decimal variant.

- Refactor `obj_type_friendly()` to more consistently show values. This is the largest part of this PR, with many new tests, and some functionality extracted in a separate `vec_type_friendly()` helper.

The goal of the second change is to consistently show values in error messages when a range is requested, so that we don't get messages like "must be a number greater than 0, not a number".

```r
foo <- function(x, min = -Inf, max = Inf) {
  check_number_whole(x, min = min, max = max)
  x
}

foo(1, max = 0)
#> Error in `foo()`:
#> ! `x` must be a number smaller than 0, not 1.

foo(-1, min = 0)
#> Error in `foo()`:
#> ! `x` must be a number larger than 0, not -1.

foo(10, min = 1, max = 5)
#> Error in `foo()`:
#> ! `x` must be a number between 1 and 5, not 10.
```