### PR TITLE
Updates for `-Wstrict-prototypes`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* rlang is now compliant with `-Wstrict-prototypes` as requested by CRAN
+  (#1508).
+
 # rlang 1.0.6
 
 * `as_closure(seq.int)` now works (#1468).

--- a/src/internal/cnd.c
+++ b/src/internal/cnd.c
@@ -141,7 +141,7 @@ void without_winch(void* payload) {
   r_poke_option("rlang_trace_use_winch", data->old_use_winch);
 }
 
-r_obj* ffi_test_stop_internal() {
+r_obj* ffi_test_stop_internal(void) {
   r_stop_internal("foo");
   return r_null;
 }

--- a/src/internal/decl/names-decl.h
+++ b/src/internal/decl/names-decl.h
@@ -16,7 +16,7 @@ static
 void names_inform_repair(r_obj* old_names, r_obj* new_names);
 
 static
-void stop_large_name();
+void stop_large_name(void);
 
 static
 bool is_dotdotint(const char* name);

--- a/src/internal/dots.c
+++ b/src/internal/dots.c
@@ -102,7 +102,7 @@ struct dots_capture_info init_capture_info(enum dots_collect type,
 
 static
 bool has_glue = false;
-r_obj* ffi_glue_is_here() {
+r_obj* ffi_glue_is_here(void) {
   has_glue = true;
   return r_null;
 }
@@ -209,7 +209,7 @@ r_obj* def_unquote_name(r_obj* expr, r_obj* env) {
   return lhs;
 }
 
-void signal_retired_splice() {
+void signal_retired_splice(void) {
   const char* msg =
     "Unquoting language objects with `!!!` is deprecated as of rlang 0.4.0.\n"
     "Please use `!!` instead.\n"

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -549,7 +549,7 @@ r_obj* ffi_eval_tidy(r_obj* call, r_obj* op, r_obj* args, r_obj* rho) {
 }
 
 
-void rlang_init_eval_tidy() {
+void rlang_init_eval_tidy(void) {
   r_obj* rlang_ns_env = KEEP(r_ns_env("rlang"));
 
   tilde_fn = r_eval(r_sym("tilde_eval"), rlang_ns_env);

--- a/src/internal/exported.c
+++ b/src/internal/exported.c
@@ -9,7 +9,7 @@ void r_vec_poke_range(r_obj* x, r_ssize offset,
                       r_obj* y, r_ssize from, r_ssize to);
 
 
-r_obj* ffi_compiled_by_gcc() {
+r_obj* ffi_compiled_by_gcc(void) {
 #if defined(__GNUC__) && !defined(__clang__)
   return r_true;
   #else
@@ -37,7 +37,7 @@ r_obj* ffi_cnd_type(r_obj* cnd) {
   }
 }
 
-r_obj* ffi_interrupt() {
+r_obj* ffi_interrupt(void) {
   r_interrupt();
   return r_null;
 }
@@ -490,7 +490,7 @@ r_obj* ffi_env_is_browsed(r_obj* env) {
   return r_lgl(RDEBUG(env));
 }
 
-r_obj* ffi_ns_registry_env() {
+r_obj* ffi_ns_registry_env(void) {
   return R_NamespaceRegistry;
 }
 
@@ -693,7 +693,7 @@ r_obj* ffi_is_reference(r_obj* x, r_obj* y) {
   return r_lgl(x == y);
 }
 
-r_obj* ffi_missing_arg() {
+r_obj* ffi_missing_arg(void) {
   return R_MissingArg;
 }
 
@@ -803,9 +803,9 @@ r_obj* ffi_chr_get(r_obj* x, r_obj* i) {
 }
 
 // Returns a copy
-r_obj* ffi_precious_dict() {
+r_obj* ffi_precious_dict(void) {
   // From rlang/sexp.c
-  struct r_dict* rlang__precious_dict();
+  struct r_dict* rlang__precious_dict(void);
 
   struct r_dict* p_dict = rlang__precious_dict();
   return wrap_dict(p_dict);

--- a/src/internal/fn.c
+++ b/src/internal/fn.c
@@ -33,7 +33,7 @@ r_obj* rlang_as_function(r_obj* x, r_obj* env) {
   return r_eval_with_xy(as_function_call, x, env, rlang_ns_env);
 }
 
-void rlang_init_fn() {
+void rlang_init_fn(void) {
   as_function_call = r_parse("as_function(x, env = y)");
   r_preserve(as_function_call);
 }

--- a/src/internal/hash.c
+++ b/src/internal/hash.c
@@ -90,7 +90,7 @@ struct hash_state_t {
 };
 
 static inline struct hash_state_t new_hash_state(XXH3_state_t* p_xx_state);
-static inline int hash_version();
+static inline int hash_version(void);
 static inline r_obj* hash_value(XXH3_state_t* p_xx_state);
 static inline void hash_bytes(R_outpstream_t stream, void* p_input, int n);
 static inline void hash_char(R_outpstream_t stream, int input);
@@ -161,7 +161,7 @@ struct hash_state_t new_hash_state(XXH3_state_t* p_xx_state) {
 }
 
 static inline
-int hash_version() {
+int hash_version(void) {
 #if USE_VERSION_3
   return 3;
 #else
@@ -345,7 +345,7 @@ void hasher_finalizer(r_obj* x) {
   R_ClearExternalPtr(x);
 }
 
-r_obj* ffi_hasher_init() {
+r_obj* ffi_hasher_init(void) {
   XXH3_state_t* p_xx_state = XXH3_createState();
 
   XXH_errorcode err = XXH3_128bits_reset(p_xx_state);

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -4,10 +4,10 @@
 
 // Library initialisation defined below
 static r_obj* ffi_init_rlang(r_obj*);
-static r_obj* ffi_fini_rlang();
+static r_obj* ffi_fini_rlang(void);
 
 // From version.c
-extern r_obj* rlang_linked_version();
+extern r_obj* rlang_linked_version(void);
 
 static const R_CallMethodDef r_callables[] = {
   {"ffi_alloc_data_frame",             (DL_FUNC) &ffi_alloc_data_frame, 3},
@@ -322,6 +322,6 @@ r_obj* ffi_init_rlang(r_obj* ns) {
 }
 
 static
-r_obj* ffi_fini_rlang() {
+r_obj* ffi_fini_rlang(void) {
   return r_null;
 }

--- a/src/internal/names.c
+++ b/src/internal/names.c
@@ -223,6 +223,6 @@ void names_inform_repair(r_obj* old_names, r_obj* new_names) {
 }
 
 static
-void stop_large_name() {
+void stop_large_name(void) {
   r_abort("Can't tidy up name because it is too large.");
 }

--- a/src/internal/nse-inject.c
+++ b/src/internal/nse-inject.c
@@ -91,14 +91,14 @@ struct injection_info which_curly_op(r_obj* first, struct injection_info info) {
 
 // These functions are questioning and might be soft-deprecated in the
 // future
-void signal_uq_soft_deprecation() {
+void signal_uq_soft_deprecation(void) {
   return ;
   const char* msg =
     "`UQ()` is soft-deprecated as of rlang 0.2.0. "
     "Please use the prefix form of `!!` instead.";
   signal_soft_deprecated(msg, msg, r_envs.empty);
 }
-void signal_uqs_soft_deprecation() {
+void signal_uqs_soft_deprecation(void) {
   return ;
   const char* msg =
     "`UQS()` is soft-deprecated as of rlang 0.2.0. "
@@ -106,7 +106,7 @@ void signal_uqs_soft_deprecation() {
   signal_soft_deprecated(msg, msg, r_envs.empty);
 }
 
-void signal_namespaced_uq_deprecation() {
+void signal_namespaced_uq_deprecation(void) {
   warn_deprecated("namespaced rlang::UQ()",
     "Prefixing `UQ()` with the rlang namespace is deprecated as of rlang 0.3.0.\n"
     "Please use the non-prefixed form or `!!` instead.\n"
@@ -121,7 +121,7 @@ void signal_namespaced_uq_deprecation() {
     "  rlang::expr(mean(!!var * 100))\n"
   );
 }
-void signal_namespaced_uqs_deprecation() {
+void signal_namespaced_uqs_deprecation(void) {
   warn_deprecated("namespaced rlang::UQS()",
     "Prefixing `UQS()` with the rlang namespace is deprecated as of rlang 0.3.0.\n"
     "Please use the non-prefixed form or `!!!` instead.\n"
@@ -431,6 +431,6 @@ r_obj* ffi_interp(r_obj* x, r_obj* env) {
 }
 
 
-void rlang_init_expr_interp() {
+void rlang_init_expr_interp(void) {
   dot_data_sym = r_sym(".data");
 }

--- a/src/internal/tests.c
+++ b/src/internal/tests.c
@@ -8,10 +8,10 @@ struct r_test {
   bool (*fn_ptr)();
 };
 
-bool test_that_true_is_true() {
+bool test_that_true_is_true(void) {
   if (true) return r_true; else return r_false;
 }
-bool test_that_false_is_false() {
+bool test_that_false_is_false(void) {
   if (false) return r_false; else return r_true;
 }
 
@@ -34,7 +34,7 @@ const enum r_type tests_df_types[TESTS_DF_SIZE] = {
 
 extern const struct r_test tests[];
 
-r_obj* ffi_c_tests() {
+r_obj* ffi_c_tests(void) {
   int n_rows = 0;
   while (tests[n_rows].desc) {
     ++n_rows;
@@ -183,7 +183,7 @@ r_obj* ffi_test_nms_are_duplicated(r_obj* nms, r_obj* from_last) {
 }
 
 
-void rlang_init_tests() {
+void rlang_init_tests(void) {
   tests_df_names = r_chr_n(tests_df_names_c_strings, TESTS_DF_SIZE);
   r_preserve_global(tests_df_names);
 }

--- a/src/internal/tests.c
+++ b/src/internal/tests.c
@@ -5,7 +5,7 @@
 
 struct r_test {
   const char* desc;
-  bool (*fn_ptr)();
+  bool (*fn_ptr)(void);
 };
 
 bool test_that_true_is_true(void) {
@@ -65,7 +65,7 @@ r_obj* ffi_run_c_test(r_obj* fn_ptr) {
     r_stop_unexpected_type(r_typeof(fn_ptr));
   }
 
-  bool (*p)() = (bool (*)()) r_fn_ptr_addr(fn_ptr);
+  bool (*p)(void) = (bool (*)(void)) r_fn_ptr_addr(fn_ptr);
   return r_lgl(p());
 }
 

--- a/src/internal/utils.c
+++ b/src/internal/utils.c
@@ -1,7 +1,7 @@
 #include <rlang.h>
 
 
-r_obj* new_preserved_empty_list() {
+r_obj* new_preserved_empty_list(void) {
   r_obj* empty_list = r_alloc_list(0);
   r_preserve(empty_list);
   r_mark_shared(empty_list);
@@ -256,7 +256,7 @@ r_obj* chr_detect_dups(r_obj* x) {
   return out;
 }
 
-r_obj* ffi_peek_srcref() {
+r_obj* ffi_peek_srcref(void) {
   if (R_Srcref) {
     return R_Srcref;
   } else {
@@ -264,7 +264,7 @@ r_obj* ffi_peek_srcref() {
   }
 }
 
-r_obj* ffi_has_local_precious_list() {
+r_obj* ffi_has_local_precious_list(void) {
   return r_lgl(_r_use_local_precious_list);
 }
 r_obj* ffi_use_local_precious_list(r_obj* x) {
@@ -273,12 +273,12 @@ r_obj* ffi_use_local_precious_list(r_obj* x) {
   return r_lgl(old);
 }
 
-r_obj* ffi_getppid() {
+r_obj* ffi_getppid(void) {
   return r_getppid();
 }
 
 
-void rlang_init_utils() {
+void rlang_init_utils(void) {
   warn_deprecated_call = r_parse("rlang:::warn_deprecated(x, id = y)");
   r_preserve(warn_deprecated_call);
 

--- a/src/internal/utils.h
+++ b/src/internal/utils.h
@@ -2,7 +2,7 @@
 #define RLANG_INTERNAL_UTILS_H
 
 
-r_obj* new_preserved_empty_list();
+r_obj* new_preserved_empty_list(void);
 r_obj* rlang_ns_get(const char* name);
 r_obj* ffi_enquo(r_obj* sym, r_obj* frame);
 

--- a/src/rlang/arg.c
+++ b/src/rlang/arg.c
@@ -5,7 +5,7 @@ int (*r_arg_match)(r_obj* arg,
                    struct r_lazy error_arg,
                    struct r_lazy error_call);
 
-void r_init_library_arg() {
+void r_init_library_arg(void) {
   r_arg_match = (int (*)(r_obj*, r_obj*, struct r_lazy, struct r_lazy))
     r_peek_c_callable("rlang", "rlang_arg_match_2");
 }

--- a/src/rlang/call.c
+++ b/src/rlang/call.c
@@ -62,6 +62,6 @@ r_obj* r_call_clone(r_obj* x) {
 }
 
 
-void r_init_library_call() {
+void r_init_library_call(void) {
   quote_prim = r_base_ns_get("quote");
 }

--- a/src/rlang/cnd.c
+++ b/src/rlang/cnd.c
@@ -87,13 +87,13 @@ void r_cnd_signal(r_obj* cnd) {
 
 #ifdef _WIN32
 #include <Rembedded.h>
-void r_interrupt() {
+void r_interrupt(void) {
   UserBreak = 1;
   R_CheckUserInterrupt();
 }
 #else
 #include <Rinterface.h>
-void r_interrupt() {
+void r_interrupt(void) {
   Rf_onintr();
 }
 #endif
@@ -134,7 +134,7 @@ enum r_cnd_type r_cnd_type(r_obj* cnd) {
 }
 
 
-void r_init_library_cnd() {
+void r_init_library_cnd(void) {
   msg_call = r_parse("message(x)");
   r_preserve(msg_call);
 

--- a/src/rlang/cnd.h
+++ b/src/rlang/cnd.h
@@ -6,7 +6,7 @@
 
 void r_inform(const char* fmt, ...);
 void r_warn(const char* fmt, ...);
-void r_interrupt();
+void r_interrupt(void);
 void r_no_return r_abort(const char* fmt, ...);
 void r_no_return r_abort_n(const struct r_pair* args, int n);
 void r_no_return r_abort_call(r_obj* call, const char* fmt, ...);
@@ -36,7 +36,7 @@ void (*r_stop_internal)(const char* file,
                         const char* fmt,
                         ...);
 
-r_obj* r_peek_frame();
+r_obj* r_peek_frame(void);
 
 #define r_stop_internal(...)                            \
   (r_stop_internal)(__FILE__, __LINE__, r_peek_frame(), \

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -119,7 +119,7 @@ void r_dyn_resize(struct r_dyn_array* p_arr,
 }
 
 
-void r_init_library_dyn_array() {
+void r_init_library_dyn_array(void) {
   r_preserve_global(attribs_dyn_array = r_pairlist(r_chr("rlang_dyn_array")));
   r_node_poke_tag(attribs_dyn_array, r_syms.class_);
 }

--- a/src/rlang/env.c
+++ b/src/rlang/env.c
@@ -282,11 +282,11 @@ r_obj* r_env_find_until(r_obj* env, r_obj* sym, r_obj* last) {
 }
 
 
-void r_init_rlang_ns_env() {
+void r_init_rlang_ns_env(void) {
   rlang_ns_env = r_ns_env("rlang");
 }
 
-void r_init_library_env() {
+void r_init_library_env(void) {
   new_env_call = r_parse_eval("as.call(list(new.env, TRUE, NULL, NULL))", r_envs.base);
   r_preserve(new_env_call);
 

--- a/src/rlang/eval.c
+++ b/src/rlang/eval.c
@@ -168,7 +168,7 @@ r_obj* r_exec_mask_n_call_poke(r_obj* fn_sym,
 }
 
 
-void r_init_library_eval() {
+void r_init_library_eval(void) {
   r_lazy_missing_arg = (struct r_lazy) { .x = r_missing_arg, .env = r_null };
 }
 

--- a/src/rlang/fn.c
+++ b/src/rlang/fn.c
@@ -25,7 +25,7 @@ r_obj* r_as_function(r_obj* x, const char* arg) {
   }
 }
 
-void r_init_library_fn() {
+void r_init_library_fn(void) {
   const char* formals_code = "formals(function(..., .x = ..1, .y = ..2, . = ..1) NULL)";
   rlang_formula_formals = r_parse_eval(formals_code, r_envs.base);
   r_preserve_global(rlang_formula_formals);

--- a/src/rlang/globals.c
+++ b/src/rlang/globals.c
@@ -55,7 +55,7 @@ void r_init_library_globals(r_obj* ns) {
   r_envs.ns = ns;
 }
 
-void r_init_library_globals_syms() {
+void r_init_library_globals_syms(void) {
   r_syms.abort = r_sym("abort");
   r_syms.arg = r_sym("arg");
   r_syms.brackets = R_BracketSymbol;

--- a/src/rlang/obj.c
+++ b/src/rlang/obj.c
@@ -96,7 +96,7 @@ int pop_precious(r_obj* stack) {
 }
 
 // For unit tests
-struct r_dict* rlang__precious_dict() {
+struct r_dict* rlang__precious_dict(void) {
   return p_precious_dict;
 }
 

--- a/src/rlang/quo.c
+++ b/src/rlang/quo.c
@@ -5,7 +5,7 @@ r_obj* (*r_quo_set_expr)(r_obj* quo, r_obj* expr);
 r_obj* (*r_quo_get_env)(r_obj* quo);
 r_obj* (*r_quo_set_env)(r_obj* quo, r_obj* env);
 
-void r_init_library_quo() {
+void r_init_library_quo(void) {
   r_quo_get_expr = (r_obj* (*)(r_obj*)) r_peek_c_callable("rlang", "rlang_quo_get_expr");
   r_quo_set_expr = (r_obj* (*)(r_obj*, r_obj*)) r_peek_c_callable("rlang", "rlang_quo_set_expr");
   r_quo_get_env = (r_obj* (*)(r_obj*)) r_peek_c_callable("rlang", "rlang_quo_get_env");

--- a/src/rlang/session.c
+++ b/src/rlang/session.c
@@ -16,7 +16,7 @@ bool r_is_installed(const char* pkg) {
 
 static r_obj* has_colour_call = NULL;
 
-bool r_has_colour() {
+bool r_has_colour(void) {
   if (!r_is_installed("crayon")) {
     return false;
   }
@@ -25,7 +25,7 @@ bool r_has_colour() {
 }
 
 
-void r_init_library_session() {
+void r_init_library_session(void) {
   is_installed_call = r_parse("requireNamespace(x, quietly = TRUE)");
   r_preserve(is_installed_call);
 
@@ -39,7 +39,7 @@ void r_init_library_session() {
 # include    <windows.h>
 # include    <tlhelp32.h>
 
-r_obj* r_getppid() {
+r_obj* r_getppid(void) {
   DWORD pid = GetCurrentProcessId();
   HANDLE handle = NULL;
   PROCESSENTRY32W pe = { 0 };
@@ -70,7 +70,7 @@ r_obj* r_getppid() {
 
 # include <unistd.h>
 
-r_obj* r_getppid() {
+r_obj* r_getppid(void) {
   return r_int(getppid());
 }
 

--- a/src/rlang/session.h
+++ b/src/rlang/session.h
@@ -3,8 +3,8 @@
 
 
 bool r_is_installed(const char* pkg);
-bool r_has_colour();
-r_obj* r_getppid();
+bool r_has_colour(void);
+r_obj* r_getppid(void);
 
 
 #endif

--- a/src/rlang/stack.c
+++ b/src/rlang/stack.c
@@ -16,7 +16,7 @@ void r_on_exit(r_obj* expr, r_obj* frame) {
 }
 
 
-r_obj* r_peek_frame() {
+r_obj* r_peek_frame(void) {
   return r_eval(peek_frame_call, r_envs.empty);
 }
 
@@ -74,7 +74,7 @@ static r_obj* generate_sys_call(const char* name, int** n_addr) {
   return sys_call;
 }
 
-void r_init_library_stack() {
+void r_init_library_stack(void) {
   r_obj* current_frame_body = KEEP(r_parse_eval("as.call(list(sys.frame, -1))", r_envs.base));
   r_obj* current_frame_fn = KEEP(r_new_function(r_null, current_frame_body, r_envs.empty));
   peek_frame_call = r_new_call(current_frame_fn, r_null);

--- a/src/rlang/stack.h
+++ b/src/rlang/stack.h
@@ -4,7 +4,7 @@
 
 void r_on_exit(r_obj* expr, r_obj* frame);
 
-r_obj* r_peek_frame();
+r_obj* r_peek_frame(void);
 r_obj* r_caller_env(r_obj* n);
 r_obj* r_sys_frame(int n, r_obj* frame);
 r_obj* r_sys_call(int n, r_obj* frame);

--- a/src/rlang/sym.c
+++ b/src/rlang/sym.c
@@ -53,7 +53,7 @@ bool r_is_symbol_any(r_obj* x, const char** strings, int n) {
 r_obj* (*r_sym_as_utf8_character)(r_obj* x) = NULL;
 r_obj* (*r_sym_as_utf8_string)(r_obj* x) = NULL;
 
-void r_init_library_sym() {
+void r_init_library_sym(void) {
   r_sym_as_utf8_character = (r_obj* (*)(r_obj*)) r_peek_c_callable("rlang", "rlang_sym_as_character");
   r_sym_as_utf8_string = (r_obj* (*)(r_obj*)) r_peek_c_callable("rlang", "rlang_sym_as_string");
 }

--- a/src/rlang/vendor.c
+++ b/src/rlang/vendor.c
@@ -2,6 +2,6 @@
 
 uint64_t (*r_xxh3_64bits)(const void*, size_t);
 
-void r_init_library_vendor() {
+void r_init_library_vendor(void) {
   r_xxh3_64bits = (uint64_t (*)(const void*, size_t)) r_peek_c_callable("rlang", "rlang_xxh3_64bits");
 }

--- a/src/version.c
+++ b/src/version.c
@@ -22,6 +22,6 @@ const char* rlang_version = "1.0.6.9000";
  */
 
 // [[ register() ]]
-SEXP rlang_linked_version() {
+SEXP rlang_linked_version(void) {
   return Rf_mkString(rlang_version);
 }


### PR DESCRIPTION
rlang is now silent with r-devel and `-Wstrict-prototypes` turned on (at least on my Mac, but I think I got them all)