### PR TITLE
fix `is_integerish()` lower bound for large negative doubles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `is_integerish()` now handles negative doubles more consistently
+  with positive ones (@sorhawell, #1530).
+
 * New `check_logical()` in `standalone-types-check.R` (#1560).
 
 * `quo_squash()` now squashes quosures in function position (#1509).

--- a/src/rlang/c-utils.h
+++ b/src/rlang/c-utils.h
@@ -26,10 +26,11 @@ void* r_shelter_deref(r_obj* x);
 // Allow integers up to 2^52, same as R_XLEN_T_MAX when long vector
 // support is enabled
 #define RLANG_MAX_DOUBLE_INT 4503599627370496
+#define RLANG_MIN_DOUBLE_INT -4503599627370496
 
 static inline
 bool r_dbl_is_decimal(double x) {
-  if (x > RLANG_MAX_DOUBLE_INT) {
+  if (x > RLANG_MAX_DOUBLE_INT || x < RLANG_MIN_DOUBLE_INT) {
     return false;
   }
 

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -111,12 +111,19 @@ test_that("scalar predicates heed type and length", {
 test_that("is_integerish() supports large numbers (#578)", {
   expect_true(is_integerish(1e10))
   expect_true(is_integerish(2^52))
+  expect_true(is_integerish(-2^52))
 
   expect_false(is_integerish(2^52 + 1))
+  expect_false(is_integerish(-2^52 - 1))
+
 
   expect_false(is_integerish(2^50 - 0.1))
   expect_false(is_integerish(2^49 - 0.05))
   expect_false(is_integerish(2^40 - 0.0001))
+
+  expect_false(is_integerish(-2^50 + 0.1))
+  expect_false(is_integerish(-2^49 + 0.05))
+  expect_false(is_integerish(-2^40 + 0.0001))
 })
 
 test_that("is_string() matches on string", {


### PR DESCRIPTION
Hello wonderful people :)

## bugfix
Currently rlang has chosen 2^52 as the upper bound for integerish doubles.
However the effective lower bound is somewhere around -2^63-2^10 which is much lower than -2^52 which was likely the intended bound. This PR adds the  lower bound `RLANG_MIN_DOUBLE_INT = -2^52` and append some test statements. If not adopting fix `rlang::is_integerish(-2^63)`will return `TRUE` although -2^63 is not unambiguously represented as a binary64 floating point.

## Bonus topic ( I will repost as issue if no obvious explanation):
I don't understand why the bound should not to allow representation of all the integers {-2^53+1, ...,  -1, 0, 1, ..., 2^53-1} . The double has 53 significant bits and the sign bit. [Wikipedia says](https://en.wikipedia.org/wiki/Double-precision_floating-point_format#Precision_limitations_on_integer_values) -2^53 to 2^53 could be represented exactly(footnote*).  Are there any other reasons?

footnote: This is true, however that is unpractical unless guaranteed the floating bound is bounded to the same range. Better to choose the range which is represented unambiguously by binary64/float64. As -2^53-1 and 2^53+1 has the same float representation as -2^53 and 2^53 respectively, that makes the -2^53 and 2^53 ambiguous represented, hence the [2^53+1; 2^53-1] bound.