### PR TITLE
Remove unused extra argument in `ffi_new_condition`

### DIFF
--- a/src/internal/cnd.c
+++ b/src/internal/cnd.c
@@ -150,8 +150,7 @@ r_obj* ffi_test_stop_internal(void) {
 // Probably should be implemented at R level
 r_obj* ffi_new_condition(r_obj* class,
                          r_obj* msg,
-                         r_obj* data,
-                         r_obj* error_call) {
+                         r_obj* data) {
   if (msg == r_null) {
     msg = r_chrs.empty_string;
   } else if (r_typeof(msg) != R_TYPE_character) {


### PR DESCRIPTION
In `src/internal/init.c`, the function `ffi_new_condition` is set in the `r_callables` table to take 3 arguments, but the implementation takes 4 arguments. This breaks rlang when running under WebAssembly, where function pointer signatures must be consistent.

It doesn't look like the `error_call` argument is used, so I've removed it to leave the first 3 arguments.