### PR TITLE
Optimize `r_dyn_*_push_back()` for vector types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* The C level `r_dyn_*_push_back()` utilities are now faster (#1542).
+
 * rlang is now compliant with `-Wstrict-prototypes` as requested by CRAN
   (#1508).
 

--- a/src/rlang/dyn-array.c
+++ b/src/rlang/dyn-array.c
@@ -70,20 +70,12 @@ struct r_dyn_array* r_new_dyn_array(r_ssize elt_byte_size,
 
 void r_dyn_push_back(struct r_dyn_array* p_arr,
                      const void* p_elt) {
-  r_ssize count = ++p_arr->count;
-  if (count > p_arr->capacity) {
-    r_ssize new_capacity = r_ssize_mult(p_arr->capacity,
-                                        p_arr->growth_factor);
-    r_dyn_resize(p_arr, new_capacity);
-  }
+  r_ssize loc = r__dyn_increment(p_arr);
 
   if (p_arr->barrier_set) {
     r_obj* value = *((r_obj* const *) p_elt);
-    p_arr->barrier_set(p_arr->data, count - 1, value);
-    return;
-  }
-
-  if (p_elt) {
+    p_arr->barrier_set(p_arr->data, loc, value);
+  } else if (p_elt) {
     memcpy(r_dyn_last(p_arr), p_elt, p_arr->elt_byte_size);
   } else {
     memset(r_dyn_last(p_arr), 0, p_arr->elt_byte_size);

--- a/src/rlang/dyn-array.h
+++ b/src/rlang/dyn-array.h
@@ -73,36 +73,6 @@ const void* r_dyn_cend(struct r_dyn_array* p_arr) {
   return r_dyn_cpointer(p_arr, p_arr->count);
 }
 
-static inline
-void* const * r_dyn_pop_back(struct r_dyn_array* p_arr) {
-  void* const * out = (void* const *) r_dyn_clast(p_arr);
-  --p_arr->count;
-  return out;
-}
-
-static inline
-void r_dyn_lgl_push_back(struct r_dyn_array* p_vec, int elt) {
-  r_dyn_push_back(p_vec, &elt);
-}
-static inline
-void r_dyn_int_push_back(struct r_dyn_array* p_vec, int elt) {
-  r_dyn_push_back(p_vec, &elt);
-}
-static inline
-void r_dyn_dbl_push_back(struct r_dyn_array* p_vec, double elt) {
-  r_dyn_push_back(p_vec, &elt);
-}
-static inline
-void r_dyn_cpl_push_back(struct r_dyn_array* p_vec, r_complex elt) {
-  r_dyn_push_back(p_vec, &elt);
-}
-static inline
-void r_dyn_list_push_back(struct r_dyn_array* p_vec, r_obj* elt) {
-  KEEP(elt);
-  r_dyn_push_back(p_vec, &elt);
-  FREE(1);
-}
-
 #define R_DYN_GET(TYPE, X, I) (*((TYPE*) r_dyn_pointer((X), (I))))
 #define R_DYN_POKE(TYPE, X, I, VAL) (*((TYPE*) r_dyn_pointer((X), (I))) = (VAL))
 
@@ -162,6 +132,53 @@ void r_dyn_chr_poke(struct r_dyn_array* p_vec, r_ssize i, r_obj* value) {
 static inline
 void r_dyn_list_poke(struct r_dyn_array* p_vec, r_ssize i, r_obj* value) {
   r_list_poke(p_vec->data, i, value);
+}
+
+static inline
+void* const * r_dyn_pop_back(struct r_dyn_array* p_arr) {
+  void* const * out = (void* const *) r_dyn_clast(p_arr);
+  --p_arr->count;
+  return out;
+}
+
+static inline
+r_ssize r__dyn_increment(struct r_dyn_array* p_arr) {
+  r_ssize loc = p_arr->count++;
+
+  if (p_arr->count > p_arr->capacity) {
+    r_ssize new_capacity = r_ssize_mult(p_arr->capacity, p_arr->growth_factor);
+    r_dyn_resize(p_arr, new_capacity);
+  }
+
+  return loc;
+}
+
+static inline
+void r_dyn_lgl_push_back(struct r_dyn_array* p_vec, int elt) {
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_lgl_poke(p_vec, loc, elt);
+}
+static inline
+void r_dyn_int_push_back(struct r_dyn_array* p_vec, int elt) {
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_int_poke(p_vec, loc, elt);
+}
+static inline
+void r_dyn_dbl_push_back(struct r_dyn_array* p_vec, double elt) {
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_dbl_poke(p_vec, loc, elt);
+}
+static inline
+void r_dyn_cpl_push_back(struct r_dyn_array* p_vec, r_complex elt) {
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_cpl_poke(p_vec, loc, elt);
+}
+static inline
+void r_dyn_list_push_back(struct r_dyn_array* p_vec, r_obj* elt) {
+  KEEP(elt);
+  r_ssize loc = r__dyn_increment(p_vec);
+  r_dyn_list_poke(p_vec, loc, elt);
+  FREE(1);
 }
 
 #endif


### PR DESCRIPTION
The push-back operation of our dynamic vector is probably one of the most commonly used ops in practice, so it would be nice if this was really fast. Currently it calls into `r_dyn_push_back()`, which is generic (which is great!) but slow because of its generality. 

I was looking into replacing our vctrs `growable` type with dynamic vectors and was surprised to see just how slow our dynamic push-back was in comparison.

Consider this simple example of doing repeated push-backs and no resizing.

```r
r_obj* ffi_test_push_back() {
  r_ssize size = 100000;

  struct r_dyn_array* p_vec = r_new_dyn_vector(R_TYPE_integer, size);
  KEEP(p_vec->shelter);

  for (r_ssize i = 0; i < size; ++i) {
    r_dyn_int_push_back(p_vec, i);
  }

  r_obj* out = r_dyn_unwrap(p_vec);

  FREE(1);
  return out;
}
```

```r
# CRAN rlang
bench::mark(.Call(ffi_test_push_back), iterations = 10000)
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 .Call(ffi_test_push_back)    503µs    610µs     1609.     391KB     11.7

# This PR
bench::mark(.Call(ffi_test_push_back), iterations = 10000)
#> # A tibble: 1 × 6
#>   expression                     min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 .Call(ffi_test_push_back)    113µs    165µs     5699.     391KB     41.3
```

Providing "native" push-back operators is a big win here, so it definitely seems worth it to me.