### PR TITLE
Fix typo (duplicate https://)

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -679,7 +679,7 @@ footer_internal <- function(env) {
       url_line <- sprintf(
         "Please report it at %s with a %s and the full backtrace.",
         format_url(url),
-        format_href("reprex", "https://https://tidyverse.org/help/")
+        format_href("reprex", "https://tidyverse.org/help/")
       )
     }
   } else {

--- a/tests/testthat/_snaps/c-api.md
+++ b/tests/testthat/_snaps/c-api.md
@@ -8,7 +8,7 @@
       ! Location 0 does not exist.
       i In file 'rlang/dyn-list-of.c' at line 167.
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
     Code
       err(lof_arr_push_back(lof, 10, 42L), "Location 10 does not exist")
     Output
@@ -17,7 +17,7 @@
       ! Location 10 does not exist.
       i In file 'rlang/dyn-list-of.c' at line 167.
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 # re-encoding fails purposefully with any bytes
 

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -1131,7 +1131,7 @@
       ! foo
       x bar
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
     Code
       err(abort("foo", body = c(x = "bar"), .internal = TRUE))
     Output
@@ -1140,7 +1140,7 @@
       ! foo
       x bar
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 # setting `.internal` adds footer bullet (fallback)
 
@@ -1152,7 +1152,7 @@
       ! foo
       x bar
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
     Code
       err(abort("foo", body = c(x = "bar"), .internal = TRUE))
     Output
@@ -1161,7 +1161,7 @@
       ! foo
       x bar
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
 
 # must pass character `body` when `message` is > 1
 
@@ -1248,7 +1248,7 @@
       Error in `f()`:
       ! foo
       i This is an internal error that was detected in the rlang package.
-        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://https://tidyverse.org/help/>) and the full backtrace.
+        Please report it at <https://github.com/r-lib/rlang/issues> with a reprex (<https://tidyverse.org/help/>) and the full backtrace.
     Code
       err(abort("foo", footer = "bar", .internal = TRUE, call = quote(f())))
     Output


### PR DESCRIPTION
Flagged by our typo tool in vctrs:

https://github.com/r-lib/vctrs/blob/af3fcc486664e30b588df1296a212e583ef00d18/tests/testthat/_snaps/expand.md?plain=1#L61