### PR TITLE
Optimize `new_data_mask()` and `r_alloc_environment()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `new_data_mask()` is now slightly faster due to a smaller initial mask size
+  and usage of the C level function `R_NewEnv()` on R >=4.1.0 (#1553).
+
 * The C level `r_dyn_*_push_back()` utilities are now faster (#1542).
 
 * rlang is now compliant with `-Wstrict-prototypes` as requested by CRAN

--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -160,14 +160,14 @@ r_obj* ffi_new_data_mask(r_obj* bottom, r_obj* top) {
   r_obj* data_mask;
 
   if (bottom == r_null) {
-    bottom = KEEP(r_alloc_environment(100, r_envs.empty));
+    bottom = KEEP(r_alloc_environment(10, r_envs.empty));
     data_mask = bottom;
   } else {
     check_data_mask_input(bottom, "bottom");
     // Create a child because we don't know what might be in `bottom`
     // and we need to clear its contents without deleting any object
     // created in the data mask environment
-    data_mask = KEEP(r_alloc_environment(100, bottom));
+    data_mask = KEEP(r_alloc_environment(10, bottom));
   }
 
   if (top == r_null) {

--- a/src/rlang/decl/env-decl.h
+++ b/src/rlang/decl/env-decl.h
@@ -2,6 +2,7 @@ r_obj* eval_with_x(r_obj* call, r_obj* x);
 r_obj* eval_with_xy(r_obj* call, r_obj* x, r_obj* y);
 r_obj* eval_with_xyz(r_obj* call, r_obj* x, r_obj* y, r_obj* z);
 
+#if R_VERSION < R_Version(4, 1, 0)
 static
 r_obj* new_env_call;
 
@@ -10,6 +11,7 @@ r_obj* new_env__parent_node;
 
 static
 r_obj* new_env__size_node;
+#endif
 
 static
 r_obj* exists_call;

--- a/src/rlang/env.c
+++ b/src/rlang/env.c
@@ -41,6 +41,7 @@ r_obj* rlang_ns_get(const char* name) {
 
 
 r_obj* r_alloc_environment(r_ssize size, r_obj* parent) {
+#if R_VERSION < R_Version(4, 1, 0)
   parent = parent ? parent : r_envs.empty;
   r_node_poke_car(new_env__parent_node, parent);
 
@@ -53,6 +54,10 @@ r_obj* r_alloc_environment(r_ssize size, r_obj* parent) {
   r_node_poke_car(new_env__parent_node, r_null);
 
   return env;
+#else
+  const int hash = 1;
+  return R_NewEnv(parent, hash, size);
+#endif
 }
 
 
@@ -287,11 +292,13 @@ void r_init_rlang_ns_env(void) {
 }
 
 void r_init_library_env(void) {
+#if R_VERSION < R_Version(4, 1, 0)
   new_env_call = r_parse_eval("as.call(list(new.env, TRUE, NULL, NULL))", r_envs.base);
   r_preserve(new_env_call);
 
   new_env__parent_node = r_node_cddr(new_env_call);
   new_env__size_node = r_node_cdr(new_env__parent_node);
+#endif
 
   env2list_call = r_parse("as.list.environment(x, all.names = TRUE)");
   r_preserve(env2list_call);
@@ -316,6 +323,7 @@ void r_init_library_env(void) {
 r_obj* rlang_ns_env = NULL;
 r_obj* r_methods_ns_env = NULL;
 
+#if R_VERSION < R_Version(4, 1, 0)
 static
 r_obj* new_env_call = NULL;
 
@@ -324,6 +332,7 @@ r_obj* new_env__parent_node = NULL;
 
 static
 r_obj* new_env__size_node = NULL;
+#endif
 
 static
 r_obj* exists_call = NULL;


### PR DESCRIPTION
This PR was motivated by this dplyr issue https://github.com/tidyverse/dplyr/issues/6666

If we are going to create a fresh data mask at each group evaluation, then mask creation needs to be very fast.

This PR helps in two ways:
- Reduce the initial data mask size from 100 down to 10. I don't think that we really need such a large initial mask size, since most of the time we don't use `<-` in `eval_tidy()` calls to poke into the mask. I think most of the time the expressions we pass to `eval_tidy()` are function calls like `eval_tidy(mean(x), mask)` or something similar, so I don't think the mask env needs to be this big.
- Optimize `r_alloc_environment()` to use `R_NewEnv()` on R >=4.1.0, which is a C level version of `new.env()`.

``` r
library(rlang)

env <- new_environment()

# CRAN rlang
bench::mark(new_data_mask(env), iterations = 1000000)
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_mask(env)   2.08µs   2.94µs   299002.    3.48KB     18.2

# Just 100->10
bench::mark(new_data_mask(env), iterations = 1000000)
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_mask(env)      2µs   2.75µs   337047.     4.3KB     20.2

# Both 100->10, and `R_NewEnv()`
bench::mark(new_data_mask(env), iterations = 1000000)
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new_data_mask(env)    980ns   1.39µs   646986.     4.3KB     14.9
```

I am hopeful that this means C calls to `new_data_mask()` in dplyr will be in the nanosecond range

We can probably also use this in vctrs if we wanted