### PR TITLE
New `r_alloc_empty_environment()`

### DIFF
--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -51,7 +51,7 @@ static r_obj* rlang_new_data_pronoun(r_obj* mask) {
   return pronoun;
 }
 static r_obj* rlang_new_ctxt_pronoun(r_obj* top) {
-  r_obj* pronoun = KEEP(r_alloc_environment(0, r_env_parent(top)));
+  r_obj* pronoun = KEEP(r_alloc_empty_environment(r_env_parent(top)));
 
   r_attrib_poke(pronoun, r_syms.class_, ctxt_pronoun_class);
 

--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -81,6 +81,15 @@ r_obj* r_base_ns_get(const char* name);
 
 r_obj* r_alloc_environment(r_ssize size, r_obj* parent);
 
+static inline
+r_obj* r_alloc_empty_environment(r_obj* parent) {
+  // Non-hashed environment.
+  // Very fast and useful when you aren't getting/setting from the result.
+  r_obj* env = Rf_allocSExp(R_TYPE_environment);
+  r_env_poke_parent(env, parent);
+  return env;
+}
+
 r_obj* r_env_as_list(r_obj* x);
 r_obj* r_list_as_environment(r_obj* x, r_obj* parent);
 r_obj* r_env_clone(r_obj* env, r_obj* parent);


### PR DESCRIPTION
For use in `rlang_new_ctxt_pronoun()` where we don't poke into the `pronoun` environment at all, which makes it slightly faster and allocate less memory. `new_data_mask()` now shows up as allocating 0 memory by profmem.

- This is actually how we define `r_new_environment()` in vctrs, so we could switch that out for this https://github.com/r-lib/vctrs/blob/793d028250824ce907970135105c461c66b7dd25/src/utils.h#L260
- I was tempted to make this what happens if you supply `0` in `r_alloc_environment()`, but that felt wrong because it creates a non-hashed environment and is different from what `R_NewEnv()` does (by using the "default" size of 29)