### PR TITLE
Turning off condition inheritance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * `abort()`, `warn()`, and `inform()` gain a `.inherit` parameter.
   This controls whether `parent` is inherited. If `FALSE`
-  `cnd_inherits()` doesn't match chained conditions across parents.
+  `cnd_inherits()` and `try_fetch()` do not match chained conditions
+  across parents.
 
   It's normally `TRUE` by default, but if a warning is chained to an
   error or a message is chained to a warning or error (downgraded

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # rlang (development version)
 
-* `abort()`, `warn()`, and `inform()` gain a `.inherit` parameter.
-  This controls whether `parent` is inherited. If `FALSE`
+* `abort()`, `warn()`, and `inform()` gain an `.inherit` parameter.
+  This controls whether `parent` is inherited. If `FALSE`,
   `cnd_inherits()` and `try_fetch()` do not match chained conditions
   across parents.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # rlang (development version)
 
+* `abort()`, `warn()`, and `inform()` gain a `.inherit` parameter.
+  This controls whether `parent` is inherited. If `FALSE`
+  `cnd_inherits()` doesn't match chained conditions across parents.
+
+  It's normally `TRUE` by default, but if a warning is chained to an
+  error or a message is chained to a warning or error (downgraded
+  chaining), `.inherit` defaults to `FALSE` (#1573).
+
 * `dots_splice()` is deprecated. This function was previously in
   the questioning lifecycle stage as we were moving towards the
   explicit `!!!` splicing style.

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -88,6 +88,11 @@
 #'   individual and unformatted lines. Any newline character `"\\n"`
 #'   already present in `message` is reformatted by cli's paragraph
 #'   formatter. See `r link("topic_condition_formatting")`.
+#' @param .inherit Whether the condition inherits from `parent`
+#'   according to [cnd_inherits()] and [try_fetch()]. By default,
+#'   parent conditions of higher severity are not inherited. For
+#'   instance an error chained to a warning is not inherited to avoid
+#'   unexpectedly catching an error downgraded to a warning.
 #' @param .internal If `TRUE`, a footer bullet is added to `message`
 #'   to let the user know that the error is internal and that they
 #'   should report it to the package authors. This argument is
@@ -252,6 +257,7 @@ abort <- function(message = NULL,
                   trace = NULL,
                   parent = NULL,
                   use_cli_format = NULL,
+                  .inherit = TRUE,
                   .internal = FALSE,
                   .file = NULL,
                   .frame = caller_env(),
@@ -321,6 +327,11 @@ abort <- function(message = NULL,
   message <- message_info$message
   extra_fields <- message_info$extra_fields
   use_cli_format <- message_info$use_cli_format
+
+  extra_fields$rlang <- c(
+    extra_fields$rlang,
+    list(inherit = .inherit)
+  )
 
   parent_trace <- if (rethrowing) parent[["trace"]]
 

--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -216,7 +216,6 @@ handler_call <- quote(function(cnd) {
     } else {
       except <- ""
     }
-    inherit <- .subset2(.subset2(cnd, "rlang"), "inherit")
   }
 
   while (!is_null(cnd)) {
@@ -225,6 +224,7 @@ handler_call <- quote(function(cnd) {
       if (!inherits(out, "rlang_zap")) throw(out)
     }
 
+    inherit <- .subset2(.subset2(cnd, "rlang"), "inherit")
     if (is_false(inherit)) {
       return()
     }

--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -132,7 +132,7 @@ environment(hnd_prompt_install) <- baseenv()
 #' insensitive to changes of implementation or context of evaluation
 #' that cause a classed error to suddenly get chained to a contextual
 #' error. Note that some chained conditions are not inherited, see the
-#' `inherit` argument of [abort()] or [warn()]. In particular,
+#' `.inherit` argument of [abort()] or [warn()]. In particular,
 #' downgraded conditions (e.g. from error to warning or from warning
 #' to message) are not matched across parents.
 #'

--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -131,8 +131,10 @@ environment(hnd_prompt_install) <- baseenv()
 #' [abort()]. This is a useful property that makes `try_fetch()`
 #' insensitive to changes of implementation or context of evaluation
 #' that cause a classed error to suddenly get chained to a contextual
-#' error. Note however that downgraded conditions (e.g. from error to
-#' warning or from warning to message) are not matched across parents.
+#' error. Note that some chained conditions are not inherited, see the
+#' `inherit` argument of [abort()] or [warn()]. In particular,
+#' downgraded conditions (e.g. from error to warning or from warning
+#' to message) are not matched across parents.
 #'
 #' @param expr An R expression.
 #' @param ... <[`dynamic-dots`][rlang::dyn-dots]> Named condition
@@ -214,12 +216,19 @@ handler_call <- quote(function(cnd) {
     } else {
       except <- ""
     }
+    inherit <- .subset2(.subset2(cnd, "rlang"), "inherit")
   }
+
   while (!is_null(cnd)) {
-    if (inherits(cnd, CLASS) && !inherits(cnd, except)) {
+    if (inherits(cnd, CLASS)) {
       out <- handlers[[I]](cnd)
       if (!inherits(out, "rlang_zap")) throw(out)
     }
+
+    if (is_false(inherit)) {
+      return()
+    }
+
     cnd <- .subset2(cnd, "parent")
   }
 })

--- a/R/cnd-signal.R
+++ b/R/cnd-signal.R
@@ -95,7 +95,9 @@ warn <- function(message = NULL,
                  ...,
                  body = NULL,
                  footer = NULL,
+                 parent = NULL,
                  use_cli_format = NULL,
+                 .inherit = NULL,
                  .frequency = c("always", "regularly", "once"),
                  .frequency_id = NULL,
                  .subclass = deprecated()) {
@@ -117,11 +119,24 @@ warn <- function(message = NULL,
     return(invisible(NULL))
   }
 
+  if (!is_null(parent)) {
+    # Don't inherit from `parent` by default if chained to a
+    # downgraded error
+    if (is_null(.inherit)) {
+      .inherit <- !inherits(parent, "error")
+    }
+    extra_fields$rlang <- c(
+      extra_fields$rlang,
+      list(inherit = .inherit)
+    )
+  }
+
   cnd <- warning_cnd(
     class,
     message = message,
     !!!extra_fields,
     use_cli_format = use_cli_format,
+    parent = parent,
     ...
   )
   cnd$footer <- c(cnd$footer, message_freq(message, .frequency, "warning"))
@@ -136,7 +151,9 @@ inform <- function(message = NULL,
                    ...,
                    body = NULL,
                    footer = NULL,
+                   parent = NULL,
                    use_cli_format = NULL,
+                   .inherit = NULL,
                    .file = NULL,
                    .frequency = c("always", "regularly", "once"),
                    .frequency_id = NULL,
@@ -161,10 +178,23 @@ inform <- function(message = NULL,
     return(invisible(NULL))
   }
 
+  if (!is_null(parent)) {
+    # Don't inherit from `parent` by default if chained to a
+    # downgraded warning or error
+    if (is_null(.inherit)) {
+      .inherit <- !inherits(parent, c("warning", "error"))
+    }
+    extra_fields$rlang <- c(
+      extra_fields$rlang,
+      list(inherit = .inherit)
+    )
+  }
+
   cnd <- message_cnd(
     class,
     message = message,
     !!!extra_fields,
+    parent = parent,
     use_cli_format = use_cli_format,
     ...
   )

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -288,7 +288,7 @@ cnd_type <- function(cnd) {
 #' error.
 #'
 #' Some chained conditions carry parents that are not inherited. See
-#' the `inherit` argument of [abort()], [warn()], and [inform()].
+#' the `.inherit` argument of [abort()], [warn()], and [inform()].
 #'
 #'
 #' # Capture an error with `cnd_inherits()`

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -32,7 +32,9 @@ warn(
   ...,
   body = NULL,
   footer = NULL,
+  parent = NULL,
   use_cli_format = NULL,
+  .inherit = NULL,
   .frequency = c("always", "regularly", "once"),
   .frequency_id = NULL,
   .subclass = deprecated()
@@ -44,7 +46,9 @@ inform(
   ...,
   body = NULL,
   footer = NULL,
+  parent = NULL,
   use_cli_format = NULL,
+  .inherit = NULL,
   .file = NULL,
   .frequency = c("always", "regularly", "once"),
   .frequency_id = NULL,
@@ -130,6 +134,12 @@ If set to \code{TRUE}, \code{message} should be a character vector of
 individual and unformatted lines. Any newline character \code{"\\\\n"}
 already present in \code{message} is reformatted by cli's paragraph
 formatter. See \ifelse{html}{\link[=topic-condition-formatting]{Formatting messages with cli}}{\link[=topic-condition-formatting]{Formatting messages with cli}}.}
+
+\item{.inherit}{Whether the condition inherits from \code{parent}
+according to \code{\link[=cnd_inherits]{cnd_inherits()}} and \code{\link[=try_fetch]{try_fetch()}}. By default,
+parent conditions of higher severity are not inherited. For
+instance an error chained to a warning is not inherited to avoid
+unexpectedly catching an error downgraded to a warning.}
 
 \item{.internal}{If \code{TRUE}, a footer bullet is added to \code{message}
 to let the user know that the error is internal and that they

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -19,6 +19,7 @@ abort(
   trace = NULL,
   parent = NULL,
   use_cli_format = NULL,
+  .inherit = TRUE,
   .internal = FALSE,
   .file = NULL,
   .frame = caller_env(),

--- a/man/cnd_inherits.Rd
+++ b/man/cnd_inherits.Rd
@@ -25,7 +25,7 @@ object is a particular kind of error or has been caused by such an
 error.
 
 Some chained conditions carry parents that are not inherited. See
-the \code{inherit} argument of \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, and \code{\link[=inform]{inform()}}.
+the \code{.inherit} argument of \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, and \code{\link[=inform]{inform()}}.
 }
 \section{Capture an error with \code{cnd_inherits()}}{
 Error catchers like \code{\link[=tryCatch]{tryCatch()}} and \code{\link[=try_fetch]{try_fetch()}} can only match

--- a/man/cnd_inherits.Rd
+++ b/man/cnd_inherits.Rd
@@ -23,6 +23,9 @@ Whereas \code{inherits()} tells you whether an object is a particular
 kind of error, \code{cnd_inherits()} answers the question whether an
 object is a particular kind of error or has been caused by such an
 error.
+
+Some chained conditions carry parents that are not inherited. See
+the \code{inherit} argument of \code{\link[=abort]{abort()}}, \code{\link[=warn]{warn()}}, and \code{\link[=inform]{inform()}}.
 }
 \section{Capture an error with \code{cnd_inherits()}}{
 Error catchers like \code{\link[=tryCatch]{tryCatch()}} and \code{\link[=try_fetch]{try_fetch()}} can only match
@@ -77,6 +80,19 @@ away. Instead, it captures it only if the handler doesn't return a
 class(cnd)
 #> [1] "rlang_error" "error"       "condition"
 class(cnd$parent)
+#> [1] "bar"         "rlang_error" "error"       "condition"
+}\if{html}{\out{</div>}}
+
+Note that \code{try_fetch()} uses \code{cnd_inherits()} internally. This
+makes it very easy to match a parent condition:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{cnd <- try_fetch(
+  f(),
+  bar = function(x) x
+)
+
+# This is the parent
+class(cnd)
 #> [1] "bar"         "rlang_error" "error"       "condition"
 }\if{html}{\out{</div>}}
 }

--- a/man/try_fetch.Rd
+++ b/man/try_fetch.Rd
@@ -67,7 +67,7 @@ that errors are matched across chains, see the \code{parent} argument of
 insensitive to changes of implementation or context of evaluation
 that cause a classed error to suddenly get chained to a contextual
 error. Note that some chained conditions are not inherited, see the
-\code{inherit} argument of \code{\link[=abort]{abort()}} or \code{\link[=warn]{warn()}}. In particular,
+\code{.inherit} argument of \code{\link[=abort]{abort()}} or \code{\link[=warn]{warn()}}. In particular,
 downgraded conditions (e.g. from error to warning or from warning
 to message) are not matched across parents.
 }

--- a/man/try_fetch.Rd
+++ b/man/try_fetch.Rd
@@ -66,8 +66,10 @@ that errors are matched across chains, see the \code{parent} argument of
 \code{\link[=abort]{abort()}}. This is a useful property that makes \code{try_fetch()}
 insensitive to changes of implementation or context of evaluation
 that cause a classed error to suddenly get chained to a contextual
-error. Note however that downgraded conditions (e.g. from error to
-warning or from warning to message) are not matched across parents.
+error. Note that some chained conditions are not inherited, see the
+\code{inherit} argument of \code{\link[=abort]{abort()}} or \code{\link[=warn]{warn()}}. In particular,
+downgraded conditions (e.g. from error to warning or from warning
+to message) are not matched across parents.
 }
 \section{Stack overflows}{
 

--- a/src/internal/cnd-handlers.c
+++ b/src/internal/cnd-handlers.c
@@ -53,7 +53,7 @@ r_obj* ffi_try_fetch(r_obj* try_fetch_args) {
     r_node_poke_car(subscript_node, r_int(i + 1));
 
     // Picks up `CLASS`
-    r_obj* class_node = r_node_cdr(r_node_cdar(r_node_cdar(r_node_cdar(r_node_cdar(r_node_cddr(r_node_cadr(r_node_cdar(r_node_cddr(hnd)))))))));
+    r_obj* class_node = r_node_cdr(r_node_cdar(r_node_cdar(r_node_cdar(r_node_cddr(r_node_cadr(r_node_cdar(r_node_cddr(hnd))))))));
     r_node_poke_car(class_node, r_str_as_character(cls));
 
     args = r_new_node3(hnd, args, r_syms.condition);

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -296,6 +296,7 @@ test_that("errors are saved by `entrace()`", {
   # Remove internal data stored by `last_error()`
   err <- last_error()
   err$rlang <- NULL
+  out$rlang <- NULL
 
   expect_equal(err, out)
 })

--- a/tests/testthat/test-cnd-handlers.R
+++ b/tests/testthat/test-cnd-handlers.R
@@ -200,3 +200,12 @@ test_that("try_fetch() matches upgraded conditions", {
   expect_s3_class(out, "warning")
   expect_equal(cnd_header(out), "Parent warning")
 })
+
+test_that("`inherit` is recursively checked", {
+  out <- try_fetch(
+    abort("foo", parent = error_cnd("qux"), .inherit = FALSE),
+    qux = function(cnd) "qux",
+    error = function(cnd) "error"
+  )
+  expect_equal(out, "error")
+})

--- a/tests/testthat/test-cnd-signal.R
+++ b/tests/testthat/test-cnd-signal.R
@@ -316,6 +316,26 @@ test_that("can reset verbosity", {
   )
 })
 
+test_that("downgraded conditions are not inherited (#1573)", {
+  cnd <- catch_cnd(warn("", parent = error_cnd()))
+  expect_false(cnd$rlang$inherit)
+
+  cnd <- catch_cnd(inform("", parent = error_cnd()))
+  expect_false(cnd$rlang$inherit)
+
+  cnd <- catch_cnd(inform("", parent = warning_cnd()))
+  expect_false(cnd$rlang$inherit)
+
+  cnd <- catch_cnd(warn("", parent = error_cnd(), .inherit = TRUE))
+  expect_true(cnd$rlang$inherit)
+
+  cnd <- catch_cnd(inform("", parent = error_cnd(), .inherit = TRUE))
+  expect_true(cnd$rlang$inherit)
+
+  cnd <- catch_cnd(inform("", parent = warning_cnd(), .inherit = TRUE))
+  expect_true(cnd$rlang$inherit)
+})
+
 
 # Lifecycle ----------------------------------------------------------
 

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -387,3 +387,18 @@ test_that("picks up caller frame", {
     quote(get_call(cnd2))
   )
 })
+
+test_that("cnd_inherits() checks `inherit` field (#1573)", {
+  cnd <- catch_cnd(warn("", parent = error_cnd()))
+  expect_false(cnd_inherits(cnd, "error"))
+  expect_true(cnd_inherits(cnd, "warning"))
+
+  cnd <- catch_cnd(warn("", parent = error_cnd(), .inherit = TRUE))
+  expect_true(cnd_inherits(cnd, "error"))
+
+  parent <- error_cnd(class = "parent")
+  cnd_default <- catch_cnd(abort("", parent = parent))
+  cnd_false <- catch_cnd(abort("", parent = parent, .inherit = FALSE))
+  expect_true(cnd_inherits(cnd_default, "parent"))
+  expect_false(cnd_inherits(cnd_false, "parent"))
+})


### PR DESCRIPTION
Follow up to #1573 (see discussion there).

New `.inherit = <bool>` argument. This controls whether `cnd_inherits()` and `try_fetch()` are allowed to match parent conditions. The default is `TRUE` in `abort()`. In `warn()` and `inform()`, the default is `TRUE` in the general case, and `FALSE` when `parent` is a condition of higher severity. This prevents matching downgraded conditions unexpectedly.

The parameter is stored in `cnd$rlang$inherit`. This is a public field (otherwise it'd be stored in `rlang$internal$`. It's namespaced to avoid name clashes with subclasses.

cc @DavisVaughan @gaborcsardi 