### PR TITLE
Pass `allow_na = FALSE`

### DIFF
--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -1,7 +1,7 @@
 # ---
 # repo: r-lib/rlang
 # file: standalone-types-check.R
-# last-updated: 2023-03-07
+# last-updated: 2023-03-13
 # license: https://unlicense.org
 # dependencies: standalone-obj-type.R
 # imports: rlang (>= 1.1.0)
@@ -289,6 +289,7 @@ check_symbol <- function(x,
     x,
     "a symbol",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -313,6 +314,7 @@ check_arg <- function(x,
     x,
     "an argument name",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -337,6 +339,7 @@ check_call <- function(x,
     x,
     "a defused call",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -361,6 +364,7 @@ check_environment <- function(x,
     x,
     "an environment",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -385,6 +389,7 @@ check_function <- function(x,
     x,
     "a function",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -409,6 +414,7 @@ check_closure <- function(x,
     x,
     "an R function",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -433,6 +439,7 @@ check_formula <- function(x,
     x,
     "a formula",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -460,6 +467,7 @@ check_character <- function(x,
     x,
     "a character vector",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call
@@ -484,6 +492,7 @@ check_logical <- function(x,
     x,
     "a logical vector",
     ...,
+    allow_na = FALSE,
     allow_null = allow_null,
     arg = arg,
     call = call

--- a/tests/testthat/_snaps/standalone-types-check.md
+++ b/tests/testthat/_snaps/standalone-types-check.md
@@ -334,17 +334,17 @@
       Error in `checker()`:
       ! `foo` must be a symbol, not `NULL`.
     Code
-      err(checker(TRUE, check_symbol, allow_na = TRUE))
+      err(checker(TRUE, check_symbol))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a symbol or `NA`, not `TRUE`.
+      ! `foo` must be a symbol, not `TRUE`.
     Code
-      err(checker(alist(foo, bar), check_symbol, allow_na = TRUE, allow_null = TRUE))
+      err(checker(alist(foo, bar), check_symbol, allow_null = TRUE))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a symbol, `NA`, or `NULL`, not a list.
+      ! `foo` must be a symbol or `NULL`, not a list.
     Code
       err(checker("foo", check_symbol))
     Output
@@ -373,17 +373,17 @@
       Error in `checker()`:
       ! `foo` must be a defused call, not `NULL`.
     Code
-      err(checker(TRUE, check_call, allow_na = TRUE))
+      err(checker(TRUE, check_call))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a defused call or `NA`, not `TRUE`.
+      ! `foo` must be a defused call, not `TRUE`.
     Code
-      err(checker(alist(foo(), bar()), check_call, allow_na = TRUE, allow_null = TRUE))
+      err(checker(alist(foo(), bar()), check_call, allow_null = TRUE))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a defused call, `NA`, or `NULL`, not a list.
+      ! `foo` must be a defused call or `NULL`, not a list.
     Code
       err(checker(quote(foo), check_call))
     Output
@@ -406,17 +406,17 @@
       Error in `checker()`:
       ! `foo` must be an environment, not `NULL`.
     Code
-      err(checker(FALSE, check_environment, allow_na = TRUE))
+      err(checker(FALSE, check_environment))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be an environment or `NA`, not `FALSE`.
+      ! `foo` must be an environment, not `FALSE`.
     Code
-      err(checker(list(env(), env()), check_environment, allow_na = TRUE, allow_null = TRUE))
+      err(checker(list(env(), env()), check_environment, allow_null = TRUE))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be an environment, `NA`, or `NULL`, not a list.
+      ! `foo` must be an environment or `NULL`, not a list.
 
 # `check_character()` checks
 
@@ -439,17 +439,17 @@
       Error in `checker()`:
       ! `foo` must be a character vector, not `NA`.
     Code
-      err(checker(1, check_character, allow_na = TRUE))
+      err(checker(1, check_character))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a character vector or `NA`, not the number 1.
+      ! `foo` must be a character vector, not the number 1.
     Code
-      err(checker(list("foo", "bar"), check_character, allow_na = TRUE, allow_null = TRUE))
+      err(checker(list("foo", "bar"), check_character, allow_null = TRUE))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a character vector, `NA`, or `NULL`, not a list.
+      ! `foo` must be a character vector or `NULL`, not a list.
 
 # `check_logical()` checks
 

--- a/tests/testthat/test-standalone-types-check.R
+++ b/tests/testthat/test-standalone-types-check.R
@@ -116,8 +116,8 @@ test_that("`check_symbol()` checks", {
   expect_snapshot({
     err(checker(, check_symbol))
     err(checker(NULL, check_symbol))
-    err(checker(TRUE, check_symbol, allow_na = TRUE))
-    err(checker(alist(foo, bar), check_symbol, allow_na = TRUE, allow_null = TRUE))
+    err(checker(TRUE, check_symbol))
+    err(checker(alist(foo, bar), check_symbol, allow_null = TRUE))
     err(checker("foo", check_symbol))
     err(checker(quote(foo()), check_symbol))
   })
@@ -130,8 +130,8 @@ test_that("`check_call()` checks", {
   expect_snapshot({
     err(checker(, check_call))
     err(checker(NULL, check_call))
-    err(checker(TRUE, check_call, allow_na = TRUE))
-    err(checker(alist(foo(), bar()), check_call, allow_na = TRUE, allow_null = TRUE))
+    err(checker(TRUE, check_call))
+    err(checker(alist(foo(), bar()), check_call, allow_null = TRUE))
     err(checker(quote(foo), check_call))
   })
 })
@@ -143,8 +143,8 @@ test_that("`check_environment()` checks", {
   expect_snapshot({
     err(checker(, check_environment))
     err(checker(NULL, check_environment))
-    err(checker(FALSE, check_environment, allow_na = TRUE))
-    err(checker(list(env(), env()), check_environment, allow_na = TRUE, allow_null = TRUE))
+    err(checker(FALSE, check_environment))
+    err(checker(list(env(), env()), check_environment, allow_null = TRUE))
   })
 })
 
@@ -160,8 +160,8 @@ test_that("`check_character()` checks", {
     err(checker(, check_character))
     err(checker(NULL, check_character))
     err(checker(NA, check_character))
-    err(checker(1, check_character, allow_na = TRUE))
-    err(checker(list("foo", "bar"), check_character, allow_na = TRUE, allow_null = TRUE))
+    err(checker(1, check_character))
+    err(checker(list("foo", "bar"), check_character, allow_null = TRUE))
   })
 })
 


### PR DESCRIPTION
I stumbled this when working on #1590. As they don't accept `NA` it makes sense to explicitly pass `allow_na = FALSE` so that you cannot pass it accidentally via the `...` arguments (this happened in the tests).
I thought this isn't worth a NEWS entry but if you want I can add one.