### PR TITLE
`check_number_*()` error messages

### DIFF
--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -10,8 +10,9 @@
 # ## Changelog
 #
 # 2023-03-13:
-# - Added `allow_infinite` argument to `check_number_whole()`.
-# - Added `check_data_frame()`.
+# - Improved error messages of number checkers (@teunbrand)
+# - Added `allow_infinite` argument to `check_number_whole()` (@mgirlich).
+# - Added `check_data_frame()` (@mgirlich).
 #
 # 2023-03-07:
 # - Added dependency on rlang (>= 1.1.0).
@@ -246,23 +247,25 @@ check_number_whole <- function(x,
                              allow_null,
                              arg,
                              call) {
+  if (allow_decimal) {
+    what <- "a number"
+  } else {
+    what <- "a whole number"
+  }
+
   if (exit_code == IS_NUMBER_oob) {
     min <- min %||% -Inf
     max <- max %||% Inf
 
     if (min > -Inf && max < Inf) {
-      what <- sprintf("a number between %s and %s", min, max)
+      what <- sprintf("%s between %s and %s", what, min, max)
     } else if (x < min) {
-      what <- sprintf("a number larger than %s", min)
+      what <- sprintf("%s larger than or equal to %s", what, min)
     } else if (x > max) {
-      what <- sprintf("a number smaller than %s", max)
+      what <- sprintf("%s smaller than or equal to %s", what, max)
     } else {
       abort("Unexpected state in OOB check", .internal = TRUE)
     }
-  } else if (allow_decimal) {
-    what <- "a number"
-  } else {
-    what <- "a whole number"
   }
 
   stop_input_type(

--- a/tests/testthat/_snaps/standalone-types-check.md
+++ b/tests/testthat/_snaps/standalone-types-check.md
@@ -212,19 +212,19 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a number smaller than 0, not the number 1.
+      ! `foo` must be a whole number smaller than or equal to 0, not the number 1.
     Code
       err(checker(-1, min = 0, check_number_whole))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a number larger than 0, not the number -1.
+      ! `foo` must be a whole number larger than or equal to 0, not the number -1.
     Code
       err(checker(10, min = 1, max = 5, check_number_whole))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must be a number between 1 and 5, not the number 10.
+      ! `foo` must be a whole number between 1 and 5, not the number 10.
     Code
       err(checker(10, min = NA, check_number_whole))
     Output


### PR DESCRIPTION
This PR aims to fix #1591.

Briefly, it does two things:
* Messages are about 'a whole number' if `allow_decimal = FALSE`, even when the number is OOB.
* The OOB check uses closed intervals, so for the upper and lower violation (not both), it now signals 'or equal to' as well.

If you'd like me to make an entry in the changelog or NEWS.md as well, please let me know.