### PR TITLE
Fix `rlang.hpp` on some platforms

### DIFF
--- a/src/rlang/rlang.hpp
+++ b/src/rlang/rlang.hpp
@@ -3,6 +3,9 @@
 
 #include <exception>
 
+#define R_NO_REMAP
+#include <Rinternals.h>
+
 extern "C" {
 #include <rlang.h>
 }


### PR DESCRIPTION
Combination of C linkage and `__cplusplus` causes:

```
  g++-8 -std=gnu++17 -I"/opt/R/devel/lib/R/include" -DNDEBUG -I./rlang  -I/usr/local/include    -fpic  -g -O2  -Wall -pedantic -c rlang-rcc.cpp -o rlang-rcc.o
  In file included from /opt/R/devel/lib/R/include/Rinternals.h:36,
                   from ./rlang/rlang.h:24,
                   from ./rlang/rlang.hpp:7,
                   from rlang/cpp/vec.cpp:1,
                   from rlang/cpp/rlang.cpp:1,
                   from rlang-rcc.cpp:1:
  /usr/include/c++/8/cstddef:68:3: error: template with C linkage
     template<typename _IntegerType> struct __byte_operand { };
     ^~~~~~~~
```