### PR TITLE
Switch from `proj_path()` to `proj_get()`

### DIFF
--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -23,7 +23,7 @@ use_rlang_c_library <- function() {
   rlang_lib_path <- fs::path(rlang_path, "src", "rlang")
   rlang_lib_include_path <- fs::path(rlang_path, "src", c("rlang.c", "rlang-rcc.cpp"))
 
-  proj_path <- usethis::proj_path()
+  proj_path <- usethis::proj_get()
   if (is_rlang_dir(proj_path)) {
     abort(c(
       "Can't update rlang from itself.",


### PR DESCRIPTION
`proj_path()` currently has a bug in dev usethis where calling it without any arguments returns `character()` rather than the project path, but I've also been told that `proj_get()` is a better way to do this anyways.

(I won't merge this until after rlang is accepted and you can bump the version)