### PR TITLE
Introduce `r_wrap_or_clone()` and `r_wrap_or_copy()`

### DIFF
--- a/src/internal/encoding.c
+++ b/src/internal/encoding.c
@@ -131,7 +131,7 @@ r_obj* obj_attrib_encode_utf8(r_obj* x, r_obj* attrib) {
   }
   KEEP(attrib_new);
 
-  x = KEEP(r_clone_shared(x));
+  x = KEEP(r_wrap_or_clone_shared(x));
   r_poke_attrib(x, attrib_new);
 
   FREE(2);

--- a/src/rlang/obj.h
+++ b/src/rlang/obj.h
@@ -81,6 +81,30 @@ r_obj* r_clone_shared(r_obj* x) {
   return r_is_shared(x) ? r_clone(x) : x;
 }
 
+// Copy/Clone equivalents that attempt to generate a thin ALTREP wrapper
+// instead of copying/cloning if possible. Typically useful before modifying
+// attributes, rather than before modifying the underlying data.
+static inline
+r_obj* r_wrap_or_copy(r_obj* x) {
+#if R_VERSION >= R_Version(3, 6, 0)
+  return R_duplicate_attr(x);
+#else
+  return r_copy(x);
+#endif
+}
+static inline
+r_obj* r_wrap_or_clone(r_obj* x) {
+#if R_VERSION >= R_Version(3, 6, 0)
+  return R_shallow_duplicate_attr(x);
+#else
+  return r_clone(x);
+#endif
+}
+static inline
+r_obj* r_wrap_or_clone_shared(r_obj* x) {
+  return r_is_shared(x) ? r_wrap_or_clone(x) : x;
+}
+
 // These also clone names
 r_obj* r_vec_clone(r_obj* x);
 r_obj* r_vec_clone_shared(r_obj* x);

--- a/tests/testthat/test-attr.R
+++ b/tests/testthat/test-attr.R
@@ -31,6 +31,7 @@ test_that("can supply function/formula to rename", {
   expect_named(set_names(x, toupper), c("A", "B"))
   expect_named(set_names(x, ~ toupper(.)), c("A", "B"))
   expect_named(set_names(x, paste, "foo"), c("a foo", "b foo"))
+  expect_named(set_names(x, ~ c(3, 4)), c("3", "4"))
 })
 
 test_that("set_names() zaps names", {

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -1284,6 +1284,24 @@ test_that("attributes are re-encoded recursively", {
   expect_utf8_encoded(attrib_nested$latin1)
 })
 
+test_that("re-encoding attributes doesn't modify the original attributes", {
+  latin1 <- test_encodings()$latin1
+
+  # Large object so duplication in `r_obj_encode_utf8()` generates an ALTREP
+  # wrapper
+  x <- 1:1e6 + 0L
+  attr(x, "foo") <- latin1
+  original <- Encoding(latin1)
+
+  result <- r_obj_encode_utf8(x)
+  attrib <- attributes(result)
+  expect_utf8_encoded(attrib$foo)
+
+  # Still the same as before
+  attrib <- attributes(x)
+  expect_identical(Encoding(attrib$foo), original)
+})
+
 test_that("NAs aren't re-encoded to 'NA' (r-lib/vctrs#1291)", {
   utf8 <- c(NA, test_encodings()$utf8)
   latin1 <- c(NA, test_encodings()$latin1)


### PR DESCRIPTION
These are aliases for `R_shallow_duplicate_attr()` and `R_duplicate_attr()` respectively

Added in 2018, with R 3.6.0, so we can use them without issues in all R versions we support except for 3.6, which we are dropping soon anyways 
https://github.com/wch/r-source/commit/bbcf6868752fcd5481e2379f93ccbe02911eea63

I've chosen these function names because they either "wrap" the object into an ALTREP wrapper if possible (i.e. if the type is supported and it is "large enough"), or they call their respective `r_clone/copy()` equivalents.

There are 2 places I use these helpers, shown below. They are only useful if you are tweaking attributes and not the main object. Otherwise you should just `r_clone()`.

---

We now use `r_wrap_or_clone_shared()` in the re-encoding helper. If we re-encode an attribute, but not the main object, then we can "wrap" the main object before re-assigning the attributes to it.

``` r
x <- 1:1e6 + 0L
attr(x, "foo") <- `Encoding<-`("fa\xE7ile", "latin1")

vctrs:::is_altrep(x)
#> [1] TRUE

bench::mark(encode = .Call(rlang:::ffi_test_obj_encode_utf8, x))

# Main
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 encode        356µs    606µs     1186.    3.81MB     149.

# This PR
#> # A tibble: 1 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 encode        1.1µs   1.53µs   499840.        0B        0


out <- .Call(rlang:::ffi_test_obj_encode_utf8, x)
vctrs:::is_altrep(out)

# Main
#> [1] FALSE

# This PR - now an altrep wrapper
#> [1] TRUE
```

---

We now also use `r_wrap_or_clone()` in `set_names()` to avoid having to call `names<-`, which is what we were doing before when I thought that was the only way to get access to the ALTREP wrappers. We now only call `names<-` if `x` is an "object" that might have an S3 method.

This gives us a little performance boost, but `names<-` was already very fast to call (typically in the 350ns range) so it doesn't look huge. It is relatively large percentage wise though, I guess.

I don't show any cases where `x` is an S3 object, that is typically in the 3.5us range because we have to do a `length()` dispatch call and a `names<-` dispatch call in case there is an S3 method registered, and those cases are completely separate from this PR. We could probably improve on this a little by actually checking to see if there is a `length()` or `names<-` method registered in the base/global env and only dispatching if we see one, but I didn't do that here.

``` r
library(rlang)

x <- 1:1e6 + 0L
names <- as.character(x)

# no names before, no names after
bench::mark(set_names(x, NULL), iterations = 1000000)
# before
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, NULL)   1.12µs   1.38µs   695965.    3.26KB     16.7

# after
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, NULL)    868ns   1.11µs   856415.     7.9KB     15.4

# no names before, names after
bench::mark(set_names(x, names), iterations = 1000000)

# before
#> # A tibble: 1 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, names)   1.51µs   1.81µs   527374.        0B     18.5

# after
#> # A tibble: 1 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, names)    1.2µs   1.52µs   636811.        0B     17.2

# this doesn't make an altrep wrapper, but `names<-` does
attr(x, "names") <- names

# names before, no names after
bench::mark(set_names(x, NULL), iterations = 1000000)

# before
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, NULL)   1.32µs   1.61µs   598498.        0B     19.8

# after
#> # A tibble: 1 × 6
#>   expression              min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>         <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, NULL)   1.03µs   1.34µs   720275.        0B     18.0

# names before, names after
bench::mark(set_names(x, names), iterations = 1000000)

# before
#> # A tibble: 1 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, names)   1.59µs   1.92µs   501267.        0B     17.5

# after
#> # A tibble: 1 × 6
#>   expression               min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>          <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 set_names(x, names)   1.33µs   1.65µs   584423.        0B     15.8
```

