### PR TITLE
Never keep sources in `parse_*()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* `parse_expr()` and `parse_exprs()` are now faster (#1603).
+
 # rlang 1.1.0
 
 ## Life cycle changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # rlang (development version)
 
-* `parse_expr()` and `parse_exprs()` are now faster (#1603).
+* `parse_expr()` and `parse_exprs()` are now faster when
+  `getOption("keep.source")` is `TRUE` (#1603).
 
 # rlang 1.1.0
 

--- a/man/parse_expr.Rd
+++ b/man/parse_expr.Rd
@@ -68,6 +68,10 @@ the latter is more convenient as you don't need to extract \code{expr}
 and \code{env}.
 }
 }
+\details{
+Unlike \code{\link[base:parse]{base::parse()}}, these functions never retain source reference
+information, as doing so is slow and rarely necessary.
+}
 \examples{
 # parse_expr() can parse any R expression:
 parse_expr("mtcars \%>\% dplyr::mutate(cyl_prime = cyl / sd(cyl))")


### PR DESCRIPTION
Closes #1603 

It turns out that in both rlang 1.0.6 and 1.1.0, source information was already being dropped in all cases (I wanted to ensure that removing usage of `flatten()` was not the result of this change, and it doesn't seem to be).

I think this makes sense as the source reference information is typically attached to the expression object, and:
- `parse_expr()` returns the individual expression element, not the expression vector
- `parse_exprs()` can parse and flatten _multiple_ expressions, and since each expression can return >1 element from `parse()`, you don't have a good 1:1 mapping between the source information and the flattened parsed expressions, so it makes sense to just drop the source information here too