### PR TITLE
Respect `show.error.messages` in `abort()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `abort()` now respects the base R global option,
+  `options(show.error.messages = FALSE)` (#1630).
+
 * `obj_type_friendly()` now only displays the first class of S3 objects (#1622).
 
 # rlang 1.1.1

--- a/tests/testthat/_snaps/cnd-abort.md
+++ b/tests/testthat/_snaps/cnd-abort.md
@@ -1841,3 +1841,19 @@
       foo
       bar
 
+# `show.error.messages` is respected by `abort()` (#1630)
+
+    Code
+      cat_line(with_messages)
+    Output
+      Error:
+      ! Oh no
+      Backtrace:
+          x
+       1. \-rlang::abort("Oh no")
+      Execution halted
+    Code
+      cat_line(without_messages)
+    Output
+      Execution halted
+

--- a/tests/testthat/fixtures/error-show-messages.R
+++ b/tests/testthat/fixtures/error-show-messages.R
@@ -1,0 +1,11 @@
+options(
+  crayon.enabled = FALSE,
+  cli.unicode = FALSE
+)
+
+opt <- Sys.getenv("show_error_messages")
+if (nzchar(opt)) {
+  options(show.error.messages = as.logical(opt))
+}
+
+rlang::abort("Oh no")

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -881,3 +881,17 @@ test_that("newlines are preserved by cli (#1535)", {
     abort("foo\fbar", use_cli_format = TRUE)
   })
 })
+
+test_that("`show.error.messages` is respected by `abort()` (#1630)", {
+  run_error_script <- function(envvars = chr()) {
+    run_script(test_path("fixtures", "error-show-messages.R"), envvars = envvars)
+  }
+
+  with_messages <- run_error_script(envvars = c("show_error_messages=TRUE"))
+  without_messages <- run_error_script(envvars = c("show_error_messages=FALSE"))
+
+  expect_snapshot({
+    cat_line(with_messages)
+    cat_line(without_messages)
+  })
+})


### PR DESCRIPTION
Closes #1630 

Test generation is a little tricky, but I followed some other existing examples