### PR TITLE
Fix off by one typo in source column location

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* Fixed an off-by-one typo in the traceback source column location (#1633).
+
 * `abort()` now respects the base R global option,
   `options(show.error.messages = FALSE)` (#1630).
 

--- a/R/trace.R
+++ b/R/trace.R
@@ -859,7 +859,7 @@ src_loc <- function(srcref) {
   }
 
   line <- srcref[[1]]
-  column <- srcref[[5]] - 1L
+  column <- srcref[[5]]
 
   style_hyperlink(
     paste0(file_trim, ":", line, ":", column),

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -124,7 +124,7 @@
       (expect_error(f()))
     Output
       <error/rlang_error>
-      Error in `g()` at bar/baz/myfile.R:2:9:
+      Error in `g()` at bar/baz/myfile.R:2:10:
       ! Foo.
 
 # inform() and warn() use fallback bullets formatting

--- a/tests/testthat/_snaps/trace.md
+++ b/tests/testthat/_snaps/trace.md
@@ -4,10 +4,10 @@
       print(trace, dir = dir)
     Output
           x
-       1. \-rlang (local) i() at test-trace.R:25:2
-       2.   \-rlang (local) j(i) at test-trace.R:18:7
-       3.     \-rlang (local) k(i) at test-trace.R:19:21
-       4.       \-rlang (local) l(i) at test-trace.R:22:4
+       1. \-rlang (local) i() at test-trace.R:25:3
+       2.   \-rlang (local) j(i) at test-trace.R:18:8
+       3.     \-rlang (local) k(i) at test-trace.R:19:22
+       4.       \-rlang (local) l(i) at test-trace.R:22:5
     Code
       cat("\n")
     Output
@@ -25,8 +25,8 @@
     Output
            x
         1. \-rlang (local) f()
-        2.   \-rlang (local) g() at test-trace.R:49:20
-        3.     +-base::tryCatch(h(), foo = identity, bar = identity) at test-trace.R:50:20
+        2.   \-rlang (local) g() at test-trace.R:49:21
+        3.     +-base::tryCatch(h(), foo = identity, bar = identity) at test-trace.R:50:21
         4.     | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
         5.     |   +-base (local) tryCatchOne(...)
         6.     |   | \-base (local) doTryCatch(return(expr), name, parentenv, handler)
@@ -34,12 +34,12 @@
         8.     |     \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
         9.     |       \-base (local) doTryCatch(return(expr), name, parentenv, handler)
        10.     \-rlang (local) h()
-       11.       +-base::tryCatch(i(), baz = identity) at test-trace.R:51:20
+       11.       +-base::tryCatch(i(), baz = identity) at test-trace.R:51:21
        12.       | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
        13.       |   \-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
        14.       |     \-base (local) doTryCatch(return(expr), name, parentenv, handler)
        15.       \-rlang (local) i()
-       16.         +-base::tryCatch(trace_back(e, bottom = 0)) at test-trace.R:52:20
+       16.         +-base::tryCatch(trace_back(e, bottom = 0)) at test-trace.R:52:21
        17.         | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
        18.         \-rlang::trace_back(e, bottom = 0)
     Code
@@ -48,8 +48,8 @@
     Output
            x
         1. \-rlang (local) f()
-        2.   \-rlang (local) g() at test-trace.R:49:20
-        3.     +<<-base::tryCatch(h(), foo = identity, bar = identity) at test-trace.R:50:20>>
+        2.   \-rlang (local) g() at test-trace.R:49:21
+        3.     +<<-base::tryCatch(h(), foo = identity, bar = identity) at test-trace.R:50:21>>
         4.     | <<\-base (local) tryCatchList(expr, classes, parentenv, handlers)>>
         5.     |   <<+-base (local) tryCatchOne(...)>>
         6.     |   <<| \-base (local) doTryCatch(return(expr), name, parentenv, handler)>>
@@ -57,7 +57,7 @@
         8.     |     <<\-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])>>
         9.     |       <<\-base (local) doTryCatch(return(expr), name, parentenv, handler)>>
        10.     \-rlang (local) h()
-       11.       +<<-base::tryCatch(i(), baz = identity) at test-trace.R:51:20>>
+       11.       +<<-base::tryCatch(i(), baz = identity) at test-trace.R:51:21>>
        12.       | <<\-base (local) tryCatchList(expr, classes, parentenv, handlers)>>
        13.       |   <<\-base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])>>
        14.       |     <<\-base (local) doTryCatch(return(expr), name, parentenv, handler)>>
@@ -68,7 +68,7 @@
     Output
         1. rlang (local) f()
         2. rlang (local) g()
-             at test-trace.R:49:20
+             at test-trace.R:49:21
        10. rlang (local) h()
        15. rlang (local) i()
 
@@ -80,12 +80,12 @@
     Output
            x
         1. \-rlang (local) f()
-        2.   +-base::eval(quote(eval(quote(g())))) at test-trace.R:61:7
+        2.   +-base::eval(quote(eval(quote(g())))) at test-trace.R:61:8
         3.   | \-base::eval(quote(eval(quote(g()))))
         4.   +-base::eval(quote(g()))
         5.   | \-base::eval(quote(g()))
         6.   \-rlang (local) g()
-        7.     +-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) at test-trace.R:62:7
+        7.     +-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) at test-trace.R:62:8
         8.     | \-base (local) tryCatchList(expr, classes, parentenv, handlers)
         9.     |   +-base (local) tryCatchOne(...)
        10.     |   | \-base (local) doTryCatch(return(expr), name, parentenv, handler)
@@ -101,12 +101,12 @@
     Output
            x
         1. \-rlang (local) f()
-        2.   +<<-base::eval(quote(eval(quote(g())))) at test-trace.R:61:7>>
+        2.   +<<-base::eval(quote(eval(quote(g())))) at test-trace.R:61:8>>
         3.   | <<\-base::eval(quote(eval(quote(g()))))>>
         4.   +<<-base::eval(quote(g()))>>
         5.   | <<\-base::eval(quote(g()))>>
         6.   \-rlang (local) g()
-        7.     +<<-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) at test-trace.R:62:7>>
+        7.     +<<-base::tryCatch(eval(quote(h())), foo = identity, bar = identity) at test-trace.R:62:8>>
         8.     | <<\-base (local) tryCatchList(expr, classes, parentenv, handlers)>>
         9.     |   <<+-base (local) tryCatchOne(...)>>
        10.     |   <<| \-base (local) doTryCatch(return(expr), name, parentenv, handler)>>
@@ -739,21 +739,21 @@
     Output
           x
        1. \-rlang (local) f(current_env())
-       2.   \-rlang (local) g(e) at fixtures/trace-srcref2.R:2:2
+       2.   \-rlang (local) g(e) at fixtures/trace-srcref2.R:2:3
     Code
       # Focused
       print_focused_trace(trace, dir = dir, srcrefs = srcrefs)
     Output
           x
        1. \-rlang (local) f(current_env())
-       2.   \-rlang (local) g(e) at fixtures/trace-srcref2.R:2:2
+       2.   \-rlang (local) g(e) at fixtures/trace-srcref2.R:2:3
     Code
       # Branch
       print(trace, simplify = "branch", dir = dir, srcrefs = srcrefs)
     Output
        1. rlang (local) f(current_env())
        2. rlang (local) g(e)
-            at fixtures/trace-srcref2.R:2:2
+            at fixtures/trace-srcref2.R:2:3
 
 # summary.rlang_trace() prints the full tree
 
@@ -822,14 +822,14 @@
       summary(trace0)
     Output
            x
-        1. \-rlang (local) f(0) at test-trace.R:412:2
-        2.   +-base::identity(identity(g(n))) at test-trace.R:408:7
+        1. \-rlang (local) f(0) at test-trace.R:412:3
+        2.   +-base::identity(identity(g(n))) at test-trace.R:408:8
         3.   +-base::identity(g(n))
         4.   \-rlang (local) g(n)
-        5.     +-base::identity(identity(h(n))) at test-trace.R:409:7
+        5.     +-base::identity(identity(h(n))) at test-trace.R:409:8
         6.     +-base::identity(h(n))
         7.     \-rlang (local) h(n)
-        8.       +-base::identity(identity(trace_back(e, bottom = n))) at test-trace.R:410:7
+        8.       +-base::identity(identity(trace_back(e, bottom = n))) at test-trace.R:410:8
         9.       +-base::identity(trace_back(e, bottom = n))
        10.       \-rlang::trace_back(e, bottom = n)
     Code
@@ -842,11 +842,11 @@
       summary(trace1)
     Output
           x
-       1. \-rlang (local) f(1) at test-trace.R:413:2
-       2.   +-base::identity(identity(g(n))) at test-trace.R:408:7
+       1. \-rlang (local) f(1) at test-trace.R:413:3
+       2.   +-base::identity(identity(g(n))) at test-trace.R:408:8
        3.   +-base::identity(g(n))
        4.   \-rlang (local) g(n)
-       5.     +-base::identity(identity(h(n))) at test-trace.R:409:7
+       5.     +-base::identity(identity(h(n))) at test-trace.R:409:8
        6.     +-base::identity(h(n))
        7.     \-rlang (local) h(n)
     Code
@@ -859,8 +859,8 @@
       summary(trace2)
     Output
           x
-       1. \-rlang (local) f(2) at test-trace.R:414:2
-       2.   +-base::identity(identity(g(n))) at test-trace.R:408:7
+       1. \-rlang (local) f(2) at test-trace.R:414:3
+       2.   +-base::identity(identity(g(n))) at test-trace.R:408:8
        3.   +-base::identity(g(n))
        4.   \-rlang (local) g(n)
     Code
@@ -873,7 +873,7 @@
       summary(trace3)
     Output
           x
-       1. \-rlang (local) f(3) at test-trace.R:415:2
+       1. \-rlang (local) f(3) at test-trace.R:415:3
 
 # caught error does not display backtrace in knitted files
 


### PR DESCRIPTION
Seems like it was introduced here, but I could not discern a reason why
https://github.com/r-lib/rlang/pull/511/files#diff-b0faac068b86ed24d71c6942ed58a7e28675e4acb353e36b4b7d323c5862bb54R179

https://github.com/r-lib/rlang/assets/19150088/f2e94ab3-8d47-4bf9-9e5a-590a3de0c981

