### PR TITLE
Add argument `args` to `check_function()`

### DIFF
--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -9,6 +9,10 @@
 #
 # ## Changelog
 #
+# 2023-08-31:
+# - `check_functions()` gains the argument `args` to specify which arguments the
+#   function should have (@mgirlich).
+#
 # 2023-03-13:
 # - Improved error messages of number checkers (@teunbrand)
 # - Added `allow_infinite` argument to `check_number_whole()` (@mgirlich).
@@ -381,11 +385,19 @@ check_environment <- function(x,
 
 check_function <- function(x,
                            ...,
+                           args = NULL,
                            allow_null = FALSE,
                            arg = caller_arg(x),
                            call = caller_env()) {
   if (!missing(x)) {
     if (is_function(x)) {
+      .check_function_args(
+        f = x,
+        expected_args = args,
+        arg = arg,
+        call = call
+      )
+
       return(invisible(NULL))
     }
     if (allow_null && is_null(x)) {
@@ -402,6 +414,48 @@ check_function <- function(x,
     arg = arg,
     call = call
   )
+}
+
+.check_function_args <- function(f,
+                                 expected_args,
+                                 arg,
+                                 call) {
+  if (is_null(expected_args)) {
+    return(invisible(NULL))
+  }
+
+  actual_args <- fn_fmls_names(f) %||% character()
+  if (identical(actual_args, expected_args)) {
+    return(invisible(NULL))
+  }
+
+  n_expected_args <- length(expected_args)
+  n_actual_args <- length(actual_args)
+
+  if (n_expected_args == 0) {
+    message <- sprintf(
+      "%s must have no arguments, not %i %s.",
+      format_arg(arg),
+      length(actual_args),
+      pluralise(n_actual_args, "argument", "arguments")
+    )
+    abort(message, call = call, arg = arg)
+  }
+
+  if (n_actual_args == 0) {
+    arg_info <- "instead of no arguments"
+  } else {
+    arg_info <- paste0("not ", format_arg(actual_args))
+  }
+
+  message <- sprintf(
+    "%s must have the %s %s, %s.",
+    format_arg(arg),
+    pluralise(n_expected_args, "argument", "arguments"),
+    format_arg(expected_args),
+    arg_info
+  )
+  abort(message, call = call, arg = arg)
 }
 
 check_closure <- function(x,

--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -3,7 +3,7 @@
 # file: standalone-types-check.R
 # last-updated: 2023-03-13
 # license: https://unlicense.org
-# dependencies: standalone-obj-type.R
+# dependencies: [standalone-obj-type.R, standalone-cli.R]
 # imports: rlang (>= 1.1.0)
 # ---
 #

--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -429,42 +429,33 @@ check_function <- function(x,
 
   if (is.numeric(expected_args)) {
     n_expected_args <- expected_args
-    if (identical(n_expected_args, n_actual_args)) {
+    if (n_actual_args >= n_expected_args) {
       return(invisible(NULL))
     }
 
     message <- sprintf(
-      "%s must have %i %s, not %i %s.",
+      "%s must have at least %i %s, not %i %s.",
       format_arg(arg),
       n_expected_args,
-      pluralise(n_actual_args, "argument", "arguments"),
+      pluralise(n_expected_args, "argument", "arguments"),
       n_actual_args,
       pluralise(n_actual_args, "argument", "arguments")
     )
     abort(message, call = call, arg = arg)
   }
 
-  if (identical(actual_args, expected_args)) {
+  missing_args <- setdiff(expected_args, actual_args)
+  if (is_empty(missing_args)) {
     return(invisible(NULL))
   }
 
-  n_expected_args <- length(expected_args)
-  if (n_expected_args == 0) {
-    message <- sprintf(
-      "%s must have no arguments, not %i %s.",
-      format_arg(arg),
-      n_actual_args,
-      pluralise(n_actual_args, "argument", "arguments")
-    )
-    abort(message, call = call, arg = arg)
-  }
-
   if (n_actual_args == 0) {
-    arg_info <- "instead of no arguments"
+    arg_info <- "instead it has no arguments"
   } else {
-    arg_info <- paste0("not ", format_arg(actual_args))
+    arg_info <- paste0("instead it has ", format_arg(actual_args))
   }
 
+  n_expected_args <- length(expected_args)
   message <- sprintf(
     "%s must have the %s %s, %s.",
     format_arg(arg),

--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -425,18 +425,35 @@ check_function <- function(x,
   }
 
   actual_args <- fn_fmls_names(f) %||% character()
+  n_actual_args <- length(actual_args)
+
+  if (is.numeric(expected_args)) {
+    n_expected_args <- expected_args
+    if (identical(n_expected_args, n_actual_args)) {
+      return(invisible(NULL))
+    }
+
+    message <- sprintf(
+      "%s must have %i %s, not %i %s.",
+      format_arg(arg),
+      n_expected_args,
+      pluralise(n_actual_args, "argument", "arguments"),
+      n_actual_args,
+      pluralise(n_actual_args, "argument", "arguments")
+    )
+    abort(message, call = call, arg = arg)
+  }
+
   if (identical(actual_args, expected_args)) {
     return(invisible(NULL))
   }
 
   n_expected_args <- length(expected_args)
-  n_actual_args <- length(actual_args)
-
   if (n_expected_args == 0) {
     message <- sprintf(
       "%s must have no arguments, not %i %s.",
       format_arg(arg),
-      length(actual_args),
+      n_actual_args,
       pluralise(n_actual_args, "argument", "arguments")
     )
     abort(message, call = call, arg = arg)

--- a/tests/testthat/_snaps/standalone-types-check.md
+++ b/tests/testthat/_snaps/standalone-types-check.md
@@ -427,6 +427,33 @@
 ---
 
     Code
+      err(checker(function(x) x, args = 0L, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have 0 argument, not 1 argument.
+    Code
+      err(checker(function(x, y) x, args = 0L, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have 0 arguments, not 2 arguments.
+    Code
+      err(checker(function() x, args = 2, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have 2 arguments, not 0 arguments.
+    Code
+      err(checker(function(x, y, z) x, args = 2, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have 2 arguments, not 3 arguments.
+
+---
+
+    Code
       err(checker(function(x) x, args = character(), check_function))
     Output
       <error/rlang_error>

--- a/tests/testthat/_snaps/standalone-types-check.md
+++ b/tests/testthat/_snaps/standalone-types-check.md
@@ -427,62 +427,32 @@
 ---
 
     Code
-      err(checker(function(x) x, args = 0L, check_function))
-    Output
-      <error/rlang_error>
-      Error in `checker()`:
-      ! `foo` must have 0 argument, not 1 argument.
-    Code
-      err(checker(function(x, y) x, args = 0L, check_function))
-    Output
-      <error/rlang_error>
-      Error in `checker()`:
-      ! `foo` must have 0 arguments, not 2 arguments.
-    Code
       err(checker(function() x, args = 2, check_function))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must have 2 arguments, not 0 arguments.
-    Code
-      err(checker(function(x, y, z) x, args = 2, check_function))
-    Output
-      <error/rlang_error>
-      Error in `checker()`:
-      ! `foo` must have 2 arguments, not 3 arguments.
+      ! `foo` must have at least 2 arguments, not 0 arguments.
 
 ---
 
-    Code
-      err(checker(function(x) x, args = character(), check_function))
-    Output
-      <error/rlang_error>
-      Error in `checker()`:
-      ! `foo` must have no arguments, not 1 argument.
-    Code
-      err(checker(function(x, y) x, args = character(), check_function))
-    Output
-      <error/rlang_error>
-      Error in `checker()`:
-      ! `foo` must have no arguments, not 2 arguments.
     Code
       err(checker(function() x, args = "x", check_function))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must have the argument `x`, instead of no arguments.
+      ! `foo` must have the argument `x`, instead it has no arguments.
     Code
       err(checker(function(y) x, args = "x", check_function))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must have the argument `x`, not `y`.
+      ! `foo` must have the argument `x`, instead it has `y`.
     Code
-      err(checker(function(y, x) x, args = c("x", "y"), check_function))
+      err(checker(function(y, z) x, args = "x", check_function))
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `foo` must have the arguments `x` and `y`, not `y` and `x`.
+      ! `foo` must have the argument `x`, instead it has `y` and `z`.
 
 # `check_environment()` checks
 

--- a/tests/testthat/_snaps/standalone-types-check.md
+++ b/tests/testthat/_snaps/standalone-types-check.md
@@ -391,6 +391,72 @@
       Error in `checker()`:
       ! `foo` must be a defused call, not a symbol.
 
+# `check_function()` checks
+
+    Code
+      err(checker(, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a function, not absent.
+    Code
+      err(checker(NULL, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a function, not `NULL`.
+    Code
+      err(checker(TRUE, check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a function, not `TRUE`.
+    Code
+      err(checker(alist(foo(), bar()), check_function, allow_null = TRUE))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a function or `NULL`, not a list.
+    Code
+      err(checker(quote(foo), check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must be a function, not a symbol.
+
+---
+
+    Code
+      err(checker(function(x) x, args = character(), check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have no arguments, not 1 argument.
+    Code
+      err(checker(function(x, y) x, args = character(), check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have no arguments, not 2 arguments.
+    Code
+      err(checker(function() x, args = "x", check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have the argument `x`, instead of no arguments.
+    Code
+      err(checker(function(y) x, args = "x", check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have the argument `x`, not `y`.
+    Code
+      err(checker(function(y, x) x, args = c("x", "y"), check_function))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `foo` must have the arguments `x` and `y`, not `y` and `x`.
+
 # `check_environment()` checks
 
     Code

--- a/tests/testthat/test-standalone-types-check.R
+++ b/tests/testthat/test-standalone-types-check.R
@@ -138,6 +138,34 @@ test_that("`check_call()` checks", {
   })
 })
 
+test_that("`check_function()` checks", {
+  expect_null(check_function(function(x) x))
+  expect_null(check_function(NULL, allow_null = TRUE))
+
+  expect_snapshot({
+    err(checker(, check_function))
+    err(checker(NULL, check_function))
+    err(checker(TRUE, check_function))
+    err(checker(alist(foo(), bar()), check_function, allow_null = TRUE))
+    err(checker(quote(foo), check_function))
+  })
+
+  expect_null(check_function(function() x, args = character()))
+  expect_null(check_function(function(x) x, args = "x"))
+  expect_null(check_function(function(x, y) x, args = c("x", "y")))
+
+  expect_snapshot({
+    # should have no arguments
+    err(checker(function(x) x, args = character(), check_function))
+    err(checker(function(x, y) x, args = character(), check_function))
+
+    # should have arguments
+    err(checker(function() x, args = "x", check_function))
+    err(checker(function(y) x, args = "x", check_function))
+    err(checker(function(y, x) x, args = c("x", "y"), check_function))
+  })
+})
+
 test_that("`check_environment()` checks", {
   expect_null(check_environment(env()))
   expect_null(check_environment(NULL, allow_null = TRUE))

--- a/tests/testthat/test-standalone-types-check.R
+++ b/tests/testthat/test-standalone-types-check.R
@@ -150,32 +150,27 @@ test_that("`check_function()` checks", {
     err(checker(quote(foo), check_function))
   })
 
-  expect_null(check_function(function() x, args = 0L))
-  expect_null(check_function(function(x, y) x, args = 2L))
+  # numeric `args`
+  expect_null(check_function(function() x, args = 0))
+  expect_null(check_function(function(x) x, args = 0))
+  # can also have more arguments
+  expect_null(check_function(function(x, y, z) x, args = 2))
 
+  # must not have too few arguments
   expect_snapshot({
-    # should have no arguments
-    err(checker(function(x) x, args = 0L, check_function))
-    err(checker(function(x, y) x, args = 0L, check_function))
-
-    # should have arguments
     err(checker(function() x, args = 2, check_function))
-    err(checker(function(x, y, z) x, args = 2, check_function))
   })
 
+  # character `args`
   expect_null(check_function(function() x, args = character()))
   expect_null(check_function(function(x) x, args = "x"))
-  expect_null(check_function(function(x, y) x, args = c("x", "y")))
+  expect_null(check_function(function(x, y, z) x, args = c("x", "y")))
 
+  # arguments missing
   expect_snapshot({
-    # should have no arguments
-    err(checker(function(x) x, args = character(), check_function))
-    err(checker(function(x, y) x, args = character(), check_function))
-
-    # should have arguments
     err(checker(function() x, args = "x", check_function))
     err(checker(function(y) x, args = "x", check_function))
-    err(checker(function(y, x) x, args = c("x", "y"), check_function))
+    err(checker(function(y, z) x, args = "x", check_function))
   })
 })
 

--- a/tests/testthat/test-standalone-types-check.R
+++ b/tests/testthat/test-standalone-types-check.R
@@ -150,6 +150,19 @@ test_that("`check_function()` checks", {
     err(checker(quote(foo), check_function))
   })
 
+  expect_null(check_function(function() x, args = 0L))
+  expect_null(check_function(function(x, y) x, args = 2L))
+
+  expect_snapshot({
+    # should have no arguments
+    err(checker(function(x) x, args = 0L, check_function))
+    err(checker(function(x, y) x, args = 0L, check_function))
+
+    # should have arguments
+    err(checker(function() x, args = 2, check_function))
+    err(checker(function(x, y, z) x, args = 2, check_function))
+  })
+
   expect_null(check_function(function() x, args = character()))
   expect_null(check_function(function(x) x, args = "x"))
   expect_null(check_function(function(x, y) x, args = c("x", "y")))


### PR DESCRIPTION
When taking a function as an argument the number or the name of the arguments are usually also important (e.g. see https://github.com/r-lib/httr2/pull/279 where this is useful).

This uses `format_arg()` from the `standalone-cli.R` file. Not sure if you want to add the dependency on this file as well or prefer a workaround.