### PR TITLE
Closes #1655 add back-compatibility to `expr_label()` for incoming `is.atomic(NULL)` change in R version 4.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * `obj_type_friendly()` now only displays the first class of S3 objects (#1622).
 
+* `expr_label()` now has back-compatility with respect to changes made by R version 4.4 and `is.atomic(NULL)` (#1655)
+
 # rlang 1.1.1
 
 * `englue()` now allows omitting `{{`. This is to make it easier to

--- a/R/expr.R
+++ b/R/expr.R
@@ -185,7 +185,7 @@ is_symbolic <- function(x) {
 expr_label <- function(expr) {
   if (is.character(expr)) {
     encodeString(expr, quote = '"')
-  } else if (is.atomic(expr)) {
+  } else if (is.null(expr) || is.atomic(expr)) {
     format(expr)
   } else if (is.name(expr)) {
     paste0("`", as.character(expr), "`")

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -42,6 +42,9 @@ test_that("expr_label() truncates long calls", {
   expect_identical(expr_label(long_call), "`foo(...)`")
 })
 
+test_that("expr_label() NULL values come out as expected", {
+  expect_identical(expr_label(NULL), "NULL")
+})
 
 # expr_name() --------------------------------------------------------
 


### PR DESCRIPTION
Closes https://github.com/r-lib/rlang/issues/1655

Copy of issue below:

One of the main "significant user-visible changes" for the upcoming R release, v4.4, is that:

- `is.atomic(NULL)` now returns `FALSE`, as `NULL` is not an atomic vector. Strict back compatibility would replace `is.atomic(foo)` by `(is.null(foo) || is.atomic(foo))` but should happen sparingly only.


`expr_label(NULL)` under R <4.4 would return "NULL"
`expr_label(NULL)` under R  4.4 would return "\`NULL\`"

Although `expr_label()` is already under lifecycle label questioning, this may have _minor_ unintended consequences

```
expr_label <- function(expr) {
  if (is.character(expr)) {
    encodeString(expr, quote = '"')
  } else if (is.atomic(expr)) { # should this be replaced with (is.null(expr) || is.atomic(expr))  ?
    format(expr)
  } else if (is.name(expr)) {
    paste0("`", as.character(expr), "`")
  } else {
    chr <- deparse_one(expr)
    paste0("`", chr, "`")
  }
}
```