### PR TITLE
speed up package version check in `.rlang_cli_compat()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * `expr_label()` now has back-compatility with respect to changes made by R version 4.4 and `is.atomic(NULL)` (#1655)
 
+* Performance improvement in `.rlang_cli_compat()` (#1657).
+
 # rlang 1.1.1
 
 * `englue()` now allows omitting `{{`. This is to make it easier to

--- a/R/standalone-cli.R
+++ b/R/standalone-cli.R
@@ -1,7 +1,7 @@
 # ---
 # repo: r-lib/rlang
 # file: standalone-cli.R
-# last-updated: 2022-09-23
+# last-updated: 2023-10-06
 # license: https://unlicense.org
 # ---
 #
@@ -10,6 +10,10 @@
 # used to format the elements. Otherwise a fallback format is used.
 #
 # ## Changelog
+#
+# 2023-10-06:
+#
+# * Speedup in `.rlang_cli_compat()`.
 #
 # 2022-09-23:
 #
@@ -451,8 +455,12 @@ cli_escape <- function(x) {
       is_interactive = return(rlang::is_interactive)
     )
 
-    # Make sure rlang knows about "x" and "i" bullets
-    if (utils::packageVersion("rlang") >= "0.4.2") {
+    ns <- asNamespace("rlang")
+
+    # Make sure rlang knows about "x" and "i" bullets.
+    # Pull from namespace rather than via `utils::packageVersion()`
+    # to avoid slowdown (#1657)
+    if (ns[[".__NAMESPACE__."]][["spec"]][["version"]] >= "0.4.2") {
       switch(
         fn,
         abort = return(rlang::abort),


### PR DESCRIPTION
I recently came across a slowdown when profiling some tidymodels code that I thought might be worth raising. The `utils::packageVersion("rlang") >= "0.4.2"` check in `standalone-cli.R` adds up for us downstream.

With rlang 1.1.1:

``` r
bench::mark(
  signal = rlang::signal(class = "boop"),
  group_by = dplyr::group_by(mtcars, cyl),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 signal        276µs    288µs     3393.  296.68KB     16.8
#> 2 group_by      860µs    900µs     1080.    3.49MB     16.8
```

With this PR:

``` r
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 signal       46.1µs   47.8µs    20399.  294.26KB     32.0
#> 2 group_by    572.5µs  604.7µs     1603.    3.48MB     23.2
```

I believe this should be compatible with the "standalone" approach but feels a bit more hacky than I'd usually be comfortable submitting. Very much open to iterate. :)