### PR TITLE
Use modern `x-r-run` convention

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* `last_trace()` hyperlinks now use the modern `x-r-run` format (#1678).
+
+
 # rlang 1.1.3
 
 * Fix for CRAN checks.

--- a/R/utils.R
+++ b/R/utils.R
@@ -336,7 +336,7 @@ cli_with_whiteline_escapes <- function(x, fn) {
 style_rlang_run <- function(code) {
   style_hyperlink(
     paste0("rlang::", code),
-    paste0("rstudio:run:rlang::", code)
+    paste0("x-r-run:rlang::", code)
   )
 }
 


### PR DESCRIPTION
Introduced in https://github.com/rstudio/rstudio/pull/12096

I think this has been out long enough that it would be ok to move to it unconditionally? I'm not sure if a release version of RStudio without `x-r-run` support was ever released, if so it would have been released between June->Oct of 2022 (based on looking at commit history), so that's a 4 month window where an RStudio release may have come out without support for `x-r-run`.

In the worst case where it isn't supported, it just means the `last_trace()` hyperlinks won't work until they upgrade RStudio I guess (that seems to be all it is used for)