### PR TITLE
Remove circular stack.Rd `@seealso`

### DIFF
--- a/R/stack.R
+++ b/R/stack.R
@@ -21,7 +21,6 @@
 #'   as returned by [caller_env()]. `NULL` is returned if the
 #'   environment does not exist on the stack.
 #'
-#' @seealso [caller_env()] and [current_env()]
 #' @name stack
 NULL
 

--- a/man/stack.Rd
+++ b/man/stack.Rd
@@ -53,6 +53,3 @@ running in the frame was invoked.
 running in the frame.
 }
 }
-\seealso{
-\code{\link[=caller_env]{caller_env()}} and \code{\link[=current_env]{current_env()}}
-}


### PR DESCRIPTION
This `@seealso` refers to itself since #1343.