### PR TITLE
Document `caller_arg()` limitation in `print()`

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -1089,6 +1089,11 @@ NULL
 #' - Use `@inheritParams rlang::args_error_context` to document an
 #'   `arg` or `error_arg` argument that takes `error_arg()` as default.
 #'
+#' @section Use in `print()`:
+#' Note that `caller_arg()` will not work properly when redefining the
+#' `print()` method, as the name of the object is not in the callstack.
+#'
+#'
 #' @param arg An argument name in the current function.
 #' @usage NULL
 #'

--- a/man/caller_arg.Rd
+++ b/man/caller_arg.Rd
@@ -19,6 +19,12 @@ in the cli package.
 \code{arg} or \code{error_arg} argument that takes \code{error_arg()} as default.
 }
 }
+\section{Use in \code{print()}}{
+
+Note that \code{caller_arg()} will not work properly when redefining the
+\code{print()} method, as the name of the object is not in the callstack.
+}
+
 \examples{
 arg_checker <- function(x, arg = caller_arg(x), call = caller_env()) {
   cli::cli_abort("{.arg {arg}} must be a thingy.", arg = arg, call = call)


### PR DESCRIPTION
Hi,

I stumbled upon the `caller_arg()` limitation when redefining a print method for hours without understanding, and thought it might deserve a bit of documentation.

As stated in https://stackoverflow.com/a/4963041/3888000: 

> This is a rather special case, as R substitutes foo by its value before calling print when you type the name at the command line.
> [...]
> There is no way on earth you'll extract the name of the object from anywhere. It's simply not there in the callstack.


Here is a `rlang` specific reprex:
``` r
my_obj=1
class(my_obj)="bar"
print.bar = function(x) rlang::caller_arg(x)
mean.bar = function(x) rlang::caller_arg(x)
my_obj
#> x
mean(my_obj)
#> [1] "my_obj"

#however, this works as intended
print(my_obj)
#> [1] "my_obj"
```

<sup>Created on 2024-02-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
