### PR TITLE
Allow reticulate errors in cnd_type() (fixes #1664)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* Fix for reticulate errors (#1664)
+
 * `last_trace()` hyperlinks now use the modern `x-r-run` format (#1678).
 
 

--- a/src/rlang/cnd.c
+++ b/src/rlang/cnd.c
@@ -100,7 +100,8 @@ void r_interrupt(void) {
 
 enum r_cnd_type r_cnd_type(r_obj* cnd) {
   r_obj* classes = r_class(cnd);
-  if (r_typeof(cnd) != R_TYPE_list ||
+  if (
+      (r_typeof(cnd) != R_TYPE_list && r_typeof(cnd) != R_TYPE_environment) ||
       r_typeof(classes) != R_TYPE_character) {
     goto error;
   }

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -165,8 +165,8 @@ test_that("calls are consistently displayed on rethrow (#1240)", {
       expr = force(expr),
       error = function(cnd) {
         rlang::abort(
-          message = "Problem while executing step.", 
-          call = call(step_name), 
+          message = "Problem while executing step.",
+          call = call(step_name),
           parent = cnd
         )
       }
@@ -252,6 +252,9 @@ test_that("cnd_type() detects condition type", {
   expect_identical(cnd_type(warning_cnd()), "warning")
   expect_identical(cnd_type(error_cnd()), "error")
   expect_identical(cnd_type(catch_cnd(interrupt())), "interrupt")
+  # reticulate stores error conditions as environments (#1664)
+  env_cnd <- structure(env(), class = c("error", "condition"))
+  expect_identical(cnd_type(env_cnd), "error")
 })
 
 test_that("bare conditions must be subclassed", {


### PR DESCRIPTION
Not sure if this is the right way to fix, but was useful enough for me for that I thought I'd share.

reticulate stores it's conditions with the right classes to work with rlang, but uses an environment instead of a list.

``` r
err <- try(reticulate::py_run_string("oops"), silent = TRUE) |> attr("condition")

is.environment(err)
#> [1] TRUE
class(err)
#> [1] "python.builtin.NameError"     "python.builtin.Exception"    
#> [3] "python.builtin.BaseException" "python.builtin.object"       
#> [5] "error"                        "condition"
```

<sup>Created on 2024-02-22 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>