### PR TITLE
docs: Wrap `on_load()` contents in examples with braces

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -79,16 +79,20 @@ the <- new.env(parent = emptyenv())
 #' }
 #'
 #' # Register a method on load
-#' on_load(s3_register("foo::bar", "my_class"))
+#' on_load({
+#'   s3_register("foo::bar", "my_class"))
+#' })
 #'
 #' # Assign an object on load
 #' var <- NULL
-#' on_load(
+#' on_load({
 #'   var <- foo()
-#' )
+#' })
 #'
 #' # To use `on_package_load()` at top level, wrap it in `on_load()`
-#' on_load(on_package_load("foo", message("foo is loaded")))
+#' on_load({
+#'   on_package_load("foo", message("foo is loaded"))
+#' })
 #'
 #' # In functions it can be called directly
 #' f <- function() on_package_load("foo", message("foo is loaded"))

--- a/man/on_load.Rd
+++ b/man/on_load.Rd
@@ -84,16 +84,20 @@ quote({  # Not run
 }
 
 # Register a method on load
-on_load(s3_register("foo::bar", "my_class"))
+on_load({
+  s3_register("foo::bar", "my_class"))
+})
 
 # Assign an object on load
 var <- NULL
-on_load(
+on_load({
   var <- foo()
-)
+})
 
 # To use `on_package_load()` at top level, wrap it in `on_load()`
-on_load(on_package_load("foo", message("foo is loaded")))
+on_load({
+  on_package_load("foo", message("foo is loaded"))
+})
 
 # In functions it can be called directly
 f <- function() on_package_load("foo", message("foo is loaded"))


### PR DESCRIPTION
This gives better tracebacks, I suppose.