### PR TITLE
Fix bug in `vec_recycle_common()`

### DIFF
--- a/R/standalone-vctrs.R
+++ b/R/standalone-vctrs.R
@@ -13,6 +13,10 @@
 # of data frames without having to depend on tibble or vctrs. The
 # embedded type system is minimal and not extensible.
 
+# 2024-04-17:
+# * `vec_recycle_common()` throws intended error when `size = 1` but input
+#   is larger.
+
 # 2021-08-27:
 # * `vec_slice()` now preserves attributes of data frames and vectors.
 # * `vec_ptype2()` detects unspecified columns of data frames.
@@ -118,7 +122,7 @@ vec_recycle_common <- function(xs, size = NULL) {
   } else if (ns == 1) {
     if (is.null(size)) {
       size <- n
-    } else if (ns != size) {
+    } else if (n != size) {
       stop("Inputs can't be recycled to `size`.", call. = FALSE)
     }
   } else {

--- a/tests/testthat/test-standalone-vctrs.R
+++ b/tests/testthat/test-standalone-vctrs.R
@@ -452,3 +452,16 @@ test_that("ptype is finalised", {
   out <- vec_cast_common(list(out, x))[[1]]
   expect_identical(out$x, NA)
 })
+
+test_that("vec_recycle_common() throws appropriate errors", {
+
+  expect_error(
+    vec_recycle_common(list(a = 1:2), size = 1),
+    "Inputs can't be recycled to `size`."
+  )
+  expect_error(
+    vec_recycle_common(list(a = 1:2, b = 1:3)),
+    "Inputs can't be recycled to a common size."
+  )
+
+})


### PR DESCRIPTION
This PR aims to fix #1700.

It restores an error that should be thrown when `size = 1` is requested, but input has larger vectors.
Reprex from issue with this PR:

``` r
rlang:::vec_recycle_common(list(a = 1, b = 1:2), size = 1)
#> Error: Inputs can't be recycled to `size`.
```

<sup>Created on 2024-04-17 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
