### PR TITLE
Show how to use call = `base::call()` in `abort()`

### DIFF
--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -245,7 +245,15 @@
 #'       abort(msg, parent = err)
 #'   })
 #' )
-#'
+#' # Hard-code call
+#'  f <- function() {
+#'   abort(call = call("the_source_fn"))
+#' }
+#' g <- function() {
+#'   f()
+#' }
+#' # will show that error occured in `the_source_fn()`
+#' try(g())
 #' }
 #' @export
 abort <- function(message = NULL,

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -245,15 +245,18 @@
 #'       abort(msg, parent = err)
 #'   })
 #' )
-#' # Hard-code call
+#'
+#' # You can also hard-code the call when it's not easy to
+#' # forward it from the caller
 #'  f <- function() {
-#'   abort(call = call("the_source_fn"))
+#'   abort("my message", call = call("my_function"))
 #' }
 #' g <- function() {
 #'   f()
 #' }
-#' # will show that error occured in `the_source_fn()`
+#' # Shows that the error occured in `my_function()`
 #' try(g())
+#'
 #' }
 #' @export
 abort <- function(message = NULL,

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -338,6 +338,17 @@ try(
   })
 )
 
+# You can also hard-code the call when it's not easy to
+# forward it from the caller
+ f <- function() {
+  abort("my message", call = call("my_function"))
+}
+g <- function() {
+  f()
+}
+# Shows that the error occured in `my_function()`
+try(g())
+
 }
 }
 \seealso{


### PR DESCRIPTION
I discovered yesterday that if you wanted  to hard-code the `call` argument, it was possible, but never found this in rlang's `abort()` documentation,

I thought adding an example could be useful? Sometimes, I think it can be useful to hard-code it? May be easier to learn to use this than all of rlang's infrastructure.