### PR TITLE
Add cross-ref between the ellipsis checking functions

### DIFF
--- a/R/dots-ellipsis.R
+++ b/R/dots-ellipsis.R
@@ -11,6 +11,7 @@
 #' @param env Environment in which to look for `...` and to set up handler.
 #' @inheritParams args_error_context
 #'
+#' @family dots checking functions
 #' @details
 #' In packages, document `...` with this standard tag:
 #'
@@ -91,6 +92,7 @@ check_dots <- function(env = caller_env(), error, action, call) {
 #' fail with an error when named arguments are detected.
 #'
 #' @inheritParams check_dots_used
+#' @family dots checking functions
 #' @param env Environment in which to look for `...`.
 #' @export
 #' @examples
@@ -139,6 +141,7 @@ check_dots_unnamed <- function(env = caller_env(),
 #' @inheritParams check_dots_used
 #' @param env Environment in which to look for `...`.
 #'
+#' @family dots checking functions
 #' @details
 #' In packages, document `...` with this standard tag:
 #'

--- a/man/check_dots_empty.Rd
+++ b/man/check_dots_empty.Rd
@@ -52,3 +52,9 @@ try(f(1, foof = 4))
 f(1, foofy = 4)
 
 }
+\seealso{
+Other dots checking functions: 
+\code{\link{check_dots_unnamed}()},
+\code{\link{check_dots_used}()}
+}
+\concept{dots checking functions}

--- a/man/check_dots_unnamed.Rd
+++ b/man/check_dots_unnamed.Rd
@@ -39,3 +39,9 @@ f(1, 2, 3, foofy = 4)
 
 try(f(1, 2, 3, foof = 4))
 }
+\seealso{
+Other dots checking functions: 
+\code{\link{check_dots_empty}()},
+\code{\link{check_dots_used}()}
+}
+\concept{dots checking functions}

--- a/man/check_dots_used.Rd
+++ b/man/check_dots_used.Rd
@@ -69,3 +69,9 @@ fn <- function(...) {
 fn()
 
 }
+\seealso{
+Other dots checking functions: 
+\code{\link{check_dots_empty}()},
+\code{\link{check_dots_unnamed}()}
+}
+\concept{dots checking functions}


### PR DESCRIPTION
Currently, there is no reference to other dot checking functions. So adding a `@family` adds the following to see also

![image](https://github.com/r-lib/rlang/assets/52606734/3b43f2b1-f089-4a83-8050-266d7046d910)

Maybe worth adding `dots_n()`?