### PR TITLE
Replace STRING_PTR with STRING_PTR_RO

### DIFF
--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -47,12 +47,12 @@ const void* r_raw_cbegin(r_obj* x) {
 }
 static inline
 r_obj* const * r_chr_cbegin(r_obj* x) {
-  return (r_obj* const *) STRING_PTR(x);
+  return (r_obj* const *) STRING_PTR_RO(x);
 }
 static inline
 r_obj* const * r_list_cbegin(r_obj* x) {
 #if (R_VERSION < R_Version(3, 5, 0))
-  return ((r_obj* const *) STRING_PTR(x));
+  return ((r_obj* const *) STRING_PTR_RO(x));
 #else
   return ((r_obj* const *) DATAPTR_RO(x));
 #endif

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -47,12 +47,12 @@ const void* r_raw_cbegin(r_obj* x) {
 }
 static inline
 r_obj* const * r_chr_cbegin(r_obj* x) {
-  return (r_obj* const *) STRING_PTR_RO(x);
+  return STRING_PTR_RO(x);
 }
 static inline
 r_obj* const * r_list_cbegin(r_obj* x) {
 #if (R_VERSION < R_Version(3, 5, 0))
-  return ((r_obj* const *) STRING_PTR_RO(x));
+  return STRING_PTR_RO(x);
 #else
   return ((r_obj* const *) DATAPTR_RO(x));
 #endif


### PR DESCRIPTION
This is to fix one of many CRAN Notes related to newly-added "non-API"s.

```
Version: 1.1.4
Check: compiled code
Result: NOTE
  File ‘rlang/libs/rlang.so’:
    Found non-API calls to R: ‘ENVFLAGS’, ‘FRAME’, ‘HASHTAB’, ‘LEVELS’,
      ‘NAMED’, ‘PRENV’, ‘PRVALUE’, ‘RDEBUG’, ‘R_PromiseExpr’,
      ‘Rf_findVarInFrame3’, ‘SETLENGTH’, ‘SET_BODY’, ‘SET_CLOENV’,
      ‘SET_ENCLOS’, ‘SET_ENVFLAGS’, ‘SET_FORMALS’, ‘SET_GROWABLE_BIT’,
      ‘SET_RDEBUG’, ‘SET_TRUELENGTH’, ‘SET_TYPEOF’, ‘STRING_PTR’,
      ‘XTRUELENGTH’
  
  Compiled code should not call non-API entry points in R.
```
(https://cran.r-project.org/web/checks/check_results_rlang.html)