### PR TITLE
Deprecate `env_unlock()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,6 +48,7 @@ RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)
 URL: https://rlang.r-lib.org, https://github.com/r-lib/rlang
 BugReports: https://github.com/r-lib/rlang/issues
+Config/build/compilation-database: true
 Config/testthat/edition: 3
 Config/Needs/website:
     dplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rlang (development version)
 
+* `env_unlock()` is now defunct because recent versions of R no long
+  make it possible to unlock an environment. Make sure to use an up-to-date
+  version of pkgload (>= 1.4.0) following this change.
+
+
 # rlang 1.1.4
 
 * Added missing C level `r_dyn_raw_push_back()` and `r_dyn_chr_push_back()`

--- a/R/env.R
+++ b/R/env.R
@@ -554,8 +554,9 @@ env_is_locked <- function(env) {
 
 #' Unlock an environment
 #'
-#' This function should only be used in development tools or
-#' interactively.
+#' `r lifecycle::badge("defunct")`. This function is now defunct
+#' because recent versions of R no longer make it possible to
+#' unlock an environment.
 #'
 #' @inheritParams env_lock
 #' @return Whether the environment has been unlocked.
@@ -563,7 +564,25 @@ env_is_locked <- function(env) {
 #' @keywords internal
 #' @export
 env_unlock <- function(env) {
-  invisible(.Call(ffi_env_unlock, env))
+  msg <- "`env_unlock()` is defunct as of rlang 1.1.5"
+
+  old_pkgload_running <- 
+    "pkgload" %in% loadedNamespaces() && 
+    some(sys.frames(), function(env) identical(topenv(env), ns_env("pkgload"))) &&
+    utils::packageVersion("pkgload") <= "1.3.4"
+
+  if (old_pkgload_running) {
+    ver <- utils::packageVersion("pkgload")
+    msg <- c(
+      msg,
+      "i" = sprintf(
+        "This error is likely caused by an outdated version of pkgload. You are running pkgload %s and you need at least 1.3.5",
+        ver
+      )
+    )
+  }
+
+  abort(msg)
 }
 
 

--- a/R/env.R
+++ b/R/env.R
@@ -576,7 +576,7 @@ env_unlock <- function(env) {
     msg <- c(
       msg,
       "i" = sprintf(
-        "This error is likely caused by an outdated version of pkgload. You are running pkgload %s and you need at least 1.3.5",
+        "This error is likely caused by an outdated version of pkgload. You are running pkgload %s and you need at least 1.4.0",
         ver
       )
     )

--- a/R/rlang-package.R
+++ b/R/rlang-package.R
@@ -18,3 +18,6 @@ compiled_by_gcc <- function() {
 #' @rawNamespace export(ffi_standalone_is_bool_1.0.7)
 #' @rawNamespace export(ffi_standalone_check_number_1.0.7)
 NULL
+
+# Enable pkgload to hotpatch `::` in detached namespaces
+on_load(`::` <- base::`::`)

--- a/man/env_unlock.Rd
+++ b/man/env_unlock.Rd
@@ -13,7 +13,8 @@ env_unlock(env)
 Whether the environment has been unlocked.
 }
 \description{
-This function should only be used in development tools or
-interactively.
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#defunct}{\figure{lifecycle-defunct.svg}{options: alt='[Defunct]'}}}{\strong{[Defunct]}}. This function is now defunct
+because recent versions of R no longer make it possible to
+unlock an environment.
 }
 \keyword{internal}

--- a/src/internal/env.c
+++ b/src/internal/env.c
@@ -1,16 +1,5 @@
 #include <rlang.h>
 
-#define FRAME_LOCK_MASK (1 << 14)
-#define FRAME_IS_LOCKED(e) (ENVFLAGS(e) & FRAME_LOCK_MASK)
-#define UNLOCK_FRAME(e) SET_ENVFLAGS(e, ENVFLAGS(e) & (~FRAME_LOCK_MASK))
-
-// Should only be used in development tools
-r_obj* ffi_env_unlock(r_obj* env) {
-  UNLOCK_FRAME(env);
-  return FRAME_IS_LOCKED(env) == 0 ? r_true : r_false;
-}
-
-
 void r_env_unbind_anywhere(r_obj* env, r_obj* sym) {
   while (env != r_envs.empty) {
     if (r_env_has(env, sym)) {

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -87,7 +87,6 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_env_poke",                     (DL_FUNC) &ffi_env_poke, 5},
   {"ffi_env_poke_parent",              (DL_FUNC) &ffi_env_poke_parent, 2},
   {"ffi_env_unbind",                   (DL_FUNC) &ffi_env_unbind, 3},
-  {"ffi_env_unlock",                   (DL_FUNC) &ffi_env_unlock, 1},
   {"ffi_eval_top",                     (DL_FUNC) &ffi_eval_top, 2},
   {"ffi_exprs_interp",                 (DL_FUNC) &ffi_exprs_interp, 6},
   {"ffi_f_lhs",                        (DL_FUNC) &r_f_lhs, 1},

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -236,14 +236,6 @@ test_that("can lock environments", {
   expect_true(env_lock(env))
 })
 
-test_that("can unlock environments", {
-  env <- env()
-  env_lock(env)
-  expect_true(env_unlock(env))
-  expect_false(env_is_locked(env))
-  expect_no_error(env_bind(env, a = 1))
-})
-
 test_that("env_print() has flexible input", {
   # because it's primarily used interactively
   f <- function() 1


### PR DESCRIPTION
Closes https://github.com/r-lib/rlang/issues/1705

`env_unlock()` is now defunct. Downstream deps have been warned of this 2 months ago.

The main revdep is `pkgload::load_all()` which is updated in https://github.com/r-lib/pkgload/pull/286 and will soon be sent to CRAN. It's likely people will end up with mismatched versions so `env_unlock()` detects outdated pkgload version and recommends to update.