### PR TITLE
Add ALTREP view support

### DIFF
--- a/R/altrep.R
+++ b/R/altrep.R
@@ -1,0 +1,3 @@
+is_altrep <- function(x) {
+  .Call(ffi_is_altrep, x)
+}

--- a/R/view.R
+++ b/R/view.R
@@ -1,0 +1,13 @@
+vec_view <- function(x, start, size) {
+  check_number_whole(start)
+  check_number_whole(size)
+  .Call(ffi_vec_view, x, start, size)
+}
+
+view_is_materialized <- function(x) {
+  .Call(ffi_view_is_materialized, x)
+}
+
+view_materialize <- function(x) {
+  .Call(ffi_view_materialize, x)
+}

--- a/R/view.R
+++ b/R/view.R
@@ -4,6 +4,10 @@ vec_view <- function(x, start, size) {
   .Call(ffi_vec_view, x, start, size)
 }
 
+view_inspect <- function(x) {
+  invisible(.Call(ffi_view_inspect, x))
+}
+
 view_is_materialized <- function(x) {
   .Call(ffi_view_is_materialized, x)
 }

--- a/src/Makevars
+++ b/src/Makevars
@@ -30,6 +30,7 @@ lib-files = \
         rlang/vec.c \
         rlang/vec-chr.c \
         rlang/vec-lgl.c \
+        rlang/view.c \
         rlang/vendor.c \
         rlang/walk.c
 

--- a/src/internal/exported.c
+++ b/src/internal/exported.c
@@ -2,6 +2,9 @@
 #include "../internal/utils.h"
 #include "../internal/vec.h"
 
+// From rlang/rlang.c
+void r_init_library_with_dll(DllInfo* dll, const char* package);
+
 // From rlang/vec.c
 void r_vec_poke_n(r_obj* x, r_ssize offset,
                   r_obj* y, r_ssize from, r_ssize n);
@@ -15,6 +18,13 @@ r_obj* ffi_compiled_by_gcc(void) {
   #else
   return r_false;
   #endif
+}
+
+
+// altrep.h
+
+r_obj* ffi_is_altrep(r_obj* x) {
+  return r_lgl(r_is_altrep(x));
 }
 
 
@@ -1050,6 +1060,25 @@ r_obj* ffi_vec_resize(r_obj* x, r_obj* n) {
 r_obj* ffi_list_poke(r_obj* x, r_obj* i, r_obj* value) {
   r_list_poke(x, r_arg_as_ssize(i, "i"), value);
   return r_null;
+}
+
+
+// view.c
+
+r_obj* ffi_vec_view(r_obj* x, r_obj* ffi_start, r_obj* ffi_size) {
+  const r_ssize start = r_arg_as_ssize(ffi_start, "start") - 1;
+  const r_ssize size = r_arg_as_ssize(ffi_size, "size");
+  return r_vec_view(x, start, size);
+}
+
+r_obj* ffi_view_is_materialized(r_obj* x) {
+  r_check_view(x);
+  return r_lgl(r_view_is_materialized(x));
+}
+
+r_obj* ffi_view_materialize(r_obj* x) {
+  r_check_view(x);
+  return r_view_materialize(x);
 }
 
 

--- a/src/internal/exported.c
+++ b/src/internal/exported.c
@@ -1071,6 +1071,11 @@ r_obj* ffi_vec_view(r_obj* x, r_obj* ffi_start, r_obj* ffi_size) {
   return r_vec_view(x, start, size);
 }
 
+r_obj* ffi_view_inspect(r_obj* x) {
+  r_check_view(x);
+  return r_lgl(r_view_inspect(x));
+}
+
 r_obj* ffi_view_is_materialized(r_obj* x) {
   r_check_view(x);
   return r_lgl(r_view_is_materialized(x));

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -111,6 +111,7 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_init_rlang",                   (DL_FUNC) &ffi_init_rlang, 1},
   {"ffi_interp",                       (DL_FUNC) &ffi_interp, 2},
   {"ffi_interrupt",                    (DL_FUNC) &ffi_interrupt, 0},
+  {"ffi_is_altrep",                    (DL_FUNC) &ffi_is_altrep, 1},
   {"ffi_is_atomic",                    (DL_FUNC) &ffi_is_atomic, 2},
   {"ffi_is_call",                      (DL_FUNC) &ffi_is_call, 4},
   {"ffi_is_character",                 (DL_FUNC) &ffi_is_character, 4},
@@ -238,6 +239,9 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_vec_poke_n",                   (DL_FUNC) &ffi_vec_poke_n, 5},
   {"ffi_vec_poke_range",               (DL_FUNC) &ffi_vec_poke_range, 5},
   {"ffi_vec_resize",                   (DL_FUNC) &ffi_vec_resize, 2},
+  {"ffi_vec_view",                     (DL_FUNC) &ffi_vec_view, 3},
+  {"ffi_view_is_materialized",         (DL_FUNC) &ffi_view_is_materialized, 1},
+  {"ffi_view_materialize",             (DL_FUNC) &ffi_view_materialize, 1},
   {"ffi_which_operator",               (DL_FUNC) &ffi_which_operator, 1},
   {"ffi_wref_key",                     (DL_FUNC) &ffi_wref_key, 1},
   {"ffi_wref_value",                   (DL_FUNC) &ffi_wref_value, 1},
@@ -321,6 +325,8 @@ void R_init_rlang(DllInfo* dll) {
 
   R_registerRoutines(dll, NULL, r_callables, NULL, externals);
   R_useDynamicSymbols(dll, FALSE);
+
+  r_init_library_with_dll(dll, "rlang");
 }
 
 

--- a/src/internal/init.c
+++ b/src/internal/init.c
@@ -240,6 +240,7 @@ static const R_CallMethodDef r_callables[] = {
   {"ffi_vec_poke_range",               (DL_FUNC) &ffi_vec_poke_range, 5},
   {"ffi_vec_resize",                   (DL_FUNC) &ffi_vec_resize, 2},
   {"ffi_vec_view",                     (DL_FUNC) &ffi_vec_view, 3},
+  {"ffi_view_inspect",                 (DL_FUNC) &ffi_view_inspect, 1},
   {"ffi_view_is_materialized",         (DL_FUNC) &ffi_view_is_materialized, 1},
   {"ffi_view_materialize",             (DL_FUNC) &ffi_view_materialize, 1},
   {"ffi_which_operator",               (DL_FUNC) &ffi_which_operator, 1},

--- a/src/rlang/altrep.h
+++ b/src/rlang/altrep.h
@@ -13,5 +13,20 @@
 # define ALTREP(x) false
 #endif
 
+static inline
+bool r_is_altrep(r_obj* x) {
+  return ALTREP(x);
+}
+
+static inline
+r_obj* r_altrep_data1(r_obj* x) {
+  return R_altrep_data1(x);
+}
+
+static inline
+r_obj* r_altrep_data2(r_obj* x) {
+  return R_altrep_data2(x);
+}
+
 
 #endif

--- a/src/rlang/altrep.h
+++ b/src/rlang/altrep.h
@@ -13,6 +13,12 @@
 # define ALTREP(x) false
 #endif
 
+#if R_VERSION >= R_Version(4, 3, 0)
+#define RLANG_R_HAS_ALTLIST 1
+#else
+#define RLANG_R_HAS_ALTLIST 0
+#endif
+
 static inline
 bool r_is_altrep(r_obj* x) {
   return ALTREP(x);

--- a/src/rlang/rlang-types.h
+++ b/src/rlang/rlang-types.h
@@ -22,6 +22,7 @@
 
 typedef struct SEXPREC r_obj;
 typedef Rcomplex r_complex;
+typedef Rbyte r_byte;
 
 typedef R_xlen_t r_ssize;
 #define R_SSIZE_MAX R_XLEN_T_MAX

--- a/src/rlang/rlang.c
+++ b/src/rlang/rlang.c
@@ -29,6 +29,7 @@
 #include "vec-chr.c"
 #include "vec-lgl.c"
 #include "vendor.c"
+#include "view.c"
 #include "walk.c"
 
 
@@ -118,6 +119,13 @@ r_obj* r_init_library(r_obj* ns) {
 
   // Return a SEXP so the init function can be called from R
   return r_null;
+}
+
+// This *must* be called before making any calls to the functions
+// provided in the library. Call this function from your `R_init_<package>()`
+// function, passing along the `dll` and your package's name.
+void r_init_library_with_dll(DllInfo* dll, const char* package) {
+  r_init_library_view(dll, package);
 }
 
 bool _r_use_local_precious_list = false;

--- a/src/rlang/rlang.h
+++ b/src/rlang/rlang.h
@@ -72,6 +72,7 @@ bool _r_use_local_precious_list;
 #include "vec-chr.h"
 #include "vec-lgl.h"
 #include "vendor.h"
+#include "view.h"
 #include "walk.h"
 
 

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -21,8 +21,12 @@ r_complex* r_cpl_begin(r_obj* x) {
   return COMPLEX(x);
 }
 static inline
-void* r_raw_begin(r_obj* x) {
+r_byte* r_raw_begin0(r_obj* x) {
   return RAW(x);
+}
+static inline
+void* r_raw_begin(r_obj* x) {
+  return r_raw_begin0(x);
 }
 
 static inline
@@ -42,8 +46,12 @@ const r_complex* r_cpl_cbegin(r_obj* x) {
   return (const r_complex*) COMPLEX(x);
 }
 static inline
+const r_byte* r_raw_cbegin0(r_obj* x) {
+  return (const r_byte*) RAW(x);
+}
+static inline
 const void* r_raw_cbegin(r_obj* x) {
-  return (const void*) RAW(x);
+  return (const void*) r_raw_cbegin0(x);
 }
 static inline
 r_obj* const * r_chr_cbegin(r_obj* x) {

--- a/src/rlang/view.c
+++ b/src/rlang/view.c
@@ -1,0 +1,481 @@
+#include "rlang.h"
+#include "view.h"
+
+#include <R_ext/Altrep.h>
+
+/*
+Structure of a `view`:
+
+Before materialization:
+- `data1` is the original vector
+- `data2` is a RAWSXP holding a `r_view_metadata`
+
+After materialization:
+- `data1` is `R_NilValue`
+- `data2` is the materialized view
+
+So `data1 == R_NilValue` is how we determine if we have materialized or not
+*/
+
+struct r_view_metadata {
+  r_ssize start;
+  r_ssize size;
+};
+
+// Initialised at load time
+R_altrep_class_t r_lgl_view_class;
+R_altrep_class_t r_int_view_class;
+R_altrep_class_t r_dbl_view_class;
+R_altrep_class_t r_cpl_view_class;
+
+// -----------------------------------------------------------------------------
+
+static inline r_obj*
+r_view(R_altrep_class_t cls, r_obj* x, r_ssize start, r_ssize size) {
+  if (r_attrib(x) != r_null) {
+    r_stop_internal("`x` can't have any attributes.");
+  }
+
+  // We don't want it to have any chance of changing out from under us
+  r_mark_shared(x);
+
+  r_obj* metadata = r_alloc_raw(sizeof(struct r_view_metadata));
+  struct r_view_metadata* p_metadata = r_raw_begin(metadata);
+  p_metadata->start = start;
+  p_metadata->size = size;
+
+  return R_new_altrep(cls, x, metadata);
+}
+
+static inline r_obj* r_lgl_view(r_obj* x, r_ssize start, r_ssize size) {
+  return r_view(r_lgl_view_class, x, start, size);
+}
+static inline r_obj* r_int_view(r_obj* x, r_ssize start, r_ssize size) {
+  return r_view(r_int_view_class, x, start, size);
+}
+static inline r_obj* r_dbl_view(r_obj* x, r_ssize start, r_ssize size) {
+  return r_view(r_dbl_view_class, x, start, size);
+}
+static inline r_obj* r_cpl_view(r_obj* x, r_ssize start, r_ssize size) {
+  return r_view(r_cpl_view_class, x, start, size);
+}
+
+// Up to the caller to verify that `start` and `size` are sized correctly.
+// `start` is 0-indexed.
+r_obj* r_vec_view(r_obj* x, r_ssize start, r_ssize size) {
+  switch (r_typeof(x)) {
+    case R_TYPE_logical:
+      return r_lgl_view(x, start, size);
+    case R_TYPE_integer:
+      return r_int_view(x, start, size);
+    case R_TYPE_double:
+      return r_dbl_view(x, start, size);
+    case R_TYPE_complex:
+      return r_cpl_view(x, start, size);
+    default:
+      r_stop_internal("Type not implemented.");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+static inline bool r_is_lgl_view(r_obj* x) {
+  return R_altrep_inherits(x, r_lgl_view_class);
+}
+static inline bool r_is_int_view(r_obj* x) {
+  return R_altrep_inherits(x, r_int_view_class);
+}
+static inline bool r_is_dbl_view(r_obj* x) {
+  return R_altrep_inherits(x, r_dbl_view_class);
+}
+static inline bool r_is_cpl_view(r_obj* x) {
+  return R_altrep_inherits(x, r_cpl_view_class);
+}
+
+bool r_is_view(r_obj* x) {
+  switch (r_typeof(x)) {
+    case R_TYPE_logical:
+      return r_is_lgl_view(x);
+    case R_TYPE_integer:
+      return r_is_int_view(x);
+    case R_TYPE_double:
+      return r_is_dbl_view(x);
+    case R_TYPE_complex:
+      return r_is_cpl_view(x);
+    default:
+      return false;
+  }
+}
+
+void r_check_view(r_obj* x) {
+  if (r_is_view(x)) {
+    return;
+  }
+  r_stop_internal("`x` must be an ALTREP view.");
+}
+
+// -----------------------------------------------------------------------------
+
+#define R_VIEW_MATERIALIZE(ALLOC, CTYPE, BEGIN, GET_REGION)                  \
+  r_obj* data = r_altrep_data1(x);                                           \
+                                                                             \
+  if (data == r_null) {                                                      \
+    r_stop_internal(                                                         \
+        "`x` has already been materialized, return `data2` directly rather " \
+        "than calling this."                                                 \
+    );                                                                       \
+  }                                                                          \
+                                                                             \
+  r_obj* metadata = r_altrep_data2(x);                                       \
+  struct r_view_metadata* p_metadata = r_raw_begin(metadata);                \
+                                                                             \
+  const r_ssize start = p_metadata->start;                                   \
+  const r_ssize size = p_metadata->size;                                     \
+                                                                             \
+  r_obj* out = KEEP(ALLOC(size));                                            \
+  CTYPE* v_out = BEGIN(out);                                                 \
+                                                                             \
+  /* Be friendly to ALTREP `data` too */                                     \
+  GET_REGION(data, start, size, v_out);                                      \
+                                                                             \
+  /* Declare ourselves as materialized */                                    \
+  R_set_altrep_data1(x, r_null);                                             \
+  R_set_altrep_data2(x, out);                                                \
+                                                                             \
+  FREE(1);                                                                   \
+  return out
+
+static r_obj* r_lgl_view_materialize(r_obj* x) {
+  R_VIEW_MATERIALIZE(r_alloc_logical, int, r_lgl_begin, LOGICAL_GET_REGION);
+}
+static r_obj* r_int_view_materialize(r_obj* x) {
+  R_VIEW_MATERIALIZE(r_alloc_integer, int, r_int_begin, INTEGER_GET_REGION);
+}
+static r_obj* r_dbl_view_materialize(r_obj* x) {
+  R_VIEW_MATERIALIZE(r_alloc_double, double, r_dbl_begin, REAL_GET_REGION);
+}
+static r_obj* r_cpl_view_materialize(r_obj* x) {
+  R_VIEW_MATERIALIZE(
+      r_alloc_complex, r_complex, r_cpl_begin, COMPLEX_GET_REGION
+  );
+}
+
+r_obj* r_view_materialize(r_obj* x) {
+  switch (r_typeof(x)) {
+    case R_TYPE_logical:
+      return r_lgl_view_materialize(x);
+    case R_TYPE_integer:
+      return r_int_view_materialize(x);
+    case R_TYPE_double:
+      return r_dbl_view_materialize(x);
+    case R_TYPE_complex:
+      return r_cpl_view_materialize(x);
+    default:
+      r_stop_internal("Type not implemented.");
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+#define R_VIEW_DATAPTR_WRITABLE(MATERIALIZE, BEGIN)                \
+  r_obj* out = NULL;                                               \
+  r_obj* data = r_altrep_data1(x);                                 \
+                                                                   \
+  if (data != r_null) {                                            \
+    /* We can't give out a writable pointer to `data`. */          \
+    /* Materialize and give a writable pointer to that instead. */ \
+    out = MATERIALIZE(x);                                          \
+  } else {                                                         \
+    /* Already materialized */                                     \
+    out = r_altrep_data2(x);                                       \
+  }                                                                \
+                                                                   \
+  return BEGIN(out);
+
+static inline int* r_lgl_view_dataptr_writable(r_obj* x) {
+  R_VIEW_DATAPTR_WRITABLE(r_lgl_view_materialize, r_lgl_begin);
+}
+static inline int* r_int_view_dataptr_writable(r_obj* x) {
+  R_VIEW_DATAPTR_WRITABLE(r_int_view_materialize, r_int_begin);
+}
+static inline double* r_dbl_view_dataptr_writable(r_obj* x) {
+  R_VIEW_DATAPTR_WRITABLE(r_dbl_view_materialize, r_dbl_begin);
+}
+static inline r_complex* r_cpl_view_dataptr_writable(r_obj* x) {
+  R_VIEW_DATAPTR_WRITABLE(r_cpl_view_materialize, r_cpl_begin);
+}
+
+#define R_VIEW_DATAPTR_READONLY(CBEGIN)                                \
+  r_obj* data = r_altrep_data1(x);                                     \
+                                                                       \
+  if (data != r_null) {                                                \
+    /* Provide a readonly view into the data at the right offset */    \
+    r_obj* metadata = r_altrep_data2(x);                               \
+    const struct r_view_metadata* p_metadata = r_raw_cbegin(metadata); \
+    return CBEGIN(data) + p_metadata->start;                           \
+  } else {                                                             \
+    /* Provide a readonly view into the materialized data */           \
+    return CBEGIN(r_altrep_data2(x));                                  \
+  }
+
+static inline int const* r_lgl_view_dataptr_readonly(r_obj* x) {
+  R_VIEW_DATAPTR_READONLY(r_lgl_cbegin);
+}
+static inline int const* r_int_view_dataptr_readonly(r_obj* x) {
+  R_VIEW_DATAPTR_READONLY(r_int_cbegin);
+}
+static inline double const* r_dbl_view_dataptr_readonly(r_obj* x) {
+  R_VIEW_DATAPTR_READONLY(r_dbl_cbegin);
+}
+static inline r_complex const* r_cpl_view_dataptr_readonly(r_obj* x) {
+  R_VIEW_DATAPTR_READONLY(r_cpl_cbegin);
+}
+
+#define R_VIEW_DATAPTR(WRITABLE, READONLY) \
+  if (writable) {                          \
+    return (void*) WRITABLE(x);            \
+  } else {                                 \
+    /* Caller promises not to mutate it */ \
+    return (void*) READONLY(x);            \
+  }
+
+static void* r_lgl_view_dataptr(r_obj* x, Rboolean writable) {
+  R_VIEW_DATAPTR(r_lgl_view_dataptr_writable, r_lgl_view_dataptr_readonly);
+}
+static void* r_int_view_dataptr(r_obj* x, Rboolean writable) {
+  R_VIEW_DATAPTR(r_int_view_dataptr_writable, r_int_view_dataptr_readonly);
+}
+static void* r_dbl_view_dataptr(r_obj* x, Rboolean writable) {
+  R_VIEW_DATAPTR(r_dbl_view_dataptr_writable, r_dbl_view_dataptr_readonly);
+}
+static void* r_cpl_view_dataptr(r_obj* x, Rboolean writable) {
+  R_VIEW_DATAPTR(r_cpl_view_dataptr_writable, r_cpl_view_dataptr_readonly);
+}
+
+// We can always provide a readonly view
+static const void* r_lgl_view_dataptr_or_null(r_obj* x) {
+  return (const void*) r_lgl_view_dataptr_readonly(x);
+}
+static const void* r_int_view_dataptr_or_null(r_obj* x) {
+  return (const void*) r_int_view_dataptr_readonly(x);
+}
+static const void* r_dbl_view_dataptr_or_null(r_obj* x) {
+  return (const void*) r_dbl_view_dataptr_readonly(x);
+}
+static const void* r_cpl_view_dataptr_or_null(r_obj* x) {
+  return (const void*) r_cpl_view_dataptr_readonly(x);
+}
+
+// -----------------------------------------------------------------------------
+
+static r_ssize r_view_length(r_obj* x) {
+  r_obj* data = r_altrep_data1(x);
+
+  if (data != r_null) {
+    // Pull from metadata
+    r_obj* metadata = r_altrep_data2(x);
+    const struct r_view_metadata* p_metadata = r_raw_cbegin(metadata);
+    return p_metadata->size;
+  } else {
+    // Pull from materialized object
+    return Rf_xlength(r_altrep_data2(x));
+  }
+}
+
+// -----------------------------------------------------------------------------
+
+static inline Rboolean r_view_inspect(
+    const char* name,
+    r_obj* x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(r_obj*, int, int, int)
+) {
+  Rprintf(
+      "%s (materialized=%s)\n", name, r_altrep_data1(x) == r_null ? "T" : "F"
+  );
+  return TRUE;
+}
+
+static Rboolean r_lgl_view_inspect(
+    r_obj* x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(r_obj*, int, int, int)
+) {
+  return r_view_inspect(
+      "altrep_logical_view", x, pre, deep, pvec, inspect_subtree
+  );
+}
+static Rboolean r_int_view_inspect(
+    r_obj* x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(r_obj*, int, int, int)
+) {
+  return r_view_inspect(
+      "altrep_integer_view", x, pre, deep, pvec, inspect_subtree
+  );
+}
+static Rboolean r_dbl_view_inspect(
+    r_obj* x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(r_obj*, int, int, int)
+) {
+  return r_view_inspect(
+      "altrep_double_view", x, pre, deep, pvec, inspect_subtree
+  );
+}
+static Rboolean r_cpl_view_inspect(
+    r_obj* x,
+    int pre,
+    int deep,
+    int pvec,
+    void (*inspect_subtree)(r_obj*, int, int, int)
+) {
+  return r_view_inspect(
+      "altrep_complex_view", x, pre, deep, pvec, inspect_subtree
+  );
+}
+
+// -----------------------------------------------------------------------------
+
+static r_obj* r_view_serialized_state(r_obj* x) {
+  // Falls back to materializing the full object and serializing that,
+  // no ALTREP used in the serialization. Particularly important to ensure
+  // we can iterate on the internal structure without worrying about loading
+  // old serialized ALTREP objects.
+  return NULL;
+}
+
+// -----------------------------------------------------------------------------
+
+#define R_VIEW_ELT(ELT)                                                \
+  r_obj* data = r_altrep_data1(x);                                     \
+                                                                       \
+  if (data != r_null) {                                                \
+    /* Element comes from original data */                             \
+    r_obj* metadata = r_altrep_data2(x);                               \
+    const struct r_view_metadata* p_metadata = r_raw_cbegin(metadata); \
+    return ELT(data, p_metadata->start + i);                           \
+  } else {                                                             \
+    /* Element comes from materialized data */                         \
+    return ELT(r_altrep_data2(x), i);                                  \
+  }
+
+static int r_lgl_view_elt(r_obj* x, r_ssize i) {
+  R_VIEW_ELT(LOGICAL_ELT);
+}
+static int r_int_view_elt(r_obj* x, r_ssize i) {
+  R_VIEW_ELT(INTEGER_ELT);
+}
+static double r_dbl_view_elt(r_obj* x, r_ssize i) {
+  R_VIEW_ELT(REAL_ELT);
+}
+static r_complex r_cpl_view_elt(r_obj* x, r_ssize i) {
+  R_VIEW_ELT(COMPLEX_ELT);
+}
+
+// -----------------------------------------------------------------------------
+
+// Purposefully not implemented
+//
+// R_set_altvec_Extract_subset_method
+// This falls back to a default implementation that uses the `Elt` method,
+// which we think is good enough (though it is slower)
+//
+// R_set_alttype_Get_region_method
+// This first tries Dataptr_or_null, which we have a very efficient method
+// for. It never returns `NULL` since we can always return a readonly pointer.
+
+static void r_init_library_lgl_view(DllInfo* dll, const char* package) {
+  r_lgl_view_class = R_make_altlogical_class("logical_view", package, dll);
+
+  // ALTVEC
+  R_set_altvec_Dataptr_method(r_lgl_view_class, r_lgl_view_dataptr);
+  R_set_altvec_Dataptr_or_null_method(
+      r_lgl_view_class, r_lgl_view_dataptr_or_null
+  );
+
+  // ALTREP
+  R_set_altrep_Length_method(r_lgl_view_class, r_view_length);
+  R_set_altrep_Inspect_method(r_lgl_view_class, r_lgl_view_inspect);
+  R_set_altrep_Serialized_state_method(
+      r_lgl_view_class, r_view_serialized_state
+  );
+
+  // ALTTYPE
+  R_set_altlogical_Elt_method(r_lgl_view_class, r_lgl_view_elt);
+}
+
+static void r_init_library_int_view(DllInfo* dll, const char* package) {
+  r_int_view_class = R_make_altinteger_class("integer_view", package, dll);
+
+  // ALTVEC
+  R_set_altvec_Dataptr_method(r_int_view_class, r_int_view_dataptr);
+  R_set_altvec_Dataptr_or_null_method(
+      r_int_view_class, r_int_view_dataptr_or_null
+  );
+
+  // ALTREP
+  R_set_altrep_Length_method(r_int_view_class, r_view_length);
+  R_set_altrep_Inspect_method(r_int_view_class, r_int_view_inspect);
+  R_set_altrep_Serialized_state_method(
+      r_int_view_class, r_view_serialized_state
+  );
+
+  // ALTTYPE
+  R_set_altinteger_Elt_method(r_int_view_class, r_int_view_elt);
+}
+
+static void r_init_library_dbl_view(DllInfo* dll, const char* package) {
+  r_dbl_view_class = R_make_altreal_class("double_view", package, dll);
+
+  // ALTVEC
+  R_set_altvec_Dataptr_method(r_dbl_view_class, r_dbl_view_dataptr);
+  R_set_altvec_Dataptr_or_null_method(
+      r_dbl_view_class, r_dbl_view_dataptr_or_null
+  );
+
+  // ALTREP
+  R_set_altrep_Length_method(r_dbl_view_class, r_view_length);
+  R_set_altrep_Inspect_method(r_dbl_view_class, r_dbl_view_inspect);
+  R_set_altrep_Serialized_state_method(
+      r_dbl_view_class, r_view_serialized_state
+  );
+
+  // ALTTYPE
+  R_set_altreal_Elt_method(r_dbl_view_class, r_dbl_view_elt);
+}
+
+static void r_init_library_cpl_view(DllInfo* dll, const char* package) {
+  r_cpl_view_class = R_make_altcomplex_class("complex_view", package, dll);
+
+  // ALTVEC
+  R_set_altvec_Dataptr_method(r_cpl_view_class, r_cpl_view_dataptr);
+  R_set_altvec_Dataptr_or_null_method(
+      r_cpl_view_class, r_cpl_view_dataptr_or_null
+  );
+
+  // ALTREP
+  R_set_altrep_Length_method(r_cpl_view_class, r_view_length);
+  R_set_altrep_Inspect_method(r_cpl_view_class, r_cpl_view_inspect);
+  R_set_altrep_Serialized_state_method(
+      r_cpl_view_class, r_view_serialized_state
+  );
+
+  // ALTTYPE
+  R_set_altcomplex_Elt_method(r_cpl_view_class, r_cpl_view_elt);
+}
+
+void r_init_library_view(DllInfo* dll, const char* package) {
+  r_init_library_lgl_view(dll, package);
+  r_init_library_int_view(dll, package);
+  r_init_library_dbl_view(dll, package);
+  r_init_library_cpl_view(dll, package);
+}

--- a/src/rlang/view.h
+++ b/src/rlang/view.h
@@ -1,0 +1,16 @@
+#ifndef RLANG_VIEW_H
+#define RLANG_VIEW_H
+
+r_obj* r_vec_view(r_obj* x, r_ssize start, r_ssize size);
+
+static inline
+bool r_view_is_materialized(r_obj* x) {
+  return r_altrep_data1(x) == r_null;
+}
+
+r_obj* r_view_materialize(r_obj* x);
+
+bool r_is_view(r_obj* x);
+void r_check_view(r_obj* x);
+
+#endif

--- a/src/rlang/view.h
+++ b/src/rlang/view.h
@@ -3,12 +3,10 @@
 
 r_obj* r_vec_view(r_obj* x, r_ssize start, r_ssize size);
 
-static inline
-bool r_view_is_materialized(r_obj* x) {
-  return r_altrep_data1(x) == r_null;
-}
-
 r_obj* r_view_materialize(r_obj* x);
+bool r_view_is_materialized(r_obj* x);
+
+Rboolean r_view_inspect(r_obj* x);
 
 bool r_is_view(r_obj* x);
 void r_check_view(r_obj* x);

--- a/tests/testthat/_snaps/view.md
+++ b/tests/testthat/_snaps/view.md
@@ -1,0 +1,49 @@
+# views can be inspected
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_logical_view (materialized=F)
+
+---
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_integer_view (materialized=F)
+
+---
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_double_view (materialized=F)
+
+---
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_complex_view (materialized=F)
+
+---
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_raw_view (materialized=F)
+
+---
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_character_view (materialized=F)
+
+---
+
+    Code
+      view_inspect(x)
+    Output
+      altrep_list_view (materialized=F)
+

--- a/tests/testthat/helper-altrep.R
+++ b/tests/testthat/helper-altrep.R
@@ -1,0 +1,6 @@
+# This helper is purposefully used at the end of each test in `test-view.R`
+# to only skip the list specific section of each `test_that()` block if
+# necessary.
+skip_if_no_altlist <- function() {
+  skip_if_not(getRversion() >= "4.3.0", message = "Missing ALTLIST support.")
+}

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -1,0 +1,177 @@
+test_that("views can be created", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
+})
+
+test_that("views have right length", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+})
+
+test_that("views can be sliced with subset", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
+})
+
+test_that("views can be sliced with subset2", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+})
+
+test_that("views can be manually materialized", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
+})
+
+test_that("view duplication causes a materialization", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+})
+
+test_that("can make zero length view", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+})

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -174,6 +174,115 @@ test_that("views can be sliced with subset2", {
   expect_false(view_is_materialized(x))
 })
 
+test_that("views can be assigned to", {
+  assign <- c(NA, TRUE)
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, c(TRUE, FALSE, TRUE, FALSE))
+
+  assign <- c(NA, 5L)
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, c(1L, 2L, 3L, 4L))
+
+  assign <- c(NA, 5)
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, c(1, 2, 3, 4))
+
+  assign <- c(NA, 5) + 2i
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, c(1, 2, 3, 4) + 1i)
+
+  assign <- as.raw(c(0, 5))
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, as.raw(c(1, 2, 3, 4)))
+
+  assign <- c(NA, "e")
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, c("a", "b", "c", "d"))
+
+  assign <- list(NA, "e")
+  base <- list("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  x[2:3] <- assign
+  expect_identical(x[2:3], assign)
+  expect_identical(base, list("a", "b", "c", "d"))
+})
+
+test_that("views can wrap other views", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+
+  base <- list("a", "b", "c", "d")
+  x <- vec_view(base, start = 1L, size = 3L)
+  y <- vec_view(x, start = 2L, size = 2L)
+  expect_identical(y[[2L]], base[[3L]])
+  expect_identical(y[1:2], base[2:3])
+  expect_identical(y, x[2:3])
+  expect_false(view_is_materialized(x))
+})
+
 test_that("views can be manually materialized", {
   base <- c(TRUE, FALSE, TRUE, FALSE)
   x <- vec_view(base, start = 2L, size = 3L)
@@ -223,6 +332,91 @@ test_that("views can be manually materialized", {
   materialized <- view_materialize(x)
   expect_true(view_is_materialized(x))
   expect_false(is_altrep(materialized))
+})
+
+test_that("views can be inspected", {
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+
+  base <- list("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_snapshot(view_inspect(x))
+})
+
+test_that("views can be roundtripped through serialization, and lose ALTREPness", {
+  # This is nice because we don't have to worry about compatibility with
+  # "old" view objects if we ever change the internals. It is also probably
+  # just the correct way to do this.
+
+  base <- c(TRUE, FALSE, TRUE, FALSE)
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
+
+  base <- c(1L, 2L, 3L, 4L)
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
+
+  base <- c(1, 2, 3, 4)
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
+
+  base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
+
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
+
+  base <- list("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  bytes <- serialize(x, connection = NULL)
+  x <- unserialize(bytes)
+  expect_false(is_altrep(x))
+  expect_identical(x, base[2:4])
 })
 
 test_that("can make zero length view", {

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -19,6 +19,11 @@ test_that("views can be created", {
   expect_false(view_is_materialized(x))
   expect_identical(x, base[2:4])
 
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
+
   base <- c("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_false(view_is_materialized(x))
@@ -44,6 +49,10 @@ test_that("views have right length", {
   expect_identical(length(x), 3L)
 
   base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+
+  base <- as.raw(c(1, 2, 3, 4))
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(length(x), 3L)
 
@@ -82,6 +91,14 @@ test_that("views can be sliced with subset", {
   expect_false(view_is_materialized(x))
 
   base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
+
+  base <- as.raw(c(1, 2, 3, 4))
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(x[1:2], base[2:3])
   expect_identical(x[2:4], base[3:5])
@@ -135,6 +152,13 @@ test_that("views can be sliced with subset2", {
   expect_error(x[[4]])
   expect_false(view_is_materialized(x))
 
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+
   base <- c("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(x[[1]], base[[2L]])
@@ -179,6 +203,13 @@ test_that("views can be manually materialized", {
   expect_true(view_is_materialized(x))
   expect_false(is_altrep(materialized))
 
+  base <- as.raw(c(1, 2, 3, 4))
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
+
   base <- c("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_false(view_is_materialized(x))
@@ -211,6 +242,11 @@ test_that("can make zero length view", {
   expect_identical(length(x), 0L)
 
   base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- as.raw(c(1, 2, 3, 4))
   x <- vec_view(base, start = 2L, size = 0L)
   expect_identical(x, base[0L])
   expect_identical(length(x), 0L)

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -18,6 +18,16 @@ test_that("views can be created", {
   x <- vec_view(base, start = 2L, size = 3L)
   expect_false(view_is_materialized(x))
   expect_identical(x, base[2:4])
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
+
+  base <- list("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_false(view_is_materialized(x))
+  expect_identical(x, base[2:4])
 })
 
 test_that("views have right length", {
@@ -34,6 +44,14 @@ test_that("views have right length", {
   expect_identical(length(x), 3L)
 
   base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(length(x), 3L)
+
+  base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(length(x), 3L)
 })
@@ -70,6 +88,22 @@ test_that("views can be sliced with subset", {
   expect_identical(x[0L], base[0L])
   expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
   expect_false(view_is_materialized(x))
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
+
+  base <- list("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[1:2], base[2:3])
+  expect_identical(x[2:4], base[3:5])
+  expect_identical(x[0L], base[0L])
+  expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
+  expect_false(view_is_materialized(x))
 })
 
 test_that("views can be sliced with subset2", {
@@ -95,6 +129,20 @@ test_that("views can be sliced with subset2", {
   expect_false(view_is_materialized(x))
 
   base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 3L)
+  expect_identical(x[[1]], base[[2L]])
+  expect_identical(x[[3]], base[[4L]])
+  expect_error(x[[4]])
+  expect_false(view_is_materialized(x))
+
+  base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(x[[1]], base[[2L]])
   expect_identical(x[[3]], base[[4L]])
@@ -130,28 +178,20 @@ test_that("views can be manually materialized", {
   materialized <- view_materialize(x)
   expect_true(view_is_materialized(x))
   expect_false(is_altrep(materialized))
-})
 
-test_that("view duplication causes a materialization", {
-  base <- c(TRUE, FALSE, TRUE, FALSE)
+  base <- c("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
-  expect_identical(x, base[0L])
-  expect_identical(length(x), 0L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
 
-  base <- c(1L, 2L, 3L, 4L)
+  base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
-  expect_identical(x, base[0L])
-  expect_identical(length(x), 0L)
-
-  base <- c(1, 2, 3, 4)
-  x <- vec_view(base, start = 2L, size = 3L)
-  expect_identical(x, base[0L])
-  expect_identical(length(x), 0L)
-
-  base <- c(1, 2, 3, 4) + 1i
-  x <- vec_view(base, start = 2L, size = 3L)
-  expect_identical(x, base[0L])
-  expect_identical(length(x), 0L)
+  expect_false(view_is_materialized(x))
+  materialized <- view_materialize(x)
+  expect_true(view_is_materialized(x))
+  expect_false(is_altrep(materialized))
 })
 
 test_that("can make zero length view", {
@@ -171,6 +211,16 @@ test_that("can make zero length view", {
   expect_identical(length(x), 0L)
 
   base <- c(1, 2, 3, 4) + 1i
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- c("a", "b", "c", "d")
+  x <- vec_view(base, start = 2L, size = 0L)
+  expect_identical(x, base[0L])
+  expect_identical(length(x), 0L)
+
+  base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 0L)
   expect_identical(x, base[0L])
   expect_identical(length(x), 0L)

--- a/tests/testthat/test-view.R
+++ b/tests/testthat/test-view.R
@@ -29,6 +29,7 @@ test_that("views can be created", {
   expect_false(view_is_materialized(x))
   expect_identical(x, base[2:4])
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_false(view_is_materialized(x))
@@ -60,6 +61,7 @@ test_that("views have right length", {
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(length(x), 3L)
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(length(x), 3L)
@@ -114,6 +116,7 @@ test_that("views can be sliced with subset", {
   expect_identical(x[c(0L, 2L)], base[c(0L, 3L)])
   expect_false(view_is_materialized(x))
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(x[1:2], base[2:3])
@@ -166,6 +169,7 @@ test_that("views can be sliced with subset2", {
   expect_error(x[[4]])
   expect_false(view_is_materialized(x))
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_identical(x[[1]], base[[2L]])
@@ -217,6 +221,7 @@ test_that("views can be assigned to", {
   expect_identical(x[2:3], assign)
   expect_identical(base, c("a", "b", "c", "d"))
 
+  skip_if_no_altlist()
   assign <- list(NA, "e")
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
@@ -274,6 +279,7 @@ test_that("views can wrap other views", {
   expect_identical(y, x[2:3])
   expect_false(view_is_materialized(x))
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 1L, size = 3L)
   y <- vec_view(x, start = 2L, size = 2L)
@@ -326,6 +332,7 @@ test_that("views can be manually materialized", {
   expect_true(view_is_materialized(x))
   expect_false(is_altrep(materialized))
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_false(view_is_materialized(x))
@@ -359,6 +366,7 @@ test_that("views can be inspected", {
   x <- vec_view(base, start = 2L, size = 3L)
   expect_snapshot(view_inspect(x))
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   expect_snapshot(view_inspect(x))
@@ -411,6 +419,7 @@ test_that("views can be roundtripped through serialization, and lose ALTREPness"
   expect_false(is_altrep(x))
   expect_identical(x, base[2:4])
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 3L)
   bytes <- serialize(x, connection = NULL)
@@ -450,6 +459,7 @@ test_that("can make zero length view", {
   expect_identical(x, base[0L])
   expect_identical(length(x), 0L)
 
+  skip_if_no_altlist()
   base <- list("a", "b", "c", "d")
   x <- vec_view(base, start = 2L, size = 0L)
   expect_identical(x, base[0L])


### PR DESCRIPTION
- [x] More tests?
- [ ] Hear back about `DATAPTR()` usage in character implementation
- [x] `Extract_subset` implementation? Or is the fallback good enough? (New approach is much faster even without `Extract_subset` due to faster `Elt` access with cached pointers, we really want base R to handle all the intricacies of this.)
- [x] Use `#define`s to section off code that doesn't work in older R versions, possibly bump minimal rlang R version
- [ ] Decide on `r_init_library_with_dll()` helper with Lionel
- [ ] Support R >=3.6?

Then
- [ ] Follow up PR to rename `r_vec_resize()` to `r_vec_grow()` and remove support for shrinking
    - [ ] Use ALTREP views in `r_dyn_unwrap()` in this PR

Adds support for ALTREP contiguous views, i.e. `vec_view(x, start, size)`, for the major R types

A few notes:
- `x` gets marked as not mutable on the way in
- No attributes are allowed on `x` right now
- The ALTREP classes are registered at load time but _need the dll_, so I had to introduce a new `r_init_library_with_dll()` helper that goes in your `R_init_<pkg>()` function (good to know if you are utilize the rlang C API). The ALTREP classes are registered with the `package` name, so if vctrs uses the rlang C API then it will register its own ALTREP view classes under the `"vctrs"` package name. I think this is a good thing.
- Serialization will force materialization, which I think is nice because it avoids us ever having to worry about "old" ALTREP view objects if we ever change the internal structure.


Here are important notes on the internal structure:


```c
/*
Structure of a `view`:
- `data1` is:
  - the original vector, before materialization
  - the materialized vector, after materialization
- `data2` is a RAWSXP holding a `r_view_metadata`
*/

struct r_view_metadata {
  // Whether or not the ALTREP view has been materialized.
  bool materialized;

  // The offset into the original data to start at.
  r_ssize start;

  // The size of the view.
  r_ssize size;

  // A read only pointer into the data, to save indirection costs. We typically
  // set this upon view creation, unless `x` is ALTREP, in which case we delay
  // setting it until the first `DATAPTR_RO()` request, to be friendly to
  // ALTREP types that we wrap. After materialization, it is always set.
  const void* v_data_read;

  // A write only pointer into the data, to save indirection costs.
  // Always `NULL` before materialization, and it set at materialization time.
  // Never set for lists or character vectors, as write pointers are unsafe.
  void* v_data_write;
};
```

Benchmarking - The most notable thing in the benchmarks is that slicing with a large slice can be up to 2x slower than native code due to `ExtractSubset()` in base R using the `*_Elt()` ALTREP method to extract out each element. I think it could be much more efficient by using `Dataptr_or_null()` to first see if it could get a cheap readonly dataptr to the altrep data (it can here, it's a view) and then using that directly. I plan to submit that patch or talk to Luke about it, then this difference would poof go away entirely.

Also note that the difference is mostly apparent only when a contiguous slice is made with `ExtractSubset()`, where native objects probably have 0 cache misses, but we have to go through an ALTREP method each time.  When you extract a _random_ slice of the same size, the timings actually tend to converge and cache misses become more important.

Otherwise I think it's pretty darn good!

``` r
# R-devel at the time
getRversion()
#> [1] '4.5.0'

# load rlang
devtools::load_all(path = "~/files/r/packages/rlang/")

# Identical test
# Currently `identical()` forces materialization due to usage of `INTEGER()`
# rather than `INTEGER_RO()`, booooo.
x <- c(1, 2, 3, 4)
y <- vec_view(x, start = 1, size = 4)
identical(x, y)
#> [1] TRUE
view_is_materialized(y)
#> [1] TRUE

# Object size test
# I think lobstr is more accurate here, there is a small fixed amount of overhead
# from the metadata. Nicely neither materialize the object.
x <- c(1, 2, 3, 4)
y <- vec_view(x, start = 1, size = 4)
object.size(x)
#> 80 bytes
object.size(y)
#> 80 bytes
lobstr::obj_size(x)
#> 80 B
lobstr::obj_size(y)
#> 776 B
view_is_materialized(y)
#> [1] FALSE


# Small view, 100 elements
base <- sample(1e6)
x <- base[1:100]
y <- vec_view(base, start = 1L, size = 100L)

is_altrep(y)
#> [1] TRUE
view_is_materialized(y)
#> [1] FALSE

# One element
bench::mark(
  x[[25L]],
  y[[25L]],
  iterations = 1000000
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x[[25L]]          0     41ns 23280892.        0B     69.8
#> 2 y[[25L]]          0     41ns 18932329.        0B     56.8

# A slice
bench::mark(
  x[10:60],
  y[10:60],
  iterations = 1000000
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x[10:60]      123ns    246ns  3228295.      512B     25.8
#> 2 y[10:60]      287ns    369ns  2216498.      512B     15.5

# Still not materialized!
view_is_materialized(y)
#> [1] FALSE

# Duplication currently forces materialization, I think this is something
# we can fix in base R. They use `INTEGER()` where I think they should use
# `INTEGER_RO()`. Returned object is not ALTREP.
z <- duplicate(y)
view_is_materialized(y)
#> [1] TRUE

is_altrep(z)
#> [1] FALSE

# A slice after materialization - still takes the same amount of time as before materialization
# (in both cases we use a cached readonly pointer to the data)
bench::mark(
  x[10:60],
  y[10:60],
  iterations = 1000000
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x[10:60]      123ns    246ns  3180695.      512B     22.3
#> 2 y[10:60]      287ns    369ns  2222617.      512B     13.3

# Large view, 1,000,000 elements
base <- sample(1e7)
x <- base[seq(from = 1000, length.out = 1000000)]
y <- vec_view(base, start = 1000, size = 1000000)

# Large slice (still roughly 2x slower, same as with small slice)
bench::mark(
  x[1:500000],
  y[1:500000],
  iterations = 1000
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x[1:5e+05] 909.54µs   1.17ms      822.    3.81MB     24.5
#> 2 y[1:5e+05]   2.19ms   2.42ms      413.    3.81MB     10.2

# Large slice, random index
# The difference goes away as cache misses tend to dominate instead
idx <- sample(1e7, 1e6)
bench::mark(
  x[idx],
  y[idx],
  iterations = 1000
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 x[idx]       2.19ms    2.4ms      408.    3.81MB    10.5 
#> 2 y[idx]       2.47ms   2.69ms      357.    3.81MB     8.78

# Still not materialized!
view_is_materialized(y)
#> [1] FALSE
```