### PR TITLE
Update link

### DIFF
--- a/R/standalone-downstream-deps.R
+++ b/R/standalone-downstream-deps.R
@@ -1,7 +1,7 @@
 # ---
 # repo: r-lib/rlang
 # file: standalone-downstream-deps.R
-# last-updated: 2022-01-19
+# last-updated: 2024-07-11
 # license: https://unlicense.org
 # ---
 #
@@ -13,6 +13,10 @@
 # outdated dep is being loaded.
 #
 # ## Changelog
+# 
+# 2024-07-11
+# 
+# * Correct link
 #
 # 2022-01-19:
 #
@@ -258,7 +262,7 @@ check_downstream <- function(ver,
   os <- tolower(Sys.info()[["sysname"]])
 
   if (os == "windows") {
-    url <- "https://github.com/jennybc/what-they-forgot/issues/62"
+    url <- "https://github.com/rstats-wtf/what-they-forgot/issues/62"
     c(
       i = sprintf("Please update %s to the latest version.", pkg),
       i = sprintf("Updating packages on Windows requires precautions:\n  <%s>", url)

--- a/R/standalone-linked-version.R
+++ b/R/standalone-linked-version.R
@@ -1,7 +1,7 @@
 # ---
 # repo: r-lib/rlang
 # file: standalone-linked-version.R
-# last-updated: 2022-05-26
+# last-updated: 2024-07-11
 # license: https://unlicense.org
 # imports: rlang (>= 1.0.0)
 # ---
@@ -16,7 +16,7 @@ check_linked_version <- local({
     os <- tolower(Sys.info()[["sysname"]])
 
     if (os == "windows") {
-      url <- "https://github.com/jennybc/what-they-forgot/issues/62"
+      url <- "https://github.com/rstats-wtf/what-they-forgot/issues/62"
       c(
         i = sprintf("Please update %s to the latest version.", pkg),
         i = sprintf("Updating packages on Windows requires precautions:\n  <%s>", url)

--- a/R/standalone-vctrs.R
+++ b/R/standalone-vctrs.R
@@ -1,7 +1,7 @@
 # ---
 # repo: r-lib/rlang
 # file: standalone-vctrs.R
-# last-updated: 2021-08-27
+# last-updated: 2024-04-17
 # license: https://unlicense.org
 # ---
 
@@ -16,11 +16,11 @@
 # 2024-04-17:
 # * `vec_recycle_common()` throws intended error when `size = 1` but input
 #   is larger.
-
+#
 # 2021-08-27:
 # * `vec_slice()` now preserves attributes of data frames and vectors.
 # * `vec_ptype2()` detects unspecified columns of data frames.
-
+#
 # 2021-08-26:
 # * Added compat for `vec_as_location()`.
 #


### PR DESCRIPTION
I encountered this message today while trying to do `devtools::load_all()` with rlang.

I never saw this before and have no idea what to do. I am using RStudio on Windows (the dev version 2024.07+292). rstudio/rstudio#13399

It seems that RStudio attempted to make a fix for this recently.

But it didn't seem to work. I don't really know how to trouble shoot.

Let me know if you have any tips

Edit: I fixed my issue with `remove.packages("rlang")` + reinstalled with R CMD INSTALL (build pane)
 