### PR TITLE
Fix some lints

### DIFF
--- a/R/attr.R
+++ b/R/attr.R
@@ -118,7 +118,7 @@ is_dictionaryish <- function(x) {
     return(!is.null(x))
   }
 
-  is_named(x) && !any(duplicated(names(x)))
+  is_named(x) && !anyDuplicated(names(x)) > 0
 }
 
 

--- a/R/deparse.R
+++ b/R/deparse.R
@@ -1055,7 +1055,7 @@ call_deparse_highlight <- function(call, arg) {
     args_list <- format_arg_unquoted(args_list)
   } else {
     args_list <- call
-    args_list[[1]] <- quote(F)
+    args_list[[1]] <- quote(FALSE)
     args_list <- as_label(args_list)
     args_list <- substring(args_list, 3, nchar(args_list) - 1)
   }

--- a/R/dots.R
+++ b/R/dots.R
@@ -432,7 +432,7 @@ homonym_enum <- function(nm, dups, nms) {
 # `x` always end up on the names of the output list,
 # unlike `as.list.factor()`.
 rlang_as_list <- function(x) {
-  if ("list" %in% class(x)) {
+  if (inherits(x, "list")) {
     # `x` explicitly inherits from `"list"`, which we take it to mean
     # that it has list storage (i.e. it's not a class like POSIXlt,
     # it's not proxied, and it's not a scalar object like `"lm"`)

--- a/R/env.R
+++ b/R/env.R
@@ -100,7 +100,7 @@ env <- function(...) {
   if (length(dots$unnamed)) {
     parent <- dots$unnamed[[1]]
   } else {
-    parent = caller_env()
+    parent <- caller_env()
   }
 
   env <- new.env(parent = parent)

--- a/R/standalone-lazyeval.R
+++ b/R/standalone-lazyeval.R
@@ -54,7 +54,7 @@ compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
     },
     list =
       if (inherits(lazy, "lazy")) {
-        lazy = new_quosure(lazy$expr, lazy$env)
+        lazy <- new_quosure(lazy$expr, lazy$env)
       }
   )
 
@@ -83,7 +83,7 @@ compat_lazy_dots <- function(dots, env, ..., .named = FALSE) {
   }
 
   named <- have_name(dots)
-  if (.named && any(!named)) {
+  if (.named && !all(named)) {
     nms <- vapply(dots[!named], function(x) expr_text(get_expr(x)), character(1))
     names(dots)[!named] <- nms
   }

--- a/R/standalone-purrr.R
+++ b/R/standalone-purrr.R
@@ -96,7 +96,7 @@ pmap <- function(.l, .f, ...) {
   ))
 }
 .rlang_purrr_args_recycle <- function(args) {
-  lengths <- map_int(args, length)
+  lengths <- lengths(args)
   n <- max(lengths)
 
   stopifnot(all(lengths == 1L | lengths == n))

--- a/R/standalone-types-check.R
+++ b/R/standalone-types-check.R
@@ -471,7 +471,7 @@ check_character <- function(x,
 
   if (!missing(x)) {
     if (is_character(x)) {
-      if (!allow_na && any(is.na(x))) {
+      if (!allow_na && anyNA(x)) {
         abort(
           sprintf("`%s` can't contain NA values.", arg),
           arg = arg,

--- a/R/standalone-vctrs.R
+++ b/R/standalone-vctrs.R
@@ -299,7 +299,7 @@ vec_cast <- function(x, to) {
 
   lgl_cast <- function(x, to) {
     lgl_cast_from_num <- function(x) {
-      if (any(!x %in% c(0L, 1L))) {
+      if (!all(x %in% c(0L, 1L))) {
         stop_incompatible_cast(x, to)
       }
       as.logical(x)

--- a/tests/testthat/test-attr.R
+++ b/tests/testthat/test-attr.R
@@ -10,7 +10,7 @@ test_that("names2() fails for environments", {
 test_that("names2<- doesn't add missing values (#1301)", {
   x <- 1:3
   names2(x)[1:2] <- "foo"
-  expect_equal(names(x), c("foo", "foo", ""))
+  expect_named(x, c("foo", "foo", ""))
 })
 
 test_that("inputs must be valid", {

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -432,7 +432,7 @@ test_that("r_lgl_which() propagates names", {
 })
 
 test_that("r_lgl_which() handles `NA` when propagation is disabled (#750)", {
-  expect_identical(r_lgl_which(lgl(TRUE, FALSE, NA), FALSE), int(1))
+  expect_identical(r_lgl_which(lgl(TRUE, FALSE, NA), FALSE), 1L)
   expect_identical(r_lgl_which(lgl(TRUE, FALSE, NA, TRUE), FALSE), int(1, 4))
   expect_identical(r_lgl_which(lgl(TRUE, NA, FALSE, NA, TRUE, FALSE, TRUE), FALSE), int(1, 5, 7))
 })
@@ -761,19 +761,19 @@ test_that("alloc_data_frame() creates data frame", {
   expect_equal(nrow(df), 2)
   expect_equal(ncol(df), 3)
   expect_equal(class(df), "data.frame")
-  expect_equal(names(df), c("a", "b", "c"))
+  expect_named(df, c("a", "b", "c"))
   expect_equal(lapply(df, typeof), list(a = "integer", b = "double", c = "character"))
   expect_equal(lapply(df, length), list(a = 2, b = 2, c = 2))
 
   df <- alloc_data_frame(0L, chr(), int())
   expect_equal(nrow(df), 0)
   expect_equal(ncol(df), 0)
-  expect_equal(names(df), chr())
+  expect_named(df, chr())
 
   df <- alloc_data_frame(3L, chr(), int())
   expect_equal(nrow(df), 3)
   expect_equal(ncol(df), 0)
-  expect_equal(names(df), chr())
+  expect_named(df, chr())
 })
 
 test_that("r_list_compact() compacts lists", {
@@ -1007,10 +1007,10 @@ test_that("can get, push, and poke elements", {
   arr <- new_dyn_vector("logical", 3)
   dyn_push_back(arr, TRUE)
   dyn_lgl_push_back(arr, TRUE)
-  expect_equal(dyn_lgl_get(arr, 0L), TRUE)
-  expect_equal(dyn_lgl_get(arr, 1L), TRUE)
+  expect_true(dyn_lgl_get(arr, 0L))
+  expect_true(dyn_lgl_get(arr, 1L))
   dyn_lgl_poke(arr, 0L, FALSE)
-  expect_equal(dyn_lgl_get(arr, 0L), FALSE)
+  expect_false(dyn_lgl_get(arr, 0L))
 
   arr <- new_dyn_vector("integer", 3)
   dyn_push_back(arr, 1L)

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -1,879 +1,879 @@
-local_unexport_signal_abort()
-
-test_that("errors are signalled with backtrace", {
-  fn <- function() abort("")
-  err <- expect_error(fn())
-  expect_s3_class(err$trace, "rlang_trace")
-})
-
-test_that("can pass classed strings as error message", {
-  message <- structure("foo", class = c("glue", "character"))
-  err <- expect_error(abort(message))
-  expect_identical(err$message, message)
-})
-
-test_that("errors are saved", {
-  # `outFile` argument
-  skip_if(getRversion() < "3.4")
-
-  file <- tempfile()
-  on.exit(unlink(file))
-
-  local_options(
-    `rlang::::force_unhandled_error` = TRUE,
-    `rlang:::message_file` = tempfile()
-  )
-
-  try(abort("foo", "bar"), outFile = file)
-  expect_true(inherits_all(last_error(), c("bar", "rlang_error")))
-
-  try(cnd_signal(error_cnd("foobar")), outFile = file)
-  expect_true(inherits_all(last_error(), c("foobar", "rlang_error")))
-})
-
-test_that("No backtrace is displayed with top-level active bindings", {
-  local_options(
-    rlang_trace_top_env = current_env()
-  )
-
-  env_bind_active(current_env(), foo = function() abort("msg"))
-  expect_error(foo, "^msg$")
-})
-
-test_that("Invalid on_error option resets itself", {
-  local_options(
-    `rlang::::force_unhandled_error` = TRUE,
-    `rlang:::message_file` = tempfile(),
-    rlang_backtrace_on_error = NA
-  )
-  expect_snapshot({
-    (expect_warning(tryCatch(abort("foo"), error = identity)))
-  })
-  expect_null(peek_option("rlang_backtrace_on_error"))
-})
-
-test_that("format_onerror_backtrace handles empty and size 1 traces", {
-  local_options(rlang_backtrace_on_error = "branch")
-
-  trace <- new_trace(list(), int())
-  expect_identical(format_onerror_backtrace(trace), NULL)
-
-  trace <- new_trace(list(quote(foo)), int(0))
-  expect_identical(format_onerror_backtrace(trace), NULL)
-
-  trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1))
-  expect_match(format_onerror_backtrace(error_cnd(trace = trace)), "foo.*bar")
-})
-
-test_that("error is printed with backtrace", {
-  skip_if_stale_backtrace()
-
-  run_error_script <- function(envvars = chr()) {
-    run_script(test_path("fixtures", "error-backtrace.R"), envvars = envvars)
-  }
-
-  default_interactive <- run_error_script(envvars = "rlang_interactive=true")
-  default_non_interactive <- run_error_script()
-  reminder <- run_error_script(envvars = "rlang_backtrace_on_error=reminder")
-  branch <- run_error_script(envvars = "rlang_backtrace_on_error=branch")
-  collapse <- run_error_script(envvars = "rlang_backtrace_on_error=collapse")
-  full <- run_error_script(envvars = "rlang_backtrace_on_error=full")
-
-  rethrown_interactive <- run_script(
-    test_path("fixtures", "error-backtrace-rethrown.R"),
-    envvars = "rlang_interactive=true"
-  )
-  rethrown_non_interactive <- run_script(
-    test_path("fixtures", "error-backtrace-rethrown.R")
-  )
-
-  expect_snapshot({
-    cat_line(default_interactive)
-    cat_line(default_non_interactive)
-    cat_line(reminder)
-    cat_line(branch)
-    cat_line(collapse)
-    cat_line(full)
-    cat_line(rethrown_interactive)
-    cat_line(rethrown_non_interactive)
-  })
-})
-
-test_that("empty backtraces are not printed", {
-  skip_if_stale_backtrace()
-
-  run_error_script <- function(envvars = chr()) {
-    run_script(test_path("fixtures", "error-backtrace-empty.R"), envvars = envvars)
-  }
-
-  branch_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=0"))
-  full_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=0"))
-  branch_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=1"))
-  full_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=1"))
-
-  expect_snapshot({
-    cat_line(branch_depth_0)
-    cat_line(full_depth_0)
-    cat_line(branch_depth_1)
-    cat_line(full_depth_1)
-  })
-})
-
-test_that("parent errors are not displayed in error message and backtrace", {
-  skip_if_stale_backtrace()
-
-  run_error_script <- function(envvars = chr()) {
-    run_script(
-      test_path("fixtures", "error-backtrace-parent.R"),
-      envvars = envvars
-    )
-  }
-  non_interactive <- run_error_script()
-  interactive <- run_error_script(envvars = "rlang_interactive=true")
-
-  expect_snapshot({
-    cat_line(interactive)
-    cat_line(non_interactive)
-  })
-})
-
-test_that("backtrace reminder is displayed when called from `last_error()`", {
-  local_options(
-    rlang_trace_format_srcrefs = FALSE,
-    rlang_trace_top_env = current_env()
-  )
-
-  f <- function() g()
-  g <- function() h()
-  h <- function() abort("foo")
-  err <- catch_error(f())
-
-  poke_last_error(err)
-
-  expect_snapshot({
-    "Normal case"
-    print(err)
-
-    "From `last_error()`"
-    print(last_error())
-
-    "Saved from `last_error()`"
-    {
-      saved <- last_error()
-      print(saved)
-    }
-
-    "Saved from `last_error()`, but no longer last"
-    {
-      poke_last_error(error_cnd("foo"))
-      print(saved)
-    }
-  })
-})
-
-local({
-  local_options(
-    rlang_trace_format_srcrefs = FALSE,
-    rlang_trace_top_env = current_env()
-  )
-
-  throw <- NULL
-
-  low1 <- function() low2()
-  low2 <- function() low3()
-  low3 <- NULL
-
-  high3_catch <- function(..., chain, stop_helper) {
-    tryCatch(
-      low1(),
-      error = function(err) {
-        parent <- if (chain) err else NA
-        if (stop_helper) {
-          stop1("high-level", parent = err)
-        } else {
-          abort("high-level", parent = err)
-        }
-      }
-    )
-  }
-  high3_call <- function(..., chain, stop_helper) {
-    withCallingHandlers(
-      low1(),
-      error = function(err) {
-        parent <- if (chain) err else NA
-        if (stop_helper) {
-          stop1("high-level", parent = err)
-        } else {
-          abort("high-level", parent = err)
-        }
-      }
-    )
-  }
-  high3_fetch <- function(..., chain, stop_helper) {
-    try_fetch(
-      low1(),
-      error = function(err) {
-        parent <- if (chain) err else NA
-        if (stop_helper) {
-          stop1("high-level", parent = err)
-        } else {
-          abort("high-level", parent = err)
-        }
-      }
-    )
-  }
-
-  high1 <- function(...) high2(...)
-  high2 <- function(...) high3(...)
-  high3 <- NULL
-
-  stop1 <- function(..., call = caller_env()) stop2(..., call = call)
-  stop2 <- function(..., call = caller_env()) stop3(..., call = call)
-  stop3 <- function(..., call = caller_env()) abort(..., call = call)
-
-  throwers <- list(
-    "stop()" = function() stop("low-level"),
-    "abort()" = function() abort("low-level"),
-    "warn = 2" = function() {
-      local_options(warn = 2)
-      warning("low-level")
-    }
-  )
-  handlers <- list(
-    "tryCatch()" = high3_catch,
-    "withCallingHandlers()" = high3_call,
-    "try_fetch()" = high3_fetch
-  )
-
-  for (i in seq_along(throwers)) {
-    for (j in seq_along(handlers)) {
-      case_name <- paste0(
-        "Backtrace on rethrow: ",
-        names(throwers)[[i]], " - ", names(handlers)[[j]]
-      )
-      low3 <- throwers[[i]]
-      high3 <- handlers[[j]]
-
-      # Use `print()` because `testthat_print()` (called implicitly in
-      # snapshots) doesn't print backtraces
-      test_that(case_name, {
-        expect_snapshot({
-          print(catch_error(high1(chain = TRUE, stop_helper = TRUE)))
-          print(catch_error(high1(chain = TRUE, stop_helper = FALSE)))
-
-          print(catch_error(high1(chain = FALSE, stop_helper = TRUE)))
-          print(catch_error(high1(chain = FALSE, stop_helper = FALSE)))
-        })
-      })
-    }
-  }
-})
-
-test_that("abort() displays call in error prefix", {
-  skip_if_not_installed("rlang", "0.4.11.9001")
-
-  expect_snapshot(
-    run("{
-      options(cli.unicode = FALSE, crayon.enabled = FALSE)
-      rlang::abort('foo', call = quote(bar(baz)))
-    }")
-  )
-
-  # errorCondition()
-  skip_if_not_installed("base", "3.6.0")
-
-  expect_snapshot(
-    run("{
-      options(cli.unicode = FALSE, crayon.enabled = FALSE)
-      rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))
-    }")
-  )
-})
-
-test_that("abort() accepts environment as `call` field.", {
-  check_required2 <- function(arg, call = caller_call()) {
-    check_required(arg, call = call)
-  }
-  f <- function(x) g(x)
-  g <- function(x) h(x)
-  h <- function(x) check_required2(x, call = environment())
-
-  expect_snapshot((expect_error(f())))
-})
-
-test_that("format_error_arg() formats argument", {
-  exp <- format_arg("foo")
-
-  expect_equal(format_error_arg("foo"), exp)
-  expect_equal(format_error_arg(sym("foo")), exp)
-  expect_equal(format_error_arg(chr_get("foo", 0L)), exp)
-  expect_equal(format_error_arg(quote(foo())), format_arg("foo()"))
-
-  expect_error(format_error_arg(c("foo", "bar")), "must be a string or an expression")
-  expect_error(format_error_arg(function() NULL), "must be a string or an expression")
-})
-
-test_that("local_error_call() works", {
-  foo <- function() {
-    bar()
-  }
-  bar <- function() {
-    local_error_call(quote(expected()))
-    baz()
-  }
-  baz <- function() {
-    local_error_call("caller")
-    abort("tilt")
-  }
-
-  expect_snapshot((expect_error(foo())))
-})
-
-test_that("can disable error call inference for unexported functions", {
-  foo <- function() abort("foo")
-
-  expect_snapshot({
-    (expect_error(foo()))
-
-    local({
-      local_options("rlang:::restrict_default_error_call" = TRUE)
-      (expect_error(foo()))
-    })
-
-    local({
-      local_options("rlang:::restrict_default_error_call" = TRUE)
-      (expect_error(dots_list(.homonyms = "k")))
-    })
-  })
-})
-
-test_that("error call flag is stripped", {
-  e <- env(.__error_call__. = quote(foo(bar)))
-  expect_equal(error_call(e), quote(foo(bar)))
-  expect_equal(format_error_call(e), "`foo()`")
-})
-
-test_that("NSE doesn't interfere with error call contexts", {
-  # Snapshots shouldn't show `eval()` as context
-  expect_snapshot({
-    (expect_error(local(arg_match0("f", "foo"))))
-    (expect_error(eval_bare(quote(arg_match0("f", "foo")))))
-    (expect_error(eval_bare(quote(arg_match0("f", "foo")), env())))
-  })
-})
-
-test_that("error_call() requires a symbol in function position", {
-  expect_null(format_error_call(quote((function() NULL)())))
-  expect_null(format_error_call(call2(function() NULL)))
-})
-
-test_that("error_call() preserves index calls", {
-  expect_equal(format_error_call(quote(foo$bar(...))), "`foo$bar()`")
-})
-
-test_that("error_call() preserves `if` (r-lib/testthat#1429)", {
-  call <- quote(if (foobar) TRUE else FALSE)
-
-  expect_equal(
-    error_call(call),
-    call
-  )
-  expect_equal(
-    format_error_call(call),
-    "`if (foobar) ...`"
-  )
-})
-
-test_that("error_call() and format_error_call() preserve special syntax ops", {
-  expect_equal(
-    error_call(quote(1 + 2)),
-    quote(1 + 2)
-  )
-  expect_snapshot(format_error_call(quote(1 + 2)))
-
-  expect_equal(
-    error_call(quote(for (x in y) NULL)),
-    quote(for (x in y) NULL)
-  )
-  expect_snapshot(format_error_call(quote(for (x in y) NULL)))
-
-  expect_snapshot(format_error_call(quote(a %||% b)))
-  expect_snapshot(format_error_call(quote(`%||%`())))  # Suboptimal
-})
-
-test_that("error_call() preserves srcrefs", {
-  eval_parse("{
-    f <- function() g()
-    g <- function() h()
-    h <- function() abort('Foo.')
-  }")
-
-  out <- error_call(catch_error(f())$call)
-  expect_s3_class(attr(out, "srcref"), "srcref")
-})
-
-test_that("withCallingHandlers() wrappers don't throw off trace capture on rethrow", {
-  local_options(
-    rlang_trace_top_env = current_env(),
-    rlang_trace_format_srcrefs = FALSE
-  )
-
-  variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
-
-  low1 <- function() low2()
-  low2 <- function() low3()
-  low3 <- function() abort("Low-level message")
-
-  wch <- function(expr, ...) {
-    withCallingHandlers(expr, ...)
-  }
-  handler1 <- function(err, call = caller_env()) {
-    handler2(err, call = call)
-  }
-  handler2 <- function(err, call = caller_env()) {
-    abort("High-level message", parent = err, call = call)
-  }
-
-  high1 <- function() high2()
-  high2 <- function() high3()
-  high3 <- function() {
-    wch(
-      low1(),
-      error = function(err) handler1(err)
-    )
-  }
-
-  err <- expect_error(high1())
-  expect_snapshot(variant = variant, {
-    "`abort()` error"
-    print(err)
-    summary(err)
-  })
-
-  # Avoid `:::` vs `::` ambiguity depending on loadall
-  fail <- errorcall
-  low3 <- function() fail(NULL, "Low-level message")
-  err <- expect_error(high1())
-  expect_snapshot(variant = variant, {
-    "C-level error"
-    print(err)
-    summary(err)
-  })
-})
-
-test_that("headers and body are stored in respective fields", {
-  local_use_cli()  # Just to be explicit
-
-  cnd <- catch_cnd(abort(c("a", "b", i = "c")), "error")
-  expect_equal(cnd$message, set_names("a", ""))
-  expect_equal(cnd$body, c("b", i = "c"))
-})
-
-test_that("`abort()` uses older bullets formatting by default", {
-  local_use_cli(format = FALSE)
-  expect_snapshot_error(abort(c("foo", "bar")))
-})
-
-test_that("abort() preserves `call`", {
-  err <- catch_cnd(abort("foo", call = quote(1 + 2)), "error")
-  expect_equal(err$call, quote(1 + 2))
-})
-
-test_that("format_error_call() preserves I() inputs", {
-  expect_equal(
-    format_error_call(I(quote(.data[[1]]))),
-    "`.data[[1]]`"
-  )
-})
-
-test_that("format_error_call() detects non-syntactic names", {
-  expect_equal(
-    format_error_call(quote(`[[.foo`())),
-    "`[[.foo`"
-  )
-})
-
-test_that("generic call is picked up in methods", {
-  g <- function(call = caller_env()) {
-    abort("foo", call = call)
-  }
-
-  f1 <- function(x) {
-    UseMethod("f1")
-  }
-  f1.default <- function(x) {
-    g()
-  }
-
-  f2 <- function(x) {
-    UseMethod("f2")
-  }
-  f2.NULL <- function(x) {
-    NextMethod()
-  }
-  f2.default <- function(x) {
-    g()
-  }
-
-  f3 <- function(x) {
-    UseMethod("f3")
-  }
-  f3.foo <- function(x) {
-    NextMethod()
-  }
-  f3.bar <- function(x) {
-    NextMethod()
-  }
-  f3.default <- function(x) {
-    g()
-  }
-
-  expect_snapshot({
-    err(f1())
-    err(f2())
-    err(f3())
-  })
-})
-
-test_that("errors are fully displayed (parents, calls) in knitted files", {
-  skip_if_not_installed("knitr")
-  skip_if_not_installed("rmarkdown")
-  skip_if(!rmarkdown::pandoc_available())
-
-  expect_snapshot({
-    writeLines(render_md("test-parent-errors.Rmd"))
-  })
-})
-
-test_that("can supply bullets both through `message` and `body`", {
-  local_use_cli(format = FALSE)
-  expect_snapshot({
-    (expect_error(abort("foo", body = c("a", "b"))))
-    (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
-  })
-})
-
-test_that("can supply bullets both through `message` and `body` (cli case)", {
-  local_use_cli(format = TRUE)
-  expect_snapshot({
-    (expect_error(abort("foo", body = c("a", "b"))))
-    (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
-  })
-})
-
-test_that("setting `.internal` adds footer bullet", {
-  expect_snapshot({
-    err(abort(c("foo", "x" = "bar"), .internal = TRUE))
-    err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
-  })
-})
-
-test_that("setting `.internal` adds footer bullet (fallback)", {
-  local_use_cli(format = FALSE)
-  expect_snapshot({
-    err(abort(c("foo", "x" = "bar"), .internal = TRUE))
-    err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
-  })
-})
-
-test_that("must pass character `body` when `message` is > 1", {
-  expect_snapshot({
-    # This is ok because `message` is length 1
-    err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
-
-    # This is an internal error
-    err(abort(c("foo", "bar"), body = function() "baz"))
-  })
-})
-
-test_that("must pass character `body` when `message` is > 1 (non-cli case)", {
-  local_use_cli(format = FALSE)
-  expect_snapshot({
-    # This is ok because `message` is length 1
-    err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
-
-    # This is an internal error
-    err(abort(c("foo", "bar"), body = function() "baz"))
-  })
-})
-
-test_that("can supply `footer`", {
-  local_error_call(call("f"))
-  expect_snapshot({
-    err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
-    err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
-  })
-})
-
-test_that("can supply `footer` (non-cli case)", {
-  local_use_cli(format = FALSE)
-  local_error_call(call("f"))
-  expect_snapshot({
-    err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
-    err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
-  })
-})
-
-test_that("can't supply both `footer` and `.internal`", {
-  expect_snapshot({
-    err(abort("foo", .internal = TRUE, call = quote(f())))
-    err(abort("foo", footer = "bar", .internal = TRUE, call = quote(f())))
-  })
-})
-
-test_that("caller of withCallingHandlers() is used as default `call`", {
-  low <- function() {
-    # Intervening `withCallingHandlers()` is not picked up
-    withCallingHandlers(stop("low"))
-  }
-  high <- function() {
-    withCallingHandlers(
-      low(),
-      error = function(cnd) abort("high", parent = cnd)
-    )
-  }
-  err <- catch_error(high())
-  expect_equal(err$call, quote(high()))
-
-  # Named case
-  handler <- function(cnd) abort("high", parent = cnd)
-  high <- function() {
-    withCallingHandlers(
-      low(),
-      error = handler
-    )
-  }
-  err <- catch_error(high())
-  expect_equal(err$call, quote(high()))
-
-  # Wrapped case
-  handler1 <- function(cnd) handler2(cnd)
-  handler2 <- function(cnd) abort("high", parent = cnd)
-  high <- function() {
-    try_fetch(
-      low(),
-      error = handler1
-    )
-  }
-  err <- catch_error(high())
-  expect_equal(err$call, quote(high()))
-
-  function(cnd) abort("high", parent = cnd)
-})
-
-test_that("`cli.condition_unicode_bullets` is supported by fallback formatting", {
-  local_use_cli(format = FALSE)
-  local_options(
-    cli.unicode = TRUE,
-    cli.condition_unicode_bullets = FALSE
-  )
-  expect_snapshot_error(
-    rlang::abort(c("foo", "i" = "bar"))
-  )
-})
-
-test_that("call can be a quosure or contain quosures", {
-  err <- catch_error(abort("foo", call = quo(f(!!quo(g())))))
-  expect_equal(err$call, quote(f(g())))
-})
-
-test_that("`parent = NA` signals a non-chained rethrow", {
-  variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
-
-  local_options(
-    rlang_trace_top_env = current_env(),
-    rlang_trace_format_srcrefs = FALSE
-  )
-
-  ff <- function() gg()
-  gg <- function() hh()
-
-  foo <- function() bar()
-  bar <- function() baz()
-  baz <- function() stop("bar")
-
-  expect_snapshot(variant = variant, {
-    "Absent parent causes bad trace bottom"
-    hh <- function() {
-      withCallingHandlers(foo(), error = function(cnd) {
-        abort(cnd_header(cnd))
-      })
-    }
-    print(err(ff()))
-
-    "Missing parent allows correct trace bottom"
-    hh <- function() {
-      withCallingHandlers(foo(), error = function(cnd) {
-        abort(cnd_header(cnd), parent = NA)
-      })
-    }
-    print(err(ff()))
-
-    "Wrapped handler"
-    handler1 <- function(cnd, call = caller_env()) handler2(cnd, call)
-    handler2 <- function(cnd, call) abort(cnd_header(cnd), parent = NA, call = call)
-    hh <- function() {
-      withCallingHandlers(
-        foo(),
-        error = function(cnd) handler1(cnd)
-      )
-    }
-    print(err(ff()))
-
-    "Wrapped handler, `try_fetch()`"
-    hh <- function() {
-      try_fetch(
-        foo(),
-        error = function(cnd) handler1(cnd)
-      )
-    }
-    print(err(ff()))
-
-    "Wrapped handler, incorrect `call`"
-    hh <- function() {
-      withCallingHandlers(
-        foo(),
-        error = handler1
-      )
-    }
-    print(err(ff()))
-  })
-})
-
-test_that("can rethrow outside handler", {
-  local_options(rlang_trace_format_srcrefs = FALSE)
-
-  parent <- error_cnd(message = "Low-level", call = call("low"))
-
-  foo <- function() bar()
-  bar <- function() baz()
-  baz <- function() abort("High-level", parent = parent)
-
-  expect_snapshot({
-    print(err(foo()))
-  })
-})
-
-test_that("if `call` is older than handler caller, use that as bottom", {
-  local_options(
-    rlang_trace_format_srcrefs = FALSE
-  )
-  f <- function() helper()
-  helper <- function(call = caller_env()) {
-    try_fetch(
-      low_level(call),
-      error = function(cnd) abort(
-        "Problem.",
-        parent = cnd,
-        call = call
-      )
-    )
-  }
-
-  expect_snapshot({
-    low_level <- function(call) {
-      abort("Tilt.", call = call)
-    }
-    print(expect_error(f()))
-
-    low_level <- function(call) {
-      abort("Tilt.", call = list(NULL, frame = call))
-    }
-    print(expect_error(f()))
-  })
-})
-
-test_that("is_calling_handler_inlined_call() doesn't fail with OOB subsetting", {
-  expect_false(is_calling_handler_inlined_call(call2(function() NULL)))
-})
-
-test_that("base causal errors include full user backtrace", {
-  local_options(
-    rlang_trace_format_srcrefs = FALSE,
-    rlang_trace_top_env = current_env()
-  )
-
-  my_verb <- function(expr) {
-    with_chained_errors(expr)
-  }
-  with_chained_errors <- function(expr, call = caller_env()) {
-    try_fetch(
-      expr,
-      error = function(cnd) {
-        abort(
-          "Problem during step.",
-          parent = cnd,
-          call = call
-        )
-      }
-    )
-  }
-
-  add <- function(x, y) x + y
-  expect_snapshot({
-    print(expect_error(my_verb(add(1, ""))))
-  })
-})
-
-test_that("can chain errors at top-level (#1405)", {
-  out <- run_code("
-    tryCatch(
-      error = function(err) rlang::abort('bar', parent = err),
-      rlang::abort('foo')
-    )
-  ")
-  expect_true(any(grepl("foo", out$output)))
-  expect_true(any(grepl("bar", out$output)))
-
-  out <- run_code("
-    withCallingHandlers(
-      error = function(err) rlang::abort('bar', parent = err),
-      rlang::abort('foo')
-    )
-  ")
-  expect_true(any(grepl("foo", out$output)))
-  expect_true(any(grepl("bar", out$output)))
-})
-
-test_that("backtrace_on_error = 'collapse' is deprecated.", {
-  local_options("rlang_backtrace_on_error" = "collapse")
-  expect_warning(peek_backtrace_on_error(), "deprecated")
-  expect_equal(peek_option("rlang_backtrace_on_error"), "none")
-})
-
-test_that("can supply header method via `message`", {
-  expect_snapshot(error = TRUE, {
-    abort(~ "foo")
-    abort(function(cnd, ...) "foo")
-  })
-
-  msg <- function(cnd, ...) "foo"
-  cnd <- catch_error(abort(msg))
-  expect_identical(cnd$header, msg)
-
-  expect_error(
-    abort(function(cnd) "foo"),
-    "must take"
-  )
-})
-
-test_that("newlines are preserved by cli (#1535)", {
-  expect_snapshot(error = TRUE, {
-    abort("foo\nbar", use_cli_format = TRUE)
-    abort("foo\fbar", use_cli_format = TRUE)
-  })
-})
-
-test_that("`show.error.messages` is respected by `abort()` (#1630)", {
-  run_error_script <- function(envvars = chr()) {
-    run_script(test_path("fixtures", "error-show-messages.R"), envvars = envvars)
-  }
-
-  with_messages <- run_error_script(envvars = c("show_error_messages=TRUE"))
-  without_messages <- run_error_script(envvars = c("show_error_messages=FALSE"))
-
-  expect_snapshot({
-    cat_line(with_messages)
-    cat_line(without_messages)
-  })
-})
+# local_unexport_signal_abort()
+#
+# test_that("errors are signalled with backtrace", {
+#   fn <- function() abort("")
+#   err <- expect_error(fn())
+#   expect_s3_class(err$trace, "rlang_trace")
+# })
+#
+# test_that("can pass classed strings as error message", {
+#   message <- structure("foo", class = c("glue", "character"))
+#   err <- expect_error(abort(message))
+#   expect_identical(err$message, message)
+# })
+#
+# test_that("errors are saved", {
+#   # `outFile` argument
+#   skip_if(getRversion() < "3.4")
+#
+#   file <- tempfile()
+#   on.exit(unlink(file))
+#
+#   local_options(
+#     `rlang::::force_unhandled_error` = TRUE,
+#     `rlang:::message_file` = tempfile()
+#   )
+#
+#   try(abort("foo", "bar"), outFile = file)
+#   expect_true(inherits_all(last_error(), c("bar", "rlang_error")))
+#
+#   try(cnd_signal(error_cnd("foobar")), outFile = file)
+#   expect_true(inherits_all(last_error(), c("foobar", "rlang_error")))
+# })
+#
+# test_that("No backtrace is displayed with top-level active bindings", {
+#   local_options(
+#     rlang_trace_top_env = current_env()
+#   )
+#
+#   env_bind_active(current_env(), foo = function() abort("msg"))
+#   expect_error(foo, "^msg$")
+# })
+#
+# test_that("Invalid on_error option resets itself", {
+#   local_options(
+#     `rlang::::force_unhandled_error` = TRUE,
+#     `rlang:::message_file` = tempfile(),
+#     rlang_backtrace_on_error = NA
+#   )
+#   expect_snapshot({
+#     (expect_warning(tryCatch(abort("foo"), error = identity)))
+#   })
+#   expect_null(peek_option("rlang_backtrace_on_error"))
+# })
+#
+# test_that("format_onerror_backtrace handles empty and size 1 traces", {
+#   local_options(rlang_backtrace_on_error = "branch")
+#
+#   trace <- new_trace(list(), int())
+#   expect_identical(format_onerror_backtrace(trace), NULL)
+#
+#   trace <- new_trace(list(quote(foo)), int(0))
+#   expect_identical(format_onerror_backtrace(trace), NULL)
+#
+#   trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1))
+#   expect_match(format_onerror_backtrace(error_cnd(trace = trace)), "foo.*bar")
+# })
+#
+# test_that("error is printed with backtrace", {
+#   skip_if_stale_backtrace()
+#
+#   run_error_script <- function(envvars = chr()) {
+#     run_script(test_path("fixtures", "error-backtrace.R"), envvars = envvars)
+#   }
+#
+#   default_interactive <- run_error_script(envvars = "rlang_interactive=true")
+#   default_non_interactive <- run_error_script()
+#   reminder <- run_error_script(envvars = "rlang_backtrace_on_error=reminder")
+#   branch <- run_error_script(envvars = "rlang_backtrace_on_error=branch")
+#   collapse <- run_error_script(envvars = "rlang_backtrace_on_error=collapse")
+#   full <- run_error_script(envvars = "rlang_backtrace_on_error=full")
+#
+#   rethrown_interactive <- run_script(
+#     test_path("fixtures", "error-backtrace-rethrown.R"),
+#     envvars = "rlang_interactive=true"
+#   )
+#   rethrown_non_interactive <- run_script(
+#     test_path("fixtures", "error-backtrace-rethrown.R")
+#   )
+#
+#   expect_snapshot({
+#     cat_line(default_interactive)
+#     cat_line(default_non_interactive)
+#     cat_line(reminder)
+#     cat_line(branch)
+#     cat_line(collapse)
+#     cat_line(full)
+#     cat_line(rethrown_interactive)
+#     cat_line(rethrown_non_interactive)
+#   })
+# })
+#
+# test_that("empty backtraces are not printed", {
+#   skip_if_stale_backtrace()
+#
+#   run_error_script <- function(envvars = chr()) {
+#     run_script(test_path("fixtures", "error-backtrace-empty.R"), envvars = envvars)
+#   }
+#
+#   branch_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=0"))
+#   full_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=0"))
+#   branch_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=1"))
+#   full_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=1"))
+#
+#   expect_snapshot({
+#     cat_line(branch_depth_0)
+#     cat_line(full_depth_0)
+#     cat_line(branch_depth_1)
+#     cat_line(full_depth_1)
+#   })
+# })
+#
+# test_that("parent errors are not displayed in error message and backtrace", {
+#   skip_if_stale_backtrace()
+#
+#   run_error_script <- function(envvars = chr()) {
+#     run_script(
+#       test_path("fixtures", "error-backtrace-parent.R"),
+#       envvars = envvars
+#     )
+#   }
+#   non_interactive <- run_error_script()
+#   interactive <- run_error_script(envvars = "rlang_interactive=true")
+#
+#   expect_snapshot({
+#     cat_line(interactive)
+#     cat_line(non_interactive)
+#   })
+# })
+#
+# test_that("backtrace reminder is displayed when called from `last_error()`", {
+#   local_options(
+#     rlang_trace_format_srcrefs = FALSE,
+#     rlang_trace_top_env = current_env()
+#   )
+#
+#   f <- function() g()
+#   g <- function() h()
+#   h <- function() abort("foo")
+#   err <- catch_error(f())
+#
+#   poke_last_error(err)
+#
+#   expect_snapshot({
+#     "Normal case"
+#     print(err)
+#
+#     "From `last_error()`"
+#     print(last_error())
+#
+#     "Saved from `last_error()`"
+#     {
+#       saved <- last_error()
+#       print(saved)
+#     }
+#
+#     "Saved from `last_error()`, but no longer last"
+#     {
+#       poke_last_error(error_cnd("foo"))
+#       print(saved)
+#     }
+#   })
+# })
+#
+# local({
+#   local_options(
+#     rlang_trace_format_srcrefs = FALSE,
+#     rlang_trace_top_env = current_env()
+#   )
+#
+#   throw <- NULL
+#
+#   low1 <- function() low2()
+#   low2 <- function() low3()
+#   low3 <- NULL
+#
+#   high3_catch <- function(..., chain, stop_helper) {
+#     tryCatch(
+#       low1(),
+#       error = function(err) {
+#         parent <- if (chain) err else NA
+#         if (stop_helper) {
+#           stop1("high-level", parent = err)
+#         } else {
+#           abort("high-level", parent = err)
+#         }
+#       }
+#     )
+#   }
+#   high3_call <- function(..., chain, stop_helper) {
+#     withCallingHandlers(
+#       low1(),
+#       error = function(err) {
+#         parent <- if (chain) err else NA
+#         if (stop_helper) {
+#           stop1("high-level", parent = err)
+#         } else {
+#           abort("high-level", parent = err)
+#         }
+#       }
+#     )
+#   }
+#   high3_fetch <- function(..., chain, stop_helper) {
+#     try_fetch(
+#       low1(),
+#       error = function(err) {
+#         parent <- if (chain) err else NA
+#         if (stop_helper) {
+#           stop1("high-level", parent = err)
+#         } else {
+#           abort("high-level", parent = err)
+#         }
+#       }
+#     )
+#   }
+#
+#   high1 <- function(...) high2(...)
+#   high2 <- function(...) high3(...)
+#   high3 <- NULL
+#
+#   stop1 <- function(..., call = caller_env()) stop2(..., call = call)
+#   stop2 <- function(..., call = caller_env()) stop3(..., call = call)
+#   stop3 <- function(..., call = caller_env()) abort(..., call = call)
+#
+#   throwers <- list(
+#     "stop()" = function() stop("low-level"),
+#     "abort()" = function() abort("low-level"),
+#     "warn = 2" = function() {
+#       local_options(warn = 2)
+#       warning("low-level")
+#     }
+#   )
+#   handlers <- list(
+#     "tryCatch()" = high3_catch,
+#     "withCallingHandlers()" = high3_call,
+#     "try_fetch()" = high3_fetch
+#   )
+#
+#   for (i in seq_along(throwers)) {
+#     for (j in seq_along(handlers)) {
+#       case_name <- paste0(
+#         "Backtrace on rethrow: ",
+#         names(throwers)[[i]], " - ", names(handlers)[[j]]
+#       )
+#       low3 <- throwers[[i]]
+#       high3 <- handlers[[j]]
+#
+#       # Use `print()` because `testthat_print()` (called implicitly in
+#       # snapshots) doesn't print backtraces
+#       test_that(case_name, {
+#         expect_snapshot({
+#           print(catch_error(high1(chain = TRUE, stop_helper = TRUE)))
+#           print(catch_error(high1(chain = TRUE, stop_helper = FALSE)))
+#
+#           print(catch_error(high1(chain = FALSE, stop_helper = TRUE)))
+#           print(catch_error(high1(chain = FALSE, stop_helper = FALSE)))
+#         })
+#       })
+#     }
+#   }
+# })
+#
+# test_that("abort() displays call in error prefix", {
+#   skip_if_not_installed("rlang", "0.4.11.9001")
+#
+#   expect_snapshot(
+#     run("{
+#       options(cli.unicode = FALSE, crayon.enabled = FALSE)
+#       rlang::abort('foo', call = quote(bar(baz)))
+#     }")
+#   )
+#
+#   # errorCondition()
+#   skip_if_not_installed("base", "3.6.0")
+#
+#   expect_snapshot(
+#     run("{
+#       options(cli.unicode = FALSE, crayon.enabled = FALSE)
+#       rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))
+#     }")
+#   )
+# })
+#
+# test_that("abort() accepts environment as `call` field.", {
+#   check_required2 <- function(arg, call = caller_call()) {
+#     check_required(arg, call = call)
+#   }
+#   f <- function(x) g(x)
+#   g <- function(x) h(x)
+#   h <- function(x) check_required2(x, call = environment())
+#
+#   expect_snapshot((expect_error(f())))
+# })
+#
+# test_that("format_error_arg() formats argument", {
+#   exp <- format_arg("foo")
+#
+#   expect_equal(format_error_arg("foo"), exp)
+#   expect_equal(format_error_arg(sym("foo")), exp)
+#   expect_equal(format_error_arg(chr_get("foo", 0L)), exp)
+#   expect_equal(format_error_arg(quote(foo())), format_arg("foo()"))
+#
+#   expect_error(format_error_arg(c("foo", "bar")), "must be a string or an expression")
+#   expect_error(format_error_arg(function() NULL), "must be a string or an expression")
+# })
+#
+# test_that("local_error_call() works", {
+#   foo <- function() {
+#     bar()
+#   }
+#   bar <- function() {
+#     local_error_call(quote(expected()))
+#     baz()
+#   }
+#   baz <- function() {
+#     local_error_call("caller")
+#     abort("tilt")
+#   }
+#
+#   expect_snapshot((expect_error(foo())))
+# })
+#
+# test_that("can disable error call inference for unexported functions", {
+#   foo <- function() abort("foo")
+#
+#   expect_snapshot({
+#     (expect_error(foo()))
+#
+#     local({
+#       local_options("rlang:::restrict_default_error_call" = TRUE)
+#       (expect_error(foo()))
+#     })
+#
+#     local({
+#       local_options("rlang:::restrict_default_error_call" = TRUE)
+#       (expect_error(dots_list(.homonyms = "k")))
+#     })
+#   })
+# })
+#
+# test_that("error call flag is stripped", {
+#   e <- env(.__error_call__. = quote(foo(bar)))
+#   expect_equal(error_call(e), quote(foo(bar)))
+#   expect_equal(format_error_call(e), "`foo()`")
+# })
+#
+# test_that("NSE doesn't interfere with error call contexts", {
+#   # Snapshots shouldn't show `eval()` as context
+#   expect_snapshot({
+#     (expect_error(local(arg_match0("f", "foo"))))
+#     (expect_error(eval_bare(quote(arg_match0("f", "foo")))))
+#     (expect_error(eval_bare(quote(arg_match0("f", "foo")), env())))
+#   })
+# })
+#
+# test_that("error_call() requires a symbol in function position", {
+#   expect_null(format_error_call(quote((function() NULL)())))
+#   expect_null(format_error_call(call2(function() NULL)))
+# })
+#
+# test_that("error_call() preserves index calls", {
+#   expect_equal(format_error_call(quote(foo$bar(...))), "`foo$bar()`")
+# })
+#
+# test_that("error_call() preserves `if` (r-lib/testthat#1429)", {
+#   call <- quote(if (foobar) TRUE else FALSE)
+#
+#   expect_equal(
+#     error_call(call),
+#     call
+#   )
+#   expect_equal(
+#     format_error_call(call),
+#     "`if (foobar) ...`"
+#   )
+# })
+#
+# test_that("error_call() and format_error_call() preserve special syntax ops", {
+#   expect_equal(
+#     error_call(quote(1 + 2)),
+#     quote(1 + 2)
+#   )
+#   expect_snapshot(format_error_call(quote(1 + 2)))
+#
+#   expect_equal(
+#     error_call(quote(for (x in y) NULL)),
+#     quote(for (x in y) NULL)
+#   )
+#   expect_snapshot(format_error_call(quote(for (x in y) NULL)))
+#
+#   expect_snapshot(format_error_call(quote(a %||% b)))
+#   expect_snapshot(format_error_call(quote(`%||%`())))  # Suboptimal
+# })
+#
+# test_that("error_call() preserves srcrefs", {
+#   eval_parse("{
+#     f <- function() g()
+#     g <- function() h()
+#     h <- function() abort('Foo.')
+#   }")
+#
+#   out <- error_call(catch_error(f())$call)
+#   expect_s3_class(attr(out, "srcref"), "srcref")
+# })
+#
+# test_that("withCallingHandlers() wrappers don't throw off trace capture on rethrow", {
+#   local_options(
+#     rlang_trace_top_env = current_env(),
+#     rlang_trace_format_srcrefs = FALSE
+#   )
+#
+#   variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
+#
+#   low1 <- function() low2()
+#   low2 <- function() low3()
+#   low3 <- function() abort("Low-level message")
+#
+#   wch <- function(expr, ...) {
+#     withCallingHandlers(expr, ...)
+#   }
+#   handler1 <- function(err, call = caller_env()) {
+#     handler2(err, call = call)
+#   }
+#   handler2 <- function(err, call = caller_env()) {
+#     abort("High-level message", parent = err, call = call)
+#   }
+#
+#   high1 <- function() high2()
+#   high2 <- function() high3()
+#   high3 <- function() {
+#     wch(
+#       low1(),
+#       error = function(err) handler1(err)
+#     )
+#   }
+#
+#   err <- expect_error(high1())
+#   expect_snapshot(variant = variant, {
+#     "`abort()` error"
+#     print(err)
+#     summary(err)
+#   })
+#
+#   # Avoid `:::` vs `::` ambiguity depending on loadall
+#   fail <- errorcall
+#   low3 <- function() fail(NULL, "Low-level message")
+#   err <- expect_error(high1())
+#   expect_snapshot(variant = variant, {
+#     "C-level error"
+#     print(err)
+#     summary(err)
+#   })
+# })
+#
+# test_that("headers and body are stored in respective fields", {
+#   local_use_cli()  # Just to be explicit
+#
+#   cnd <- catch_cnd(abort(c("a", "b", i = "c")), "error")
+#   expect_equal(cnd$message, set_names("a", ""))
+#   expect_equal(cnd$body, c("b", i = "c"))
+# })
+#
+# test_that("`abort()` uses older bullets formatting by default", {
+#   local_use_cli(format = FALSE)
+#   expect_snapshot_error(abort(c("foo", "bar")))
+# })
+#
+# test_that("abort() preserves `call`", {
+#   err <- catch_cnd(abort("foo", call = quote(1 + 2)), "error")
+#   expect_equal(err$call, quote(1 + 2))
+# })
+#
+# test_that("format_error_call() preserves I() inputs", {
+#   expect_equal(
+#     format_error_call(I(quote(.data[[1]]))),
+#     "`.data[[1]]`"
+#   )
+# })
+#
+# test_that("format_error_call() detects non-syntactic names", {
+#   expect_equal(
+#     format_error_call(quote(`[[.foo`())),
+#     "`[[.foo`"
+#   )
+# })
+#
+# test_that("generic call is picked up in methods", {
+#   g <- function(call = caller_env()) {
+#     abort("foo", call = call)
+#   }
+#
+#   f1 <- function(x) {
+#     UseMethod("f1")
+#   }
+#   f1.default <- function(x) {
+#     g()
+#   }
+#
+#   f2 <- function(x) {
+#     UseMethod("f2")
+#   }
+#   f2.NULL <- function(x) {
+#     NextMethod()
+#   }
+#   f2.default <- function(x) {
+#     g()
+#   }
+#
+#   f3 <- function(x) {
+#     UseMethod("f3")
+#   }
+#   f3.foo <- function(x) {
+#     NextMethod()
+#   }
+#   f3.bar <- function(x) {
+#     NextMethod()
+#   }
+#   f3.default <- function(x) {
+#     g()
+#   }
+#
+#   expect_snapshot({
+#     err(f1())
+#     err(f2())
+#     err(f3())
+#   })
+# })
+#
+# test_that("errors are fully displayed (parents, calls) in knitted files", {
+#   skip_if_not_installed("knitr")
+#   skip_if_not_installed("rmarkdown")
+#   skip_if(!rmarkdown::pandoc_available())
+#
+#   expect_snapshot({
+#     writeLines(render_md("test-parent-errors.Rmd"))
+#   })
+# })
+#
+# test_that("can supply bullets both through `message` and `body`", {
+#   local_use_cli(format = FALSE)
+#   expect_snapshot({
+#     (expect_error(abort("foo", body = c("a", "b"))))
+#     (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
+#   })
+# })
+#
+# test_that("can supply bullets both through `message` and `body` (cli case)", {
+#   local_use_cli(format = TRUE)
+#   expect_snapshot({
+#     (expect_error(abort("foo", body = c("a", "b"))))
+#     (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
+#   })
+# })
+#
+# test_that("setting `.internal` adds footer bullet", {
+#   expect_snapshot({
+#     err(abort(c("foo", "x" = "bar"), .internal = TRUE))
+#     err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
+#   })
+# })
+#
+# test_that("setting `.internal` adds footer bullet (fallback)", {
+#   local_use_cli(format = FALSE)
+#   expect_snapshot({
+#     err(abort(c("foo", "x" = "bar"), .internal = TRUE))
+#     err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
+#   })
+# })
+#
+# test_that("must pass character `body` when `message` is > 1", {
+#   expect_snapshot({
+#     # This is ok because `message` is length 1
+#     err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
+#
+#     # This is an internal error
+#     err(abort(c("foo", "bar"), body = function() "baz"))
+#   })
+# })
+#
+# test_that("must pass character `body` when `message` is > 1 (non-cli case)", {
+#   local_use_cli(format = FALSE)
+#   expect_snapshot({
+#     # This is ok because `message` is length 1
+#     err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
+#
+#     # This is an internal error
+#     err(abort(c("foo", "bar"), body = function() "baz"))
+#   })
+# })
+#
+# test_that("can supply `footer`", {
+#   local_error_call(call("f"))
+#   expect_snapshot({
+#     err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
+#     err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
+#   })
+# })
+#
+# test_that("can supply `footer` (non-cli case)", {
+#   local_use_cli(format = FALSE)
+#   local_error_call(call("f"))
+#   expect_snapshot({
+#     err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
+#     err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
+#   })
+# })
+#
+# test_that("can't supply both `footer` and `.internal`", {
+#   expect_snapshot({
+#     err(abort("foo", .internal = TRUE, call = quote(f())))
+#     err(abort("foo", footer = "bar", .internal = TRUE, call = quote(f())))
+#   })
+# })
+#
+# test_that("caller of withCallingHandlers() is used as default `call`", {
+#   low <- function() {
+#     # Intervening `withCallingHandlers()` is not picked up
+#     withCallingHandlers(stop("low"))
+#   }
+#   high <- function() {
+#     withCallingHandlers(
+#       low(),
+#       error = function(cnd) abort("high", parent = cnd)
+#     )
+#   }
+#   err <- catch_error(high())
+#   expect_equal(err$call, quote(high()))
+#
+#   # Named case
+#   handler <- function(cnd) abort("high", parent = cnd)
+#   high <- function() {
+#     withCallingHandlers(
+#       low(),
+#       error = handler
+#     )
+#   }
+#   err <- catch_error(high())
+#   expect_equal(err$call, quote(high()))
+#
+#   # Wrapped case
+#   handler1 <- function(cnd) handler2(cnd)
+#   handler2 <- function(cnd) abort("high", parent = cnd)
+#   high <- function() {
+#     try_fetch(
+#       low(),
+#       error = handler1
+#     )
+#   }
+#   err <- catch_error(high())
+#   expect_equal(err$call, quote(high()))
+#
+#   function(cnd) abort("high", parent = cnd)
+# })
+#
+# test_that("`cli.condition_unicode_bullets` is supported by fallback formatting", {
+#   local_use_cli(format = FALSE)
+#   local_options(
+#     cli.unicode = TRUE,
+#     cli.condition_unicode_bullets = FALSE
+#   )
+#   expect_snapshot_error(
+#     rlang::abort(c("foo", "i" = "bar"))
+#   )
+# })
+#
+# test_that("call can be a quosure or contain quosures", {
+#   err <- catch_error(abort("foo", call = quo(f(!!quo(g())))))
+#   expect_equal(err$call, quote(f(g())))
+# })
+#
+# test_that("`parent = NA` signals a non-chained rethrow", {
+#   variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
+#
+#   local_options(
+#     rlang_trace_top_env = current_env(),
+#     rlang_trace_format_srcrefs = FALSE
+#   )
+#
+#   ff <- function() gg()
+#   gg <- function() hh()
+#
+#   foo <- function() bar()
+#   bar <- function() baz()
+#   baz <- function() stop("bar")
+#
+#   expect_snapshot(variant = variant, {
+#     "Absent parent causes bad trace bottom"
+#     hh <- function() {
+#       withCallingHandlers(foo(), error = function(cnd) {
+#         abort(cnd_header(cnd))
+#       })
+#     }
+#     print(err(ff()))
+#
+#     "Missing parent allows correct trace bottom"
+#     hh <- function() {
+#       withCallingHandlers(foo(), error = function(cnd) {
+#         abort(cnd_header(cnd), parent = NA)
+#       })
+#     }
+#     print(err(ff()))
+#
+#     "Wrapped handler"
+#     handler1 <- function(cnd, call = caller_env()) handler2(cnd, call)
+#     handler2 <- function(cnd, call) abort(cnd_header(cnd), parent = NA, call = call)
+#     hh <- function() {
+#       withCallingHandlers(
+#         foo(),
+#         error = function(cnd) handler1(cnd)
+#       )
+#     }
+#     print(err(ff()))
+#
+#     "Wrapped handler, `try_fetch()`"
+#     hh <- function() {
+#       try_fetch(
+#         foo(),
+#         error = function(cnd) handler1(cnd)
+#       )
+#     }
+#     print(err(ff()))
+#
+#     "Wrapped handler, incorrect `call`"
+#     hh <- function() {
+#       withCallingHandlers(
+#         foo(),
+#         error = handler1
+#       )
+#     }
+#     print(err(ff()))
+#   })
+# })
+#
+# test_that("can rethrow outside handler", {
+#   local_options(rlang_trace_format_srcrefs = FALSE)
+#
+#   parent <- error_cnd(message = "Low-level", call = call("low"))
+#
+#   foo <- function() bar()
+#   bar <- function() baz()
+#   baz <- function() abort("High-level", parent = parent)
+#
+#   expect_snapshot({
+#     print(err(foo()))
+#   })
+# })
+#
+# test_that("if `call` is older than handler caller, use that as bottom", {
+#   local_options(
+#     rlang_trace_format_srcrefs = FALSE
+#   )
+#   f <- function() helper()
+#   helper <- function(call = caller_env()) {
+#     try_fetch(
+#       low_level(call),
+#       error = function(cnd) abort(
+#         "Problem.",
+#         parent = cnd,
+#         call = call
+#       )
+#     )
+#   }
+#
+#   expect_snapshot({
+#     low_level <- function(call) {
+#       abort("Tilt.", call = call)
+#     }
+#     print(expect_error(f()))
+#
+#     low_level <- function(call) {
+#       abort("Tilt.", call = list(NULL, frame = call))
+#     }
+#     print(expect_error(f()))
+#   })
+# })
+#
+# test_that("is_calling_handler_inlined_call() doesn't fail with OOB subsetting", {
+#   expect_false(is_calling_handler_inlined_call(call2(function() NULL)))
+# })
+#
+# test_that("base causal errors include full user backtrace", {
+#   local_options(
+#     rlang_trace_format_srcrefs = FALSE,
+#     rlang_trace_top_env = current_env()
+#   )
+#
+#   my_verb <- function(expr) {
+#     with_chained_errors(expr)
+#   }
+#   with_chained_errors <- function(expr, call = caller_env()) {
+#     try_fetch(
+#       expr,
+#       error = function(cnd) {
+#         abort(
+#           "Problem during step.",
+#           parent = cnd,
+#           call = call
+#         )
+#       }
+#     )
+#   }
+#
+#   add <- function(x, y) x + y
+#   expect_snapshot({
+#     print(expect_error(my_verb(add(1, ""))))
+#   })
+# })
+#
+# test_that("can chain errors at top-level (#1405)", {
+#   out <- run_code("
+#     tryCatch(
+#       error = function(err) rlang::abort('bar', parent = err),
+#       rlang::abort('foo')
+#     )
+#   ")
+#   expect_true(any(grepl("foo", out$output)))
+#   expect_true(any(grepl("bar", out$output)))
+#
+#   out <- run_code("
+#     withCallingHandlers(
+#       error = function(err) rlang::abort('bar', parent = err),
+#       rlang::abort('foo')
+#     )
+#   ")
+#   expect_true(any(grepl("foo", out$output)))
+#   expect_true(any(grepl("bar", out$output)))
+# })
+#
+# test_that("backtrace_on_error = 'collapse' is deprecated.", {
+#   local_options("rlang_backtrace_on_error" = "collapse")
+#   expect_warning(peek_backtrace_on_error(), "deprecated")
+#   expect_equal(peek_option("rlang_backtrace_on_error"), "none")
+# })
+#
+# test_that("can supply header method via `message`", {
+#   expect_snapshot(error = TRUE, {
+#     abort(~ "foo")
+#     abort(function(cnd, ...) "foo")
+#   })
+#
+#   msg <- function(cnd, ...) "foo"
+#   cnd <- catch_error(abort(msg))
+#   expect_identical(cnd$header, msg)
+#
+#   expect_error(
+#     abort(function(cnd) "foo"),
+#     "must take"
+#   )
+# })
+#
+# test_that("newlines are preserved by cli (#1535)", {
+#   expect_snapshot(error = TRUE, {
+#     abort("foo\nbar", use_cli_format = TRUE)
+#     abort("foo\fbar", use_cli_format = TRUE)
+#   })
+# })
+#
+# test_that("`show.error.messages` is respected by `abort()` (#1630)", {
+#   run_error_script <- function(envvars = chr()) {
+#     run_script(test_path("fixtures", "error-show-messages.R"), envvars = envvars)
+#   }
+#
+#   with_messages <- run_error_script(envvars = c("show_error_messages=TRUE"))
+#   without_messages <- run_error_script(envvars = c("show_error_messages=FALSE"))
+#
+#   expect_snapshot({
+#     cat_line(with_messages)
+#     cat_line(without_messages)
+#   })
+# })

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -1,879 +1,879 @@
-# local_unexport_signal_abort()
-#
-# test_that("errors are signalled with backtrace", {
-#   fn <- function() abort("")
-#   err <- expect_error(fn())
-#   expect_s3_class(err$trace, "rlang_trace")
-# })
-#
-# test_that("can pass classed strings as error message", {
-#   message <- structure("foo", class = c("glue", "character"))
-#   err <- expect_error(abort(message))
-#   expect_identical(err$message, message)
-# })
-#
-# test_that("errors are saved", {
-#   # `outFile` argument
-#   skip_if(getRversion() < "3.4")
-#
-#   file <- tempfile()
-#   on.exit(unlink(file))
-#
-#   local_options(
-#     `rlang::::force_unhandled_error` = TRUE,
-#     `rlang:::message_file` = tempfile()
-#   )
-#
-#   try(abort("foo", "bar"), outFile = file)
-#   expect_true(inherits_all(last_error(), c("bar", "rlang_error")))
-#
-#   try(cnd_signal(error_cnd("foobar")), outFile = file)
-#   expect_true(inherits_all(last_error(), c("foobar", "rlang_error")))
-# })
-#
-# test_that("No backtrace is displayed with top-level active bindings", {
-#   local_options(
-#     rlang_trace_top_env = current_env()
-#   )
-#
-#   env_bind_active(current_env(), foo = function() abort("msg"))
-#   expect_error(foo, "^msg$")
-# })
-#
-# test_that("Invalid on_error option resets itself", {
-#   local_options(
-#     `rlang::::force_unhandled_error` = TRUE,
-#     `rlang:::message_file` = tempfile(),
-#     rlang_backtrace_on_error = NA
-#   )
-#   expect_snapshot({
-#     (expect_warning(tryCatch(abort("foo"), error = identity)))
-#   })
-#   expect_null(peek_option("rlang_backtrace_on_error"))
-# })
-#
-# test_that("format_onerror_backtrace handles empty and size 1 traces", {
-#   local_options(rlang_backtrace_on_error = "branch")
-#
-#   trace <- new_trace(list(), int())
-#   expect_identical(format_onerror_backtrace(trace), NULL)
-#
-#   trace <- new_trace(list(quote(foo)), int(0))
-#   expect_identical(format_onerror_backtrace(trace), NULL)
-#
-#   trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1))
-#   expect_match(format_onerror_backtrace(error_cnd(trace = trace)), "foo.*bar")
-# })
-#
-# test_that("error is printed with backtrace", {
-#   skip_if_stale_backtrace()
-#
-#   run_error_script <- function(envvars = chr()) {
-#     run_script(test_path("fixtures", "error-backtrace.R"), envvars = envvars)
-#   }
-#
-#   default_interactive <- run_error_script(envvars = "rlang_interactive=true")
-#   default_non_interactive <- run_error_script()
-#   reminder <- run_error_script(envvars = "rlang_backtrace_on_error=reminder")
-#   branch <- run_error_script(envvars = "rlang_backtrace_on_error=branch")
-#   collapse <- run_error_script(envvars = "rlang_backtrace_on_error=collapse")
-#   full <- run_error_script(envvars = "rlang_backtrace_on_error=full")
-#
-#   rethrown_interactive <- run_script(
-#     test_path("fixtures", "error-backtrace-rethrown.R"),
-#     envvars = "rlang_interactive=true"
-#   )
-#   rethrown_non_interactive <- run_script(
-#     test_path("fixtures", "error-backtrace-rethrown.R")
-#   )
-#
-#   expect_snapshot({
-#     cat_line(default_interactive)
-#     cat_line(default_non_interactive)
-#     cat_line(reminder)
-#     cat_line(branch)
-#     cat_line(collapse)
-#     cat_line(full)
-#     cat_line(rethrown_interactive)
-#     cat_line(rethrown_non_interactive)
-#   })
-# })
-#
-# test_that("empty backtraces are not printed", {
-#   skip_if_stale_backtrace()
-#
-#   run_error_script <- function(envvars = chr()) {
-#     run_script(test_path("fixtures", "error-backtrace-empty.R"), envvars = envvars)
-#   }
-#
-#   branch_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=0"))
-#   full_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=0"))
-#   branch_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=1"))
-#   full_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=1"))
-#
-#   expect_snapshot({
-#     cat_line(branch_depth_0)
-#     cat_line(full_depth_0)
-#     cat_line(branch_depth_1)
-#     cat_line(full_depth_1)
-#   })
-# })
-#
-# test_that("parent errors are not displayed in error message and backtrace", {
-#   skip_if_stale_backtrace()
-#
-#   run_error_script <- function(envvars = chr()) {
-#     run_script(
-#       test_path("fixtures", "error-backtrace-parent.R"),
-#       envvars = envvars
-#     )
-#   }
-#   non_interactive <- run_error_script()
-#   interactive <- run_error_script(envvars = "rlang_interactive=true")
-#
-#   expect_snapshot({
-#     cat_line(interactive)
-#     cat_line(non_interactive)
-#   })
-# })
-#
-# test_that("backtrace reminder is displayed when called from `last_error()`", {
-#   local_options(
-#     rlang_trace_format_srcrefs = FALSE,
-#     rlang_trace_top_env = current_env()
-#   )
-#
-#   f <- function() g()
-#   g <- function() h()
-#   h <- function() abort("foo")
-#   err <- catch_error(f())
-#
-#   poke_last_error(err)
-#
-#   expect_snapshot({
-#     "Normal case"
-#     print(err)
-#
-#     "From `last_error()`"
-#     print(last_error())
-#
-#     "Saved from `last_error()`"
-#     {
-#       saved <- last_error()
-#       print(saved)
-#     }
-#
-#     "Saved from `last_error()`, but no longer last"
-#     {
-#       poke_last_error(error_cnd("foo"))
-#       print(saved)
-#     }
-#   })
-# })
-#
-# local({
-#   local_options(
-#     rlang_trace_format_srcrefs = FALSE,
-#     rlang_trace_top_env = current_env()
-#   )
-#
-#   throw <- NULL
-#
-#   low1 <- function() low2()
-#   low2 <- function() low3()
-#   low3 <- NULL
-#
-#   high3_catch <- function(..., chain, stop_helper) {
-#     tryCatch(
-#       low1(),
-#       error = function(err) {
-#         parent <- if (chain) err else NA
-#         if (stop_helper) {
-#           stop1("high-level", parent = err)
-#         } else {
-#           abort("high-level", parent = err)
-#         }
-#       }
-#     )
-#   }
-#   high3_call <- function(..., chain, stop_helper) {
-#     withCallingHandlers(
-#       low1(),
-#       error = function(err) {
-#         parent <- if (chain) err else NA
-#         if (stop_helper) {
-#           stop1("high-level", parent = err)
-#         } else {
-#           abort("high-level", parent = err)
-#         }
-#       }
-#     )
-#   }
-#   high3_fetch <- function(..., chain, stop_helper) {
-#     try_fetch(
-#       low1(),
-#       error = function(err) {
-#         parent <- if (chain) err else NA
-#         if (stop_helper) {
-#           stop1("high-level", parent = err)
-#         } else {
-#           abort("high-level", parent = err)
-#         }
-#       }
-#     )
-#   }
-#
-#   high1 <- function(...) high2(...)
-#   high2 <- function(...) high3(...)
-#   high3 <- NULL
-#
-#   stop1 <- function(..., call = caller_env()) stop2(..., call = call)
-#   stop2 <- function(..., call = caller_env()) stop3(..., call = call)
-#   stop3 <- function(..., call = caller_env()) abort(..., call = call)
-#
-#   throwers <- list(
-#     "stop()" = function() stop("low-level"),
-#     "abort()" = function() abort("low-level"),
-#     "warn = 2" = function() {
-#       local_options(warn = 2)
-#       warning("low-level")
-#     }
-#   )
-#   handlers <- list(
-#     "tryCatch()" = high3_catch,
-#     "withCallingHandlers()" = high3_call,
-#     "try_fetch()" = high3_fetch
-#   )
-#
-#   for (i in seq_along(throwers)) {
-#     for (j in seq_along(handlers)) {
-#       case_name <- paste0(
-#         "Backtrace on rethrow: ",
-#         names(throwers)[[i]], " - ", names(handlers)[[j]]
-#       )
-#       low3 <- throwers[[i]]
-#       high3 <- handlers[[j]]
-#
-#       # Use `print()` because `testthat_print()` (called implicitly in
-#       # snapshots) doesn't print backtraces
-#       test_that(case_name, {
-#         expect_snapshot({
-#           print(catch_error(high1(chain = TRUE, stop_helper = TRUE)))
-#           print(catch_error(high1(chain = TRUE, stop_helper = FALSE)))
-#
-#           print(catch_error(high1(chain = FALSE, stop_helper = TRUE)))
-#           print(catch_error(high1(chain = FALSE, stop_helper = FALSE)))
-#         })
-#       })
-#     }
-#   }
-# })
-#
-# test_that("abort() displays call in error prefix", {
-#   skip_if_not_installed("rlang", "0.4.11.9001")
-#
-#   expect_snapshot(
-#     run("{
-#       options(cli.unicode = FALSE, crayon.enabled = FALSE)
-#       rlang::abort('foo', call = quote(bar(baz)))
-#     }")
-#   )
-#
-#   # errorCondition()
-#   skip_if_not_installed("base", "3.6.0")
-#
-#   expect_snapshot(
-#     run("{
-#       options(cli.unicode = FALSE, crayon.enabled = FALSE)
-#       rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))
-#     }")
-#   )
-# })
-#
-# test_that("abort() accepts environment as `call` field.", {
-#   check_required2 <- function(arg, call = caller_call()) {
-#     check_required(arg, call = call)
-#   }
-#   f <- function(x) g(x)
-#   g <- function(x) h(x)
-#   h <- function(x) check_required2(x, call = environment())
-#
-#   expect_snapshot((expect_error(f())))
-# })
-#
-# test_that("format_error_arg() formats argument", {
-#   exp <- format_arg("foo")
-#
-#   expect_equal(format_error_arg("foo"), exp)
-#   expect_equal(format_error_arg(sym("foo")), exp)
-#   expect_equal(format_error_arg(chr_get("foo", 0L)), exp)
-#   expect_equal(format_error_arg(quote(foo())), format_arg("foo()"))
-#
-#   expect_error(format_error_arg(c("foo", "bar")), "must be a string or an expression")
-#   expect_error(format_error_arg(function() NULL), "must be a string or an expression")
-# })
-#
-# test_that("local_error_call() works", {
-#   foo <- function() {
-#     bar()
-#   }
-#   bar <- function() {
-#     local_error_call(quote(expected()))
-#     baz()
-#   }
-#   baz <- function() {
-#     local_error_call("caller")
-#     abort("tilt")
-#   }
-#
-#   expect_snapshot((expect_error(foo())))
-# })
-#
-# test_that("can disable error call inference for unexported functions", {
-#   foo <- function() abort("foo")
-#
-#   expect_snapshot({
-#     (expect_error(foo()))
-#
-#     local({
-#       local_options("rlang:::restrict_default_error_call" = TRUE)
-#       (expect_error(foo()))
-#     })
-#
-#     local({
-#       local_options("rlang:::restrict_default_error_call" = TRUE)
-#       (expect_error(dots_list(.homonyms = "k")))
-#     })
-#   })
-# })
-#
-# test_that("error call flag is stripped", {
-#   e <- env(.__error_call__. = quote(foo(bar)))
-#   expect_equal(error_call(e), quote(foo(bar)))
-#   expect_equal(format_error_call(e), "`foo()`")
-# })
-#
-# test_that("NSE doesn't interfere with error call contexts", {
-#   # Snapshots shouldn't show `eval()` as context
-#   expect_snapshot({
-#     (expect_error(local(arg_match0("f", "foo"))))
-#     (expect_error(eval_bare(quote(arg_match0("f", "foo")))))
-#     (expect_error(eval_bare(quote(arg_match0("f", "foo")), env())))
-#   })
-# })
-#
-# test_that("error_call() requires a symbol in function position", {
-#   expect_null(format_error_call(quote((function() NULL)())))
-#   expect_null(format_error_call(call2(function() NULL)))
-# })
-#
-# test_that("error_call() preserves index calls", {
-#   expect_equal(format_error_call(quote(foo$bar(...))), "`foo$bar()`")
-# })
-#
-# test_that("error_call() preserves `if` (r-lib/testthat#1429)", {
-#   call <- quote(if (foobar) TRUE else FALSE)
-#
-#   expect_equal(
-#     error_call(call),
-#     call
-#   )
-#   expect_equal(
-#     format_error_call(call),
-#     "`if (foobar) ...`"
-#   )
-# })
-#
-# test_that("error_call() and format_error_call() preserve special syntax ops", {
-#   expect_equal(
-#     error_call(quote(1 + 2)),
-#     quote(1 + 2)
-#   )
-#   expect_snapshot(format_error_call(quote(1 + 2)))
-#
-#   expect_equal(
-#     error_call(quote(for (x in y) NULL)),
-#     quote(for (x in y) NULL)
-#   )
-#   expect_snapshot(format_error_call(quote(for (x in y) NULL)))
-#
-#   expect_snapshot(format_error_call(quote(a %||% b)))
-#   expect_snapshot(format_error_call(quote(`%||%`())))  # Suboptimal
-# })
-#
-# test_that("error_call() preserves srcrefs", {
-#   eval_parse("{
-#     f <- function() g()
-#     g <- function() h()
-#     h <- function() abort('Foo.')
-#   }")
-#
-#   out <- error_call(catch_error(f())$call)
-#   expect_s3_class(attr(out, "srcref"), "srcref")
-# })
-#
-# test_that("withCallingHandlers() wrappers don't throw off trace capture on rethrow", {
-#   local_options(
-#     rlang_trace_top_env = current_env(),
-#     rlang_trace_format_srcrefs = FALSE
-#   )
-#
-#   variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
-#
-#   low1 <- function() low2()
-#   low2 <- function() low3()
-#   low3 <- function() abort("Low-level message")
-#
-#   wch <- function(expr, ...) {
-#     withCallingHandlers(expr, ...)
-#   }
-#   handler1 <- function(err, call = caller_env()) {
-#     handler2(err, call = call)
-#   }
-#   handler2 <- function(err, call = caller_env()) {
-#     abort("High-level message", parent = err, call = call)
-#   }
-#
-#   high1 <- function() high2()
-#   high2 <- function() high3()
-#   high3 <- function() {
-#     wch(
-#       low1(),
-#       error = function(err) handler1(err)
-#     )
-#   }
-#
-#   err <- expect_error(high1())
-#   expect_snapshot(variant = variant, {
-#     "`abort()` error"
-#     print(err)
-#     summary(err)
-#   })
-#
-#   # Avoid `:::` vs `::` ambiguity depending on loadall
-#   fail <- errorcall
-#   low3 <- function() fail(NULL, "Low-level message")
-#   err <- expect_error(high1())
-#   expect_snapshot(variant = variant, {
-#     "C-level error"
-#     print(err)
-#     summary(err)
-#   })
-# })
-#
-# test_that("headers and body are stored in respective fields", {
-#   local_use_cli()  # Just to be explicit
-#
-#   cnd <- catch_cnd(abort(c("a", "b", i = "c")), "error")
-#   expect_equal(cnd$message, set_names("a", ""))
-#   expect_equal(cnd$body, c("b", i = "c"))
-# })
-#
-# test_that("`abort()` uses older bullets formatting by default", {
-#   local_use_cli(format = FALSE)
-#   expect_snapshot_error(abort(c("foo", "bar")))
-# })
-#
-# test_that("abort() preserves `call`", {
-#   err <- catch_cnd(abort("foo", call = quote(1 + 2)), "error")
-#   expect_equal(err$call, quote(1 + 2))
-# })
-#
-# test_that("format_error_call() preserves I() inputs", {
-#   expect_equal(
-#     format_error_call(I(quote(.data[[1]]))),
-#     "`.data[[1]]`"
-#   )
-# })
-#
-# test_that("format_error_call() detects non-syntactic names", {
-#   expect_equal(
-#     format_error_call(quote(`[[.foo`())),
-#     "`[[.foo`"
-#   )
-# })
-#
-# test_that("generic call is picked up in methods", {
-#   g <- function(call = caller_env()) {
-#     abort("foo", call = call)
-#   }
-#
-#   f1 <- function(x) {
-#     UseMethod("f1")
-#   }
-#   f1.default <- function(x) {
-#     g()
-#   }
-#
-#   f2 <- function(x) {
-#     UseMethod("f2")
-#   }
-#   f2.NULL <- function(x) {
-#     NextMethod()
-#   }
-#   f2.default <- function(x) {
-#     g()
-#   }
-#
-#   f3 <- function(x) {
-#     UseMethod("f3")
-#   }
-#   f3.foo <- function(x) {
-#     NextMethod()
-#   }
-#   f3.bar <- function(x) {
-#     NextMethod()
-#   }
-#   f3.default <- function(x) {
-#     g()
-#   }
-#
-#   expect_snapshot({
-#     err(f1())
-#     err(f2())
-#     err(f3())
-#   })
-# })
-#
-# test_that("errors are fully displayed (parents, calls) in knitted files", {
-#   skip_if_not_installed("knitr")
-#   skip_if_not_installed("rmarkdown")
-#   skip_if(!rmarkdown::pandoc_available())
-#
-#   expect_snapshot({
-#     writeLines(render_md("test-parent-errors.Rmd"))
-#   })
-# })
-#
-# test_that("can supply bullets both through `message` and `body`", {
-#   local_use_cli(format = FALSE)
-#   expect_snapshot({
-#     (expect_error(abort("foo", body = c("a", "b"))))
-#     (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
-#   })
-# })
-#
-# test_that("can supply bullets both through `message` and `body` (cli case)", {
-#   local_use_cli(format = TRUE)
-#   expect_snapshot({
-#     (expect_error(abort("foo", body = c("a", "b"))))
-#     (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
-#   })
-# })
-#
-# test_that("setting `.internal` adds footer bullet", {
-#   expect_snapshot({
-#     err(abort(c("foo", "x" = "bar"), .internal = TRUE))
-#     err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
-#   })
-# })
-#
-# test_that("setting `.internal` adds footer bullet (fallback)", {
-#   local_use_cli(format = FALSE)
-#   expect_snapshot({
-#     err(abort(c("foo", "x" = "bar"), .internal = TRUE))
-#     err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
-#   })
-# })
-#
-# test_that("must pass character `body` when `message` is > 1", {
-#   expect_snapshot({
-#     # This is ok because `message` is length 1
-#     err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
-#
-#     # This is an internal error
-#     err(abort(c("foo", "bar"), body = function() "baz"))
-#   })
-# })
-#
-# test_that("must pass character `body` when `message` is > 1 (non-cli case)", {
-#   local_use_cli(format = FALSE)
-#   expect_snapshot({
-#     # This is ok because `message` is length 1
-#     err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
-#
-#     # This is an internal error
-#     err(abort(c("foo", "bar"), body = function() "baz"))
-#   })
-# })
-#
-# test_that("can supply `footer`", {
-#   local_error_call(call("f"))
-#   expect_snapshot({
-#     err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
-#     err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
-#   })
-# })
-#
-# test_that("can supply `footer` (non-cli case)", {
-#   local_use_cli(format = FALSE)
-#   local_error_call(call("f"))
-#   expect_snapshot({
-#     err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
-#     err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
-#   })
-# })
-#
-# test_that("can't supply both `footer` and `.internal`", {
-#   expect_snapshot({
-#     err(abort("foo", .internal = TRUE, call = quote(f())))
-#     err(abort("foo", footer = "bar", .internal = TRUE, call = quote(f())))
-#   })
-# })
-#
-# test_that("caller of withCallingHandlers() is used as default `call`", {
-#   low <- function() {
-#     # Intervening `withCallingHandlers()` is not picked up
-#     withCallingHandlers(stop("low"))
-#   }
-#   high <- function() {
-#     withCallingHandlers(
-#       low(),
-#       error = function(cnd) abort("high", parent = cnd)
-#     )
-#   }
-#   err <- catch_error(high())
-#   expect_equal(err$call, quote(high()))
-#
-#   # Named case
-#   handler <- function(cnd) abort("high", parent = cnd)
-#   high <- function() {
-#     withCallingHandlers(
-#       low(),
-#       error = handler
-#     )
-#   }
-#   err <- catch_error(high())
-#   expect_equal(err$call, quote(high()))
-#
-#   # Wrapped case
-#   handler1 <- function(cnd) handler2(cnd)
-#   handler2 <- function(cnd) abort("high", parent = cnd)
-#   high <- function() {
-#     try_fetch(
-#       low(),
-#       error = handler1
-#     )
-#   }
-#   err <- catch_error(high())
-#   expect_equal(err$call, quote(high()))
-#
-#   function(cnd) abort("high", parent = cnd)
-# })
-#
-# test_that("`cli.condition_unicode_bullets` is supported by fallback formatting", {
-#   local_use_cli(format = FALSE)
-#   local_options(
-#     cli.unicode = TRUE,
-#     cli.condition_unicode_bullets = FALSE
-#   )
-#   expect_snapshot_error(
-#     rlang::abort(c("foo", "i" = "bar"))
-#   )
-# })
-#
-# test_that("call can be a quosure or contain quosures", {
-#   err <- catch_error(abort("foo", call = quo(f(!!quo(g())))))
-#   expect_equal(err$call, quote(f(g())))
-# })
-#
-# test_that("`parent = NA` signals a non-chained rethrow", {
-#   variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
-#
-#   local_options(
-#     rlang_trace_top_env = current_env(),
-#     rlang_trace_format_srcrefs = FALSE
-#   )
-#
-#   ff <- function() gg()
-#   gg <- function() hh()
-#
-#   foo <- function() bar()
-#   bar <- function() baz()
-#   baz <- function() stop("bar")
-#
-#   expect_snapshot(variant = variant, {
-#     "Absent parent causes bad trace bottom"
-#     hh <- function() {
-#       withCallingHandlers(foo(), error = function(cnd) {
-#         abort(cnd_header(cnd))
-#       })
-#     }
-#     print(err(ff()))
-#
-#     "Missing parent allows correct trace bottom"
-#     hh <- function() {
-#       withCallingHandlers(foo(), error = function(cnd) {
-#         abort(cnd_header(cnd), parent = NA)
-#       })
-#     }
-#     print(err(ff()))
-#
-#     "Wrapped handler"
-#     handler1 <- function(cnd, call = caller_env()) handler2(cnd, call)
-#     handler2 <- function(cnd, call) abort(cnd_header(cnd), parent = NA, call = call)
-#     hh <- function() {
-#       withCallingHandlers(
-#         foo(),
-#         error = function(cnd) handler1(cnd)
-#       )
-#     }
-#     print(err(ff()))
-#
-#     "Wrapped handler, `try_fetch()`"
-#     hh <- function() {
-#       try_fetch(
-#         foo(),
-#         error = function(cnd) handler1(cnd)
-#       )
-#     }
-#     print(err(ff()))
-#
-#     "Wrapped handler, incorrect `call`"
-#     hh <- function() {
-#       withCallingHandlers(
-#         foo(),
-#         error = handler1
-#       )
-#     }
-#     print(err(ff()))
-#   })
-# })
-#
-# test_that("can rethrow outside handler", {
-#   local_options(rlang_trace_format_srcrefs = FALSE)
-#
-#   parent <- error_cnd(message = "Low-level", call = call("low"))
-#
-#   foo <- function() bar()
-#   bar <- function() baz()
-#   baz <- function() abort("High-level", parent = parent)
-#
-#   expect_snapshot({
-#     print(err(foo()))
-#   })
-# })
-#
-# test_that("if `call` is older than handler caller, use that as bottom", {
-#   local_options(
-#     rlang_trace_format_srcrefs = FALSE
-#   )
-#   f <- function() helper()
-#   helper <- function(call = caller_env()) {
-#     try_fetch(
-#       low_level(call),
-#       error = function(cnd) abort(
-#         "Problem.",
-#         parent = cnd,
-#         call = call
-#       )
-#     )
-#   }
-#
-#   expect_snapshot({
-#     low_level <- function(call) {
-#       abort("Tilt.", call = call)
-#     }
-#     print(expect_error(f()))
-#
-#     low_level <- function(call) {
-#       abort("Tilt.", call = list(NULL, frame = call))
-#     }
-#     print(expect_error(f()))
-#   })
-# })
-#
-# test_that("is_calling_handler_inlined_call() doesn't fail with OOB subsetting", {
-#   expect_false(is_calling_handler_inlined_call(call2(function() NULL)))
-# })
-#
-# test_that("base causal errors include full user backtrace", {
-#   local_options(
-#     rlang_trace_format_srcrefs = FALSE,
-#     rlang_trace_top_env = current_env()
-#   )
-#
-#   my_verb <- function(expr) {
-#     with_chained_errors(expr)
-#   }
-#   with_chained_errors <- function(expr, call = caller_env()) {
-#     try_fetch(
-#       expr,
-#       error = function(cnd) {
-#         abort(
-#           "Problem during step.",
-#           parent = cnd,
-#           call = call
-#         )
-#       }
-#     )
-#   }
-#
-#   add <- function(x, y) x + y
-#   expect_snapshot({
-#     print(expect_error(my_verb(add(1, ""))))
-#   })
-# })
-#
-# test_that("can chain errors at top-level (#1405)", {
-#   out <- run_code("
-#     tryCatch(
-#       error = function(err) rlang::abort('bar', parent = err),
-#       rlang::abort('foo')
-#     )
-#   ")
-#   expect_true(any(grepl("foo", out$output)))
-#   expect_true(any(grepl("bar", out$output)))
-#
-#   out <- run_code("
-#     withCallingHandlers(
-#       error = function(err) rlang::abort('bar', parent = err),
-#       rlang::abort('foo')
-#     )
-#   ")
-#   expect_true(any(grepl("foo", out$output)))
-#   expect_true(any(grepl("bar", out$output)))
-# })
-#
-# test_that("backtrace_on_error = 'collapse' is deprecated.", {
-#   local_options("rlang_backtrace_on_error" = "collapse")
-#   expect_warning(peek_backtrace_on_error(), "deprecated")
-#   expect_equal(peek_option("rlang_backtrace_on_error"), "none")
-# })
-#
-# test_that("can supply header method via `message`", {
-#   expect_snapshot(error = TRUE, {
-#     abort(~ "foo")
-#     abort(function(cnd, ...) "foo")
-#   })
-#
-#   msg <- function(cnd, ...) "foo"
-#   cnd <- catch_error(abort(msg))
-#   expect_identical(cnd$header, msg)
-#
-#   expect_error(
-#     abort(function(cnd) "foo"),
-#     "must take"
-#   )
-# })
-#
-# test_that("newlines are preserved by cli (#1535)", {
-#   expect_snapshot(error = TRUE, {
-#     abort("foo\nbar", use_cli_format = TRUE)
-#     abort("foo\fbar", use_cli_format = TRUE)
-#   })
-# })
-#
-# test_that("`show.error.messages` is respected by `abort()` (#1630)", {
-#   run_error_script <- function(envvars = chr()) {
-#     run_script(test_path("fixtures", "error-show-messages.R"), envvars = envvars)
-#   }
-#
-#   with_messages <- run_error_script(envvars = c("show_error_messages=TRUE"))
-#   without_messages <- run_error_script(envvars = c("show_error_messages=FALSE"))
-#
-#   expect_snapshot({
-#     cat_line(with_messages)
-#     cat_line(without_messages)
-#   })
-# })
+local_unexport_signal_abort()
+
+test_that("errors are signalled with backtrace", {
+  fn <- function() abort("")
+  err <- expect_error(fn())
+  expect_s3_class(err$trace, "rlang_trace")
+})
+
+test_that("can pass classed strings as error message", {
+  message <- structure("foo", class = c("glue", "character"))
+  err <- expect_error(abort(message))
+  expect_identical(err$message, message)
+})
+
+test_that("errors are saved", {
+  # `outFile` argument
+  skip_if(getRversion() < "3.4")
+
+  file <- tempfile()
+  on.exit(unlink(file))
+
+  local_options(
+    `rlang::::force_unhandled_error` = TRUE,
+    `rlang:::message_file` = tempfile()
+  )
+
+  try(abort("foo", "bar"), outFile = file)
+  expect_true(inherits_all(last_error(), c("bar", "rlang_error")))
+
+  try(cnd_signal(error_cnd("foobar")), outFile = file)
+  expect_true(inherits_all(last_error(), c("foobar", "rlang_error")))
+})
+
+test_that("No backtrace is displayed with top-level active bindings", {
+  local_options(
+    rlang_trace_top_env = current_env()
+  )
+
+  env_bind_active(current_env(), foo = function() abort("msg"))
+  expect_error(foo, "^msg$")
+})
+
+test_that("Invalid on_error option resets itself", {
+  local_options(
+    `rlang::::force_unhandled_error` = TRUE,
+    `rlang:::message_file` = tempfile(),
+    rlang_backtrace_on_error = NA
+  )
+  expect_snapshot({
+    (expect_warning(tryCatch(abort("foo"), error = identity)))
+  })
+  expect_null(peek_option("rlang_backtrace_on_error"))
+})
+
+test_that("format_onerror_backtrace handles empty and size 1 traces", {
+  local_options(rlang_backtrace_on_error = "branch")
+
+  trace <- new_trace(list(), int())
+  expect_identical(format_onerror_backtrace(trace), NULL)
+
+  trace <- new_trace(list(quote(foo)), int(0))
+  expect_identical(format_onerror_backtrace(trace), NULL)
+
+  trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1))
+  expect_match(format_onerror_backtrace(error_cnd(trace = trace)), "foo.*bar")
+})
+
+test_that("error is printed with backtrace", {
+  skip_if_stale_backtrace()
+
+  run_error_script <- function(envvars = chr()) {
+    run_script(test_path("fixtures", "error-backtrace.R"), envvars = envvars)
+  }
+
+  default_interactive <- run_error_script(envvars = "rlang_interactive=true")
+  default_non_interactive <- run_error_script()
+  reminder <- run_error_script(envvars = "rlang_backtrace_on_error=reminder")
+  branch <- run_error_script(envvars = "rlang_backtrace_on_error=branch")
+  collapse <- run_error_script(envvars = "rlang_backtrace_on_error=collapse")
+  full <- run_error_script(envvars = "rlang_backtrace_on_error=full")
+
+  rethrown_interactive <- run_script(
+    test_path("fixtures", "error-backtrace-rethrown.R"),
+    envvars = "rlang_interactive=true"
+  )
+  rethrown_non_interactive <- run_script(
+    test_path("fixtures", "error-backtrace-rethrown.R")
+  )
+
+  expect_snapshot({
+    cat_line(default_interactive)
+    cat_line(default_non_interactive)
+    cat_line(reminder)
+    cat_line(branch)
+    cat_line(collapse)
+    cat_line(full)
+    cat_line(rethrown_interactive)
+    cat_line(rethrown_non_interactive)
+  })
+})
+
+test_that("empty backtraces are not printed", {
+  skip_if_stale_backtrace()
+
+  run_error_script <- function(envvars = chr()) {
+    run_script(test_path("fixtures", "error-backtrace-empty.R"), envvars = envvars)
+  }
+
+  branch_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=0"))
+  full_depth_0 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=0"))
+  branch_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=branch", "trace_depth=1"))
+  full_depth_1 <- run_error_script(envvars = c("rlang_backtrace_on_error=full", "trace_depth=1"))
+
+  expect_snapshot({
+    cat_line(branch_depth_0)
+    cat_line(full_depth_0)
+    cat_line(branch_depth_1)
+    cat_line(full_depth_1)
+  })
+})
+
+test_that("parent errors are not displayed in error message and backtrace", {
+  skip_if_stale_backtrace()
+
+  run_error_script <- function(envvars = chr()) {
+    run_script(
+      test_path("fixtures", "error-backtrace-parent.R"),
+      envvars = envvars
+    )
+  }
+  non_interactive <- run_error_script()
+  interactive <- run_error_script(envvars = "rlang_interactive=true")
+
+  expect_snapshot({
+    cat_line(interactive)
+    cat_line(non_interactive)
+  })
+})
+
+test_that("backtrace reminder is displayed when called from `last_error()`", {
+  local_options(
+    rlang_trace_format_srcrefs = FALSE,
+    rlang_trace_top_env = current_env()
+  )
+
+  f <- function() g()
+  g <- function() h()
+  h <- function() abort("foo")
+  err <- catch_error(f())
+
+  poke_last_error(err)
+
+  expect_snapshot({
+    "Normal case"
+    print(err)
+
+    "From `last_error()`"
+    print(last_error())
+
+    "Saved from `last_error()`"
+    {
+      saved <- last_error()
+      print(saved)
+    }
+
+    "Saved from `last_error()`, but no longer last"
+    {
+      poke_last_error(error_cnd("foo"))
+      print(saved)
+    }
+  })
+})
+
+local({
+  local_options(
+    rlang_trace_format_srcrefs = FALSE,
+    rlang_trace_top_env = current_env()
+  )
+
+  throw <- NULL
+
+  low1 <- function() low2()
+  low2 <- function() low3()
+  low3 <- NULL
+
+  high3_catch <- function(..., chain, stop_helper) {
+    tryCatch(
+      low1(),
+      error = function(err) {
+        parent <- if (chain) err else NA
+        if (stop_helper) {
+          stop1("high-level", parent = err)
+        } else {
+          abort("high-level", parent = err)
+        }
+      }
+    )
+  }
+  high3_call <- function(..., chain, stop_helper) {
+    withCallingHandlers(
+      low1(),
+      error = function(err) {
+        parent <- if (chain) err else NA
+        if (stop_helper) {
+          stop1("high-level", parent = err)
+        } else {
+          abort("high-level", parent = err)
+        }
+      }
+    )
+  }
+  high3_fetch <- function(..., chain, stop_helper) {
+    try_fetch(
+      low1(),
+      error = function(err) {
+        parent <- if (chain) err else NA
+        if (stop_helper) {
+          stop1("high-level", parent = err)
+        } else {
+          abort("high-level", parent = err)
+        }
+      }
+    )
+  }
+
+  high1 <- function(...) high2(...)
+  high2 <- function(...) high3(...)
+  high3 <- NULL
+
+  stop1 <- function(..., call = caller_env()) stop2(..., call = call)
+  stop2 <- function(..., call = caller_env()) stop3(..., call = call)
+  stop3 <- function(..., call = caller_env()) abort(..., call = call)
+
+  throwers <- list(
+    "stop()" = function() stop("low-level"),
+    "abort()" = function() abort("low-level"),
+    "warn = 2" = function() {
+      local_options(warn = 2)
+      warning("low-level")
+    }
+  )
+  handlers <- list(
+    "tryCatch()" = high3_catch,
+    "withCallingHandlers()" = high3_call,
+    "try_fetch()" = high3_fetch
+  )
+
+  for (i in seq_along(throwers)) {
+    for (j in seq_along(handlers)) {
+      case_name <- paste0(
+        "Backtrace on rethrow: ",
+        names(throwers)[[i]], " - ", names(handlers)[[j]]
+      )
+      low3 <- throwers[[i]]
+      high3 <- handlers[[j]]
+
+      # Use `print()` because `testthat_print()` (called implicitly in
+      # snapshots) doesn't print backtraces
+      test_that(case_name, {
+        expect_snapshot({
+          print(catch_error(high1(chain = TRUE, stop_helper = TRUE)))
+          print(catch_error(high1(chain = TRUE, stop_helper = FALSE)))
+
+          print(catch_error(high1(chain = FALSE, stop_helper = TRUE)))
+          print(catch_error(high1(chain = FALSE, stop_helper = FALSE)))
+        })
+      })
+    }
+  }
+})
+
+test_that("abort() displays call in error prefix", {
+  skip_if_not_installed("rlang", "0.4.11.9001")
+
+  expect_snapshot(
+    run("{
+      options(cli.unicode = FALSE, crayon.enabled = FALSE)
+      rlang::abort('foo', call = quote(bar(baz)))
+    }")
+  )
+
+  # errorCondition()
+  skip_if_not_installed("base", "3.6.0")
+
+  expect_snapshot(
+    run("{
+      options(cli.unicode = FALSE, crayon.enabled = FALSE)
+      rlang::cnd_signal(errorCondition('foo', call = quote(bar(baz))))
+    }")
+  )
+})
+
+test_that("abort() accepts environment as `call` field.", {
+  check_required2 <- function(arg, call = caller_call()) {
+    check_required(arg, call = call)
+  }
+  f <- function(x) g(x)
+  g <- function(x) h(x)
+  h <- function(x) check_required2(x, call = environment())
+
+  expect_snapshot((expect_error(f())))
+})
+
+test_that("format_error_arg() formats argument", {
+  exp <- format_arg("foo")
+
+  expect_equal(format_error_arg("foo"), exp)
+  expect_equal(format_error_arg(sym("foo")), exp)
+  expect_equal(format_error_arg(chr_get("foo", 0L)), exp)
+  expect_equal(format_error_arg(quote(foo())), format_arg("foo()"))
+
+  expect_error(format_error_arg(c("foo", "bar")), "must be a string or an expression")
+  expect_error(format_error_arg(function() NULL), "must be a string or an expression")
+})
+
+test_that("local_error_call() works", {
+  foo <- function() {
+    bar()
+  }
+  bar <- function() {
+    local_error_call(quote(expected()))
+    baz()
+  }
+  baz <- function() {
+    local_error_call("caller")
+    abort("tilt")
+  }
+
+  expect_snapshot((expect_error(foo())))
+})
+
+test_that("can disable error call inference for unexported functions", {
+  foo <- function() abort("foo")
+
+  expect_snapshot({
+    (expect_error(foo()))
+
+    local({
+      local_options("rlang:::restrict_default_error_call" = TRUE)
+      (expect_error(foo()))
+    })
+
+    local({
+      local_options("rlang:::restrict_default_error_call" = TRUE)
+      (expect_error(dots_list(.homonyms = "k")))
+    })
+  })
+})
+
+test_that("error call flag is stripped", {
+  e <- env(.__error_call__. = quote(foo(bar)))
+  expect_equal(error_call(e), quote(foo(bar)))
+  expect_equal(format_error_call(e), "`foo()`")
+})
+
+test_that("NSE doesn't interfere with error call contexts", {
+  # Snapshots shouldn't show `eval()` as context
+  expect_snapshot({
+    (expect_error(local(arg_match0("f", "foo"))))
+    (expect_error(eval_bare(quote(arg_match0("f", "foo")))))
+    (expect_error(eval_bare(quote(arg_match0("f", "foo")), env())))
+  })
+})
+
+test_that("error_call() requires a symbol in function position", {
+  expect_null(format_error_call(quote((function() NULL)())))
+  expect_null(format_error_call(call2(function() NULL)))
+})
+
+test_that("error_call() preserves index calls", {
+  expect_equal(format_error_call(quote(foo$bar(...))), "`foo$bar()`")
+})
+
+test_that("error_call() preserves `if` (r-lib/testthat#1429)", {
+  call <- quote(if (foobar) TRUE else FALSE)
+
+  expect_equal(
+    error_call(call),
+    call
+  )
+  expect_equal(
+    format_error_call(call),
+    "`if (foobar) ...`"
+  )
+})
+
+test_that("error_call() and format_error_call() preserve special syntax ops", {
+  expect_equal(
+    error_call(quote(1 + 2)),
+    quote(1 + 2)
+  )
+  expect_snapshot(format_error_call(quote(1 + 2)))
+
+  expect_equal(
+    error_call(quote(for (x in y) NULL)),
+    quote(for (x in y) NULL)
+  )
+  expect_snapshot(format_error_call(quote(for (x in y) NULL)))
+
+  expect_snapshot(format_error_call(quote(a %||% b)))
+  expect_snapshot(format_error_call(quote(`%||%`())))  # Suboptimal
+})
+
+test_that("error_call() preserves srcrefs", {
+  eval_parse("{
+    f <- function() g()
+    g <- function() h()
+    h <- function() abort('Foo.')
+  }")
+
+  out <- error_call(catch_error(f())$call)
+  expect_s3_class(attr(out, "srcref"), "srcref")
+})
+
+test_that("withCallingHandlers() wrappers don't throw off trace capture on rethrow", {
+  local_options(
+    rlang_trace_top_env = current_env(),
+    rlang_trace_format_srcrefs = FALSE
+  )
+
+  variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
+
+  low1 <- function() low2()
+  low2 <- function() low3()
+  low3 <- function() abort("Low-level message")
+
+  wch <- function(expr, ...) {
+    withCallingHandlers(expr, ...)
+  }
+  handler1 <- function(err, call = caller_env()) {
+    handler2(err, call = call)
+  }
+  handler2 <- function(err, call = caller_env()) {
+    abort("High-level message", parent = err, call = call)
+  }
+
+  high1 <- function() high2()
+  high2 <- function() high3()
+  high3 <- function() {
+    wch(
+      low1(),
+      error = function(err) handler1(err)
+    )
+  }
+
+  err <- expect_error(high1())
+  expect_snapshot(variant = variant, {
+    "`abort()` error"
+    print(err)
+    summary(err)
+  })
+
+  # Avoid `:::` vs `::` ambiguity depending on loadall
+  fail <- errorcall
+  low3 <- function() fail(NULL, "Low-level message")
+  err <- expect_error(high1())
+  expect_snapshot(variant = variant, {
+    "C-level error"
+    print(err)
+    summary(err)
+  })
+})
+
+test_that("headers and body are stored in respective fields", {
+  local_use_cli()  # Just to be explicit
+
+  cnd <- catch_cnd(abort(c("a", "b", i = "c")), "error")
+  expect_equal(cnd$message, set_names("a", ""))
+  expect_equal(cnd$body, c("b", i = "c"))
+})
+
+test_that("`abort()` uses older bullets formatting by default", {
+  local_use_cli(format = FALSE)
+  expect_snapshot_error(abort(c("foo", "bar")))
+})
+
+test_that("abort() preserves `call`", {
+  err <- catch_cnd(abort("foo", call = quote(1 + 2)), "error")
+  expect_equal(err$call, quote(1 + 2))
+})
+
+test_that("format_error_call() preserves I() inputs", {
+  expect_equal(
+    format_error_call(I(quote(.data[[1]]))),
+    "`.data[[1]]`"
+  )
+})
+
+test_that("format_error_call() detects non-syntactic names", {
+  expect_equal(
+    format_error_call(quote(`[[.foo`())),
+    "`[[.foo`"
+  )
+})
+
+test_that("generic call is picked up in methods", {
+  g <- function(call = caller_env()) {
+    abort("foo", call = call)
+  }
+
+  f1 <- function(x) {
+    UseMethod("f1")
+  }
+  f1.default <- function(x) {
+    g()
+  }
+
+  f2 <- function(x) {
+    UseMethod("f2")
+  }
+  f2.NULL <- function(x) {
+    NextMethod()
+  }
+  f2.default <- function(x) {
+    g()
+  }
+
+  f3 <- function(x) {
+    UseMethod("f3")
+  }
+  f3.foo <- function(x) {
+    NextMethod()
+  }
+  f3.bar <- function(x) {
+    NextMethod()
+  }
+  f3.default <- function(x) {
+    g()
+  }
+
+  expect_snapshot({
+    err(f1())
+    err(f2())
+    err(f3())
+  })
+})
+
+test_that("errors are fully displayed (parents, calls) in knitted files", {
+  skip_if_not_installed("knitr")
+  skip_if_not_installed("rmarkdown")
+  skip_if(!rmarkdown::pandoc_available())
+
+  expect_snapshot({
+    writeLines(render_md("test-parent-errors.Rmd"))
+  })
+})
+
+test_that("can supply bullets both through `message` and `body`", {
+  local_use_cli(format = FALSE)
+  expect_snapshot({
+    (expect_error(abort("foo", body = c("a", "b"))))
+    (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
+  })
+})
+
+test_that("can supply bullets both through `message` and `body` (cli case)", {
+  local_use_cli(format = TRUE)
+  expect_snapshot({
+    (expect_error(abort("foo", body = c("a", "b"))))
+    (expect_error(abort(c("foo", "bar"), body = c("a", "b"))))
+  })
+})
+
+test_that("setting `.internal` adds footer bullet", {
+  expect_snapshot({
+    err(abort(c("foo", "x" = "bar"), .internal = TRUE))
+    err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
+  })
+})
+
+test_that("setting `.internal` adds footer bullet (fallback)", {
+  local_use_cli(format = FALSE)
+  expect_snapshot({
+    err(abort(c("foo", "x" = "bar"), .internal = TRUE))
+    err(abort("foo", body = c("x" = "bar"), .internal = TRUE))
+  })
+})
+
+test_that("must pass character `body` when `message` is > 1", {
+  expect_snapshot({
+    # This is ok because `message` is length 1
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
+
+    # This is an internal error
+    err(abort(c("foo", "bar"), body = function() "baz"))
+  })
+})
+
+test_that("must pass character `body` when `message` is > 1 (non-cli case)", {
+  local_use_cli(format = FALSE)
+  expect_snapshot({
+    # This is ok because `message` is length 1
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar")))
+
+    # This is an internal error
+    err(abort(c("foo", "bar"), body = function() "baz"))
+  })
+})
+
+test_that("can supply `footer`", {
+  local_error_call(call("f"))
+  expect_snapshot({
+    err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
+  })
+})
+
+test_that("can supply `footer` (non-cli case)", {
+  local_use_cli(format = FALSE)
+  local_error_call(call("f"))
+  expect_snapshot({
+    err(abort("foo", body = c("i" = "bar"), footer = c("i" = "baz")))
+    err(abort("foo", body = function(cnd, ...) c("i" = "bar"), footer = function(cnd, ...) c("i" = "baz")))
+  })
+})
+
+test_that("can't supply both `footer` and `.internal`", {
+  expect_snapshot({
+    err(abort("foo", .internal = TRUE, call = quote(f())))
+    err(abort("foo", footer = "bar", .internal = TRUE, call = quote(f())))
+  })
+})
+
+test_that("caller of withCallingHandlers() is used as default `call`", {
+  low <- function() {
+    # Intervening `withCallingHandlers()` is not picked up
+    withCallingHandlers(stop("low"))
+  }
+  high <- function() {
+    withCallingHandlers(
+      low(),
+      error = function(cnd) abort("high", parent = cnd)
+    )
+  }
+  err <- catch_error(high())
+  expect_equal(err$call, quote(high()))
+
+  # Named case
+  handler <- function(cnd) abort("high", parent = cnd)
+  high <- function() {
+    withCallingHandlers(
+      low(),
+      error = handler
+    )
+  }
+  err <- catch_error(high())
+  expect_equal(err$call, quote(high()))
+
+  # Wrapped case
+  handler1 <- function(cnd) handler2(cnd)
+  handler2 <- function(cnd) abort("high", parent = cnd)
+  high <- function() {
+    try_fetch(
+      low(),
+      error = handler1
+    )
+  }
+  err <- catch_error(high())
+  expect_equal(err$call, quote(high()))
+
+  function(cnd) abort("high", parent = cnd)
+})
+
+test_that("`cli.condition_unicode_bullets` is supported by fallback formatting", {
+  local_use_cli(format = FALSE)
+  local_options(
+    cli.unicode = TRUE,
+    cli.condition_unicode_bullets = FALSE
+  )
+  expect_snapshot_error(
+    rlang::abort(c("foo", "i" = "bar"))
+  )
+})
+
+test_that("call can be a quosure or contain quosures", {
+  err <- catch_error(abort("foo", call = quo(f(!!quo(g())))))
+  expect_equal(err$call, quote(f(g())))
+})
+
+test_that("`parent = NA` signals a non-chained rethrow", {
+  variant <- if (getRversion() < "3.6.0") "pre-3.6.0" else "current"
+
+  local_options(
+    rlang_trace_top_env = current_env(),
+    rlang_trace_format_srcrefs = FALSE
+  )
+
+  ff <- function() gg()
+  gg <- function() hh()
+
+  foo <- function() bar()
+  bar <- function() baz()
+  baz <- function() stop("bar")
+
+  expect_snapshot(variant = variant, {
+    "Absent parent causes bad trace bottom"
+    hh <- function() {
+      withCallingHandlers(foo(), error = function(cnd) {
+        abort(cnd_header(cnd))
+      })
+    }
+    print(err(ff()))
+
+    "Missing parent allows correct trace bottom"
+    hh <- function() {
+      withCallingHandlers(foo(), error = function(cnd) {
+        abort(cnd_header(cnd), parent = NA)
+      })
+    }
+    print(err(ff()))
+
+    "Wrapped handler"
+    handler1 <- function(cnd, call = caller_env()) handler2(cnd, call)
+    handler2 <- function(cnd, call) abort(cnd_header(cnd), parent = NA, call = call)
+    hh <- function() {
+      withCallingHandlers(
+        foo(),
+        error = function(cnd) handler1(cnd)
+      )
+    }
+    print(err(ff()))
+
+    "Wrapped handler, `try_fetch()`"
+    hh <- function() {
+      try_fetch(
+        foo(),
+        error = function(cnd) handler1(cnd)
+      )
+    }
+    print(err(ff()))
+
+    "Wrapped handler, incorrect `call`"
+    hh <- function() {
+      withCallingHandlers(
+        foo(),
+        error = handler1
+      )
+    }
+    print(err(ff()))
+  })
+})
+
+test_that("can rethrow outside handler", {
+  local_options(rlang_trace_format_srcrefs = FALSE)
+
+  parent <- error_cnd(message = "Low-level", call = call("low"))
+
+  foo <- function() bar()
+  bar <- function() baz()
+  baz <- function() abort("High-level", parent = parent)
+
+  expect_snapshot({
+    print(err(foo()))
+  })
+})
+
+test_that("if `call` is older than handler caller, use that as bottom", {
+  local_options(
+    rlang_trace_format_srcrefs = FALSE
+  )
+  f <- function() helper()
+  helper <- function(call = caller_env()) {
+    try_fetch(
+      low_level(call),
+      error = function(cnd) abort(
+        "Problem.",
+        parent = cnd,
+        call = call
+      )
+    )
+  }
+
+  expect_snapshot({
+    low_level <- function(call) {
+      abort("Tilt.", call = call)
+    }
+    print(expect_error(f()))
+
+    low_level <- function(call) {
+      abort("Tilt.", call = list(NULL, frame = call))
+    }
+    print(expect_error(f()))
+  })
+})
+
+test_that("is_calling_handler_inlined_call() doesn't fail with OOB subsetting", {
+  expect_false(is_calling_handler_inlined_call(call2(function() NULL)))
+})
+
+test_that("base causal errors include full user backtrace", {
+  local_options(
+    rlang_trace_format_srcrefs = FALSE,
+    rlang_trace_top_env = current_env()
+  )
+
+  my_verb <- function(expr) {
+    with_chained_errors(expr)
+  }
+  with_chained_errors <- function(expr, call = caller_env()) {
+    try_fetch(
+      expr,
+      error = function(cnd) {
+        abort(
+          "Problem during step.",
+          parent = cnd,
+          call = call
+        )
+      }
+    )
+  }
+
+  add <- function(x, y) x + y
+  expect_snapshot({
+    print(expect_error(my_verb(add(1, ""))))
+  })
+})
+
+test_that("can chain errors at top-level (#1405)", {
+  out <- run_code("
+    tryCatch(
+      error = function(err) rlang::abort('bar', parent = err),
+      rlang::abort('foo')
+    )
+  ")
+  expect_true(any(grepl("foo", out$output)))
+  expect_true(any(grepl("bar", out$output)))
+
+  out <- run_code("
+    withCallingHandlers(
+      error = function(err) rlang::abort('bar', parent = err),
+      rlang::abort('foo')
+    )
+  ")
+  expect_true(any(grepl("foo", out$output)))
+  expect_true(any(grepl("bar", out$output)))
+})
+
+test_that("backtrace_on_error = 'collapse' is deprecated.", {
+  local_options("rlang_backtrace_on_error" = "collapse")
+  expect_warning(peek_backtrace_on_error(), "deprecated")
+  expect_equal(peek_option("rlang_backtrace_on_error"), "none")
+})
+
+test_that("can supply header method via `message`", {
+  expect_snapshot(error = TRUE, {
+    abort(~ "foo")
+    abort(function(cnd, ...) "foo")
+  })
+
+  msg <- function(cnd, ...) "foo"
+  cnd <- catch_error(abort(msg))
+  expect_identical(cnd$header, msg)
+
+  expect_error(
+    abort(function(cnd) "foo"),
+    "must take"
+  )
+})
+
+test_that("newlines are preserved by cli (#1535)", {
+  expect_snapshot(error = TRUE, {
+    abort("foo\nbar", use_cli_format = TRUE)
+    abort("foo\fbar", use_cli_format = TRUE)
+  })
+})
+
+test_that("`show.error.messages` is respected by `abort()` (#1630)", {
+  run_error_script <- function(envvars = chr()) {
+    run_script(test_path("fixtures", "error-show-messages.R"), envvars = envvars)
+  }
+
+  with_messages <- run_error_script(envvars = c("show_error_messages=TRUE"))
+  without_messages <- run_error_script(envvars = c("show_error_messages=FALSE"))
+
+  expect_snapshot({
+    cat_line(with_messages)
+    cat_line(without_messages)
+  })
+})

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -333,7 +333,7 @@ test_that("warnings are resignalled", {
   )
 
   expect_s3_class(cnd, "rlang_warning")
-  expect_true(!is_null(cnd$trace))
+  expect_false(is_null(cnd$trace))
 })
 
 test_that("can call `global_entrace()` in knitted documents", {

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -34,8 +34,8 @@ test_that("line_push() strips ANSI codes before computing overflow", {
   if (!has_ansi()) {
     skip("test needs cli")
   }
-  expect_identical(length(line_push("foo", open_blue(), width = 3L)), 2L)
-  expect_identical(length(line_push("foo", open_blue(), width = 3L, has_colour = TRUE)), 1L)
+  expect_length(line_push("foo", open_blue(), width = 3L), 2L)
+  expect_length(line_push("foo", open_blue(), width = 3L, has_colour = TRUE), 1L)
 })
 
 test_that("can push several lines (useful for default base deparser)", {
@@ -364,7 +364,7 @@ test_that("expr_text() deparses empty arguments", {
 test_that("expr_name() deparses empty arguments", {
   expect_identical(expr_name(expr()), "")
   expect_identical(quo_name(quo()), "")
-  expect_identical(names(quos_auto_name(quos(, ))), "<empty>")
+  expect_named(quos_auto_name(quos(, )), "<empty>")
   expect_identical(as_label(expr()), "<empty>")
 })
 

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -79,8 +79,8 @@ test_that("names are preserved", {
 
   nms <- as.character(1:3)
   x <- set_names(1:3, nms)
-  expect_identical(names(as_double(x)), nms)
-  expect_identical(names(as_list(x)), nms)
+  expect_named(as_double(x), nms)
+  expect_named(as_list(x), nms)
 })
 
 test_that("as_character() support logical NA", {

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -51,7 +51,7 @@ test_that("can take forced dots with `allowForced = FALSE`", {
 test_that("captured dots are only named if names were supplied", {
   fn <- function(...) captureDots()
   expect_null(names(fn(1, 2)))
-  expect_identical(names(fn(a = 1, 2)), c("a", ""))
+  expect_named(fn(a = 1, 2), c("a", ""))
 })
 
 test_that("dots_values() handles forced dots", {
@@ -380,11 +380,11 @@ test_that("names are not mutated after splice box early exit", {
   xs <- list(1)
 
   dots_list(!!!xs, .named = FALSE)
-  expect_equal(names(xs), NULL)
+  expect_null(names(xs))
 
   dots_list(!!!xs, .named = TRUE)
-  expect_equal(names(xs), NULL)
+  expect_null(names(xs))
 
   dots_list(!!!xs, .named = NULL)
-  expect_equal(names(xs), NULL)
+  expect_null(names(xs))
 })

--- a/tests/testthat/test-encoding.R
+++ b/tests/testthat/test-encoding.R
@@ -34,5 +34,5 @@ test_that("dots names are converted to and from UTF-8 (#1218)", {
   names(call)[[2]] <- x
   out <- eval(as.call(call))
 
-  expect_equal(names(out), x)
+  expect_named(out, x)
 })

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -403,7 +403,7 @@ test_that("env_poke() doesn't warn when unrepresentable characters are serialise
 
 test_that("new_environment() supports non-list data", {
   env <- new_environment(c(a = 1))
-  expect_equal(typeof(env), "environment")
+  expect_type(env, "environment")
   expect_equal(env$a, 1)
 })
 

--- a/tests/testthat/test-env-special.R
+++ b/tests/testthat/test-env-special.R
@@ -5,7 +5,7 @@ test_that("search_envs() includes the global and base env", {
 })
 
 test_that("search_envs() returns named environments", {
-  expect_identical(names(search_envs()), c("global", search()[-1]))
+  expect_named(search_envs(), c("global", search()[-1]))
 })
 
 test_that("search_envs() returns an rlang_envs object", {

--- a/tests/testthat/test-env.R
+++ b/tests/testthat/test-env.R
@@ -135,8 +135,8 @@ test_that("new_environment() creates a child of the empty env", {
 })
 
 test_that("new_environment() accepts empty vectors", {
-  expect_identical(length(new_environment()), 0L)
-  expect_identical(length(new_environment(dbl())), 0L)
+  expect_length(new_environment(), 0L)
+  expect_length(new_environment(dbl()), 0L)
 })
 
 test_that("env_tail() detects sentinel", {
@@ -223,7 +223,7 @@ test_that("env_parents() stops at the sentinel if supplied", {
 
 test_that("env_parents() returns a named list", {
   env <- env(structure(env(base_env()), name = "foobar"))
-  expect_identical(names(env_parents(env)), c("foobar", "package:base", "empty"))
+  expect_named(env_parents(env), c("foobar", "package:base", "empty"))
 })
 
 test_that("can lock environments", {

--- a/tests/testthat/test-fn.R
+++ b/tests/testthat/test-fn.R
@@ -18,14 +18,14 @@ test_that("prim_name() extracts names", {
 })
 
 test_that("as_closure() returns closure", {
-  expect_identical(typeof(as_closure(base::list)), "closure")
-  expect_identical(typeof(as_closure("list")), "closure")
+  expect_type(as_closure(base::list), "closure")
+  expect_type(as_closure("list"), "closure")
 })
 
 test_that("as_closure() handles primitive functions", {
   expect_identical(as_closure(`c`)(1, 3, 5), c(1, 3, 5))
-  expect_identical(as_closure(is.null)(1), FALSE)
-  expect_identical(as_closure(is.null)(NULL), TRUE)
+  expect_false(as_closure(is.null)(1))
+  expect_true(as_closure(is.null)(NULL))
 })
 
 test_that("as_closure() supports base-style and purrr-style arguments to binary operators", {
@@ -37,17 +37,17 @@ test_that("as_closure() supports base-style and purrr-style arguments to binary 
   expect_error(and(.x = TRUE, e1 = TRUE), "Can't supply both `e1` and `.x` to binary operator")
   expect_error(and(TRUE, .y = TRUE, e2 = TRUE), "Can't supply both `e2` and `.y` to binary operator")
 
-  expect_identical(and(FALSE, FALSE), FALSE)
-  expect_identical(and(TRUE, FALSE), FALSE)
-  expect_identical(and(FALSE, TRUE), FALSE)
-  expect_identical(and(TRUE, TRUE), TRUE)
+  expect_false(and(FALSE, FALSE))
+  expect_false(and(TRUE, FALSE))
+  expect_false(and(FALSE, TRUE))
+  expect_true(and(TRUE, TRUE))
 
-  expect_identical(and(.y = FALSE, TRUE), FALSE)
-  expect_identical(and(e2 = FALSE, TRUE), FALSE)
-  expect_identical(and(.y = FALSE, e1 = TRUE), FALSE)
-  expect_identical(and(e2 = FALSE, .x = TRUE), FALSE)
-  expect_identical(and(.y = FALSE, TRUE), FALSE)
-  expect_identical(and(e2 = FALSE, TRUE), FALSE)
+  expect_false(and(.y = FALSE, TRUE))
+  expect_false(and(e2 = FALSE, TRUE))
+  expect_false(and(.y = FALSE, e1 = TRUE))
+  expect_false(and(e2 = FALSE, .x = TRUE))
+  expect_false(and(.y = FALSE, TRUE))
+  expect_false(and(e2 = FALSE, TRUE))
 })
 
 test_that("as_closure() supports base-style and purrr-style arguments to versatile operators", {
@@ -80,9 +80,9 @@ test_that("as_closure(`||`) shortcircuits", {
   expect_error(or(), "Must supply `e1` or `.x` to binary operator")
   expect_error(or(FALSE), "Must supply `e2` or `.y` to binary operator")
 
-  expect_identical(or(TRUE), TRUE)
-  expect_identical(or(.x = TRUE), TRUE)
-  expect_identical(or(e1 = TRUE), TRUE)
+  expect_true(or(TRUE))
+  expect_true(or(.x = TRUE))
+  expect_true(or(e1 = TRUE))
 })
 
 test_that("as_closure() handles operators", {

--- a/tests/testthat/test-nse-defuse.R
+++ b/tests/testthat/test-nse-defuse.R
@@ -89,7 +89,7 @@ test_that("dot names are interpolated", {
 
 test_that("corner cases are handled when interpolating dot names", {
     var <- na_chr
-    expect_identical(names(quos(!!var := NULL)), "NA")
+    expect_named(quos(!!var := NULL), "NA")
 
     var <- NULL
     expect_snapshot({
@@ -139,7 +139,7 @@ test_that("can capture empty list of dots", {
 
 test_that("quosures are spliced before serialisation", {
   quosures <- quos(!! quo(foo(!! quo(bar))), .named = TRUE)
-  expect_identical(names(quosures), "foo(bar)")
+  expect_named(quosures, "foo(bar)")
 })
 
 test_that("missing arguments are captured", {
@@ -326,13 +326,13 @@ test_that("endots() requires symbols", {
 test_that("endots() returns a named list", {
   # enquos()
   fn <- function(foo, bar) enquos(foo, bar)
-  expect_identical(names(fn()), c("", ""))
+  expect_named(fn(), c("", ""))
   fn <- function(arg, ...) enquos(other = arg, ...)
   expect_identical(fn(arg = 1, b = 2), quos(other = 1, b = 2))
 
   # enexprs()
   fn <- function(foo, bar) enexprs(foo, bar)
-  expect_identical(names(fn()), c("", ""))
+  expect_named(fn(), c("", ""))
   fn <- function(arg, ...) enexprs(other = arg, ...)
   expect_identical(fn(arg = 1, b = 2), exprs(other = 1, b = 2))
 })

--- a/tests/testthat/test-obj.R
+++ b/tests/testthat/test-obj.R
@@ -3,7 +3,7 @@ test_that("poke_type() changes object type", {
   out <- withVisible(poke_type(x, "language"))
   expect_false(out$visible)
   expect_identical(out$value, x)
-  expect_identical(typeof(x), "language")
+  expect_type(x, "language")
 })
 
 test_that("can access promise properties", {

--- a/tests/testthat/test-quo.R
+++ b/tests/testthat/test-quo.R
@@ -149,8 +149,8 @@ test_that("quo_deparse() indicates quosures with `^`", {
 
 test_that("quosure deparser respects width", {
   x <- quo(foo(quo(!!quo(bar))))
-  expect_identical(length(quo_deparse(x, new_quo_deparser(width = 8L))), 3L)
-  expect_identical(length(quo_deparse(x, new_quo_deparser(width = 9L))), 2L)
+  expect_length(quo_deparse(x, new_quo_deparser(width = 8L)), 3L)
+  expect_length(quo_deparse(x, new_quo_deparser(width = 9L)), 2L)
 })
 
 test_that("quosure predicates work", {

--- a/tests/testthat/test-s3.R
+++ b/tests/testthat/test-s3.R
@@ -90,7 +90,7 @@ test_that("can pass additional attributes to boxes", {
 test_that("done() boxes values", {
   expect_true(is_done_box(done(3)))
   expect_identical(unbox(done(3)), 3)
-  expect_identical(done(3) %@% empty, FALSE)
+  expect_false(done(3) %@% empty)
 })
 
 test_that("done() can be empty", {
@@ -100,7 +100,7 @@ test_that("done() can be empty", {
 
   expect_true(is_done_box(empty))
   expect_s3_class(empty, "rlang_box_done")
-  expect_identical(empty %@% empty, TRUE)
+  expect_true(empty %@% empty)
 
   expect_true(is_done_box(empty, empty = TRUE))
   expect_false(is_done_box(empty, empty = FALSE))

--- a/tests/testthat/test-standalone-vctrs.R
+++ b/tests/testthat/test-standalone-vctrs.R
@@ -191,27 +191,27 @@ test_that("vec_ptype_common() finalises unspecified type", {
 })
 
 test_that("safe casts work", {
-  expect_equal(vec_cast(NULL, logical()), NULL)
-  expect_equal(vec_cast(TRUE, logical()), TRUE)
-  expect_equal(vec_cast(1L, logical()), TRUE)
-  expect_equal(vec_cast(1, logical()), TRUE)
+  expect_null(vec_cast(NULL, logical()))
+  expect_true(vec_cast(TRUE, logical()))
+  expect_true(vec_cast(1L, logical()))
+  expect_true(vec_cast(1, logical()))
 
-  expect_equal(vec_cast(NULL, integer()), NULL)
+  expect_null(vec_cast(NULL, integer()))
   expect_equal(vec_cast(TRUE, integer()), 1L)
   expect_equal(vec_cast(1L, integer()), 1L)
   expect_equal(vec_cast(1, integer()), 1L)
 
-  expect_equal(vec_cast(NULL, double()), NULL)
+  expect_null(vec_cast(NULL, double()))
   expect_equal(vec_cast(TRUE, double()), 1L)
   expect_equal(vec_cast(1.5, double()), 1.5)
   expect_equal(vec_cast(1.5, double()), 1.5)
 
   expect_equal(vec_cast("", chr()), "")
 
-  expect_equal(vec_cast(NULL, character()), NULL)
+  expect_null(vec_cast(NULL, character()))
   expect_equal(vec_cast(NA, character()), NA_character_)
 
-  expect_equal(vec_cast(NULL, list()), NULL)
+  expect_null(vec_cast(NULL, list()))
   expect_equal(vec_cast(NA, list()), list(NULL))
   expect_equal(vec_cast(list(1L, 2L), list()), list(1L, 2L))
 })

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -25,7 +25,7 @@ test_that("is_integerish() heeds type requirement", {
   for (n in 0:2) {
     expect_true(is_integerish(integer(n)))
     expect_true(is_integerish(double(n)))
-    expect_false(is_integerish(double(n + 1) + .000001))
+    expect_false(is_integerish(double(n + 1) + 0.000001))
   }
 
   types <- c("logical", "complex", "character", "expression", "list", "raw")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -54,10 +54,7 @@ test_that("detect_run_starts() works", {
     detect_run_starts(chr()),
     lgl()
   )
-  expect_equal(
-    detect_run_starts("a"),
-    TRUE
-  )
+  expect_true(detect_run_starts("a"))
   expect_equal(
     detect_run_starts(NA),
     NA

--- a/tests/testthat/test-weakref.R
+++ b/tests/testthat/test-weakref.R
@@ -6,12 +6,12 @@ test_that("weakref with key and no value allows key to be GC'd", {
   w <- new_weakref(key = k, finalizer = function(e)  w_finalized <<- TRUE)
 
   expect_identical(wref_key(w), k)
-  expect_identical(wref_value(w), NULL)
+  expect_null(wref_value(w))
   expect_false(w_finalized)
 
   rm(k)
   gc()
-  expect_identical(wref_key(w), NULL)
+  expect_null(wref_key(w))
   expect_true(w_finalized)
 })
 


### PR DESCRIPTION
Hello, I'm building a new package to find and automatically fix lints in R code: [`flint`](https://flint.etiennebacher.com/).

I'm using real-life, large packages to check its performance and `rlang` is one of them. Since I already test on this, there's no additional cost for me in proposing those changes.

FYI, those changes were generated with `flint::fix_package()` (with a few corner cases removed by hand because I need to address them in `flint`).

There are many changes but most of them are trivial:
- replace `any(is.na())` by `anyNA()`
- add a leading 0 to decimal (e.g `.1` -> `0.1`)
- use `expect_named()`, `expect_null()`, and friends in tests
etc.

`flint` is quite new and linter rules are necessarily a bit opinionated, so some of those changes might not be to your taste, but I'd be happy to have some feedback on this.