### PR TITLE
Suggests cli 3.1.1 in standalone-cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Depends:
 Imports:
     utils
 Suggests:
-    cli (>= 3.1.0),
+    cli (>= 3.1.1),
     covr,
     crayon,
     fs,

--- a/R/standalone-cli.R
+++ b/R/standalone-cli.R
@@ -3,6 +3,7 @@
 # file: standalone-cli.R
 # last-updated: 2023-10-06
 # license: https://unlicense.org
+# suggests: cli (>= 3.1.1)
 # ---
 #
 # Provides a minimal shim API to format message elements consistently


### PR DESCRIPTION
Addresses r-lib/usethis#2071

Since this standalone file contains calls to functions of the cli package, the cli package must be added to the Suggests field.

It seems that 3.1.1 or higher should be suggested.
https://github.com/r-lib/rlang/blob/3d48c13d052724cd5997a730ea41bc8e6991691b/R/standalone-cli.R#L163