### PR TITLE
Simplify tests by using `cnd_class = TRUE` from `expect_snapshot()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     pillar,
     rmarkdown,
     stats,
-    testthat (>= 3.0.0),
+    testthat (>= 3.2.0),
     tibble,
     usethis,
     vctrs (>= 0.2.3),

--- a/tests/testthat/_snaps/arg.md
+++ b/tests/testthat/_snaps/arg.md
@@ -5,94 +5,85 @@
 # gives an error with more than one arg
 
     Code
-      (expect_error(arg_match0_wrapper(c("bar", "fun"), c("bar", "baz"))))
-    Output
-      <error/rlang_error>
+      arg_match0_wrapper(c("bar", "fun"), c("bar", "baz"))
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `arg` must be length 1 or a permutation of `c("bar", "baz")`.
 
 # gives error with different than rearranged arg vs value
 
-    `myarg` must be one of "fun" or "bar", not "foo".
-
----
-
-    `arg` must be length 1 or a permutation of `c("foo", "bar")`.
+    Code
+      f()
+    Condition
+      Error in `f()`:
+      ! `myarg` must be one of "fun" or "bar", not "foo".
+    Code
+      arg_match0_wrapper(c("foo", "foo"), c("foo", "bar"), arg_nm = "x")
+    Condition
+      Error in `arg_match0_wrapper()`:
+      ! `arg` must be length 1 or a permutation of `c("foo", "bar")`.
 
 # `arg_match()` has informative error messages
 
     Code
-      (expect_error(arg_match_wrapper("continuuos", c("discrete", "continuous"),
-      "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match_wrapper("continuuos", c("discrete", "continuous"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "discrete" or "continuous", not "continuuos".
       i Did you mean "continuous"?
     Code
-      (expect_error(arg_match_wrapper("fou", c("bar", "foo"), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match_wrapper("fou", c("bar", "foo"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "bar" or "foo", not "fou".
       i Did you mean "foo"?
     Code
-      (expect_error(arg_match_wrapper("fu", c("ba", "fo"), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match_wrapper("fu", c("ba", "fo"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "ba" or "fo", not "fu".
       i Did you mean "fo"?
     Code
-      (expect_error(arg_match_wrapper("baq", c("foo", "baz", "bas"), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match_wrapper("baq", c("foo", "baz", "bas"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "foo", "baz", or "bas", not "baq".
       i Did you mean "baz"?
     Code
-      (expect_error(arg_match_wrapper("", character(), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match_wrapper("", character(), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0()`:
       ! `values` must have at least one element.
     Code
-      (expect_error(arg_match_wrapper("fo", "foo", quote(f()))))
-    Output
-      <error/rlang_error>
+      arg_match_wrapper("fo", "foo", quote(f()))
+    Condition <rlang_error>
       Error in `arg_match0()`:
       ! `arg_nm` must be a string or symbol.
 
 # `arg_match()` provides no suggestion when the edit distance is too large
 
     Code
-      (expect_error(arg_match0_wrapper("foobaz", c("fooquxs", "discrete"), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match0_wrapper("foobaz", c("fooquxs", "discrete"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "fooquxs" or "discrete", not "foobaz".
     Code
-      (expect_error(arg_match0_wrapper("a", c("b", "c"), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match0_wrapper("a", c("b", "c"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "b" or "c", not "a".
 
 # `arg_match()` makes case-insensitive match
 
     Code
-      (expect_error(arg_match0_wrapper("a", c("A", "B"), "my_arg"),
-      "Did you mean \"A\"?"))
-    Output
-      <error/rlang_error>
+      arg_match0_wrapper("a", c("A", "B"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "A" or "B", not "a".
       i Did you mean "A"?
     Code
-      (expect_error(arg_match0_wrapper("aa", c("AA", "aA"), "my_arg"),
-      "Did you mean \"aA\"?"))
-    Output
-      <error/rlang_error>
+      arg_match0_wrapper("aa", c("AA", "aA"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "AA" or "aA", not "aa".
       i Did you mean "aA"?
@@ -100,24 +91,21 @@
 # check_required() checks argument is supplied (#1118)
 
     Code
-      (expect_error(f()))
-    Output
-      <error/rlang_error>
+      f()
+    Condition <rlang_error>
       Error in `f()`:
       ! `x` is absent but must be supplied.
     Code
-      (expect_error(g()))
-    Output
-      <error/rlang_error>
+      g()
+    Condition <rlang_error>
       Error in `f()`:
       ! `x` is absent but must be supplied.
 
 # arg_match() supports symbols and scalar strings
 
     Code
-      (expect_error(arg_match0_wrapper(chr_get("fo", 0L), c("bar", "foo"), "my_arg")))
-    Output
-      <error/rlang_error>
+      arg_match0_wrapper(chr_get("fo", 0L), c("bar", "foo"), "my_arg")
+    Condition <rlang_error>
       Error in `arg_match0_wrapper()`:
       ! `my_arg` must be one of "bar" or "foo", not "fo".
       i Did you mean "foo"?
@@ -125,25 +113,22 @@
 # arg_match() requires an argument symbol
 
     Code
-      (expect_error(wrapper()))
-    Output
-      <error/rlang_error>
+      wrapper()
+    Condition <rlang_error>
       Error in `arg_match()`:
       ! `arg` must be a symbol, not the string "foo".
 
 # can match multiple arguments
 
     Code
-      (expect_error(my_wrapper("ba")))
-    Output
-      <error/rlang_error>
+      my_wrapper("ba")
+    Condition <rlang_error>
       Error in `my_wrapper()`:
       ! `my_arg` must be one of "foo", "bar", or "baz", not "ba".
       i Did you mean "bar"?
     Code
-      (expect_error(my_wrapper(c("foo", "ba"))))
-    Output
-      <error/rlang_error>
+      my_wrapper(c("foo", "ba"))
+    Condition <rlang_error>
       Error in `my_wrapper()`:
       ! `my_arg` must be one of "foo", "bar", or "baz", not "ba".
       i Did you mean "bar"?
@@ -151,45 +136,39 @@
 # arg_match0() defuses argument
 
     Code
-      (expect_error(fn("foo")))
-    Output
-      <error/rlang_error>
+      fn("foo")
+    Condition <rlang_error>
       Error in `fn()`:
       ! `arg` must be one of "bar" or "baz", not "foo".
     Code
-      (expect_error(arg_match0("foo", c("bar", "baz"))))
-    Output
-      <error/rlang_error>
+      arg_match0("foo", c("bar", "baz"))
+    Condition <rlang_error>
       Error:
       ! `"foo"` must be one of "bar" or "baz", not "foo".
 
 # check_exclusive works
 
     Code
-      (expect_error(f()))
-    Output
-      <error/rlang_error>
+      f()
+    Condition <rlang_error>
       Error in `check_exclusive()`:
       ! Must supply at least two arguments.
     Code
-      (expect_error(g()))
-    Output
-      <error/rlang_error>
+      g()
+    Condition <rlang_error>
       Error in `check_exclusive()`:
       ! Must supply at least two arguments.
     Code
-      (expect_error(h()))
-    Output
-      <error/rlang_error>
+      h()
+    Condition <rlang_error>
       Error in `check_exclusive()`:
       ! Must supply at least two arguments.
 
 ---
 
     Code
-      (expect_error(f()))
-    Output
-      <error/rlang_error>
+      f()
+    Condition <rlang_error>
       Error in `f()`:
       ! One of `foo` or `bar` must be supplied.
 
@@ -197,16 +176,14 @@
 
     Code
       # All arguments supplied
-      (expect_error(g(foo, bar, baz)))
-    Output
-      <error/rlang_error>
+      g(foo, bar, baz)
+    Condition <rlang_error>
       Error in `g()`:
       ! Exactly one of `foo`, `bar`, or `baz` must be supplied.
     Code
       # Some arguments supplied
-      (expect_error(g(foo, bar)))
-    Output
-      <error/rlang_error>
+      g(foo, bar)
+    Condition <rlang_error>
       Error in `g()`:
       ! Exactly one of `foo`, `bar`, or `baz` must be supplied.
       x `foo` and `bar` were supplied together.
@@ -214,15 +191,13 @@
 # arg_match() mentions correct call if wrong type is supplied (#1388)
 
     Code
-      (expect_error(f(1)))
-    Output
-      <error/rlang_error>
+      f(1)
+    Condition <rlang_error>
       Error in `f()`:
       ! `my_arg` must be a string or character vector.
     Code
-      (expect_error(g(1)))
-    Output
-      <error/rlang_error>
+      g(1)
+    Condition <rlang_error>
       Error in `g()`:
       ! `my_arg` must be a character vector, not the number 1.
 
@@ -253,21 +228,18 @@
 # arg_match() supports `NA` (#1519)
 
     Code
-      (expect_error(f(NA)))
-    Output
-      <error/rlang_error>
+      f(NA)
+    Condition <rlang_error>
       Error in `f()`:
       ! `x` must be a character vector, not `NA`.
     Code
-      (expect_error(f(na_chr)))
-    Output
-      <error/rlang_error>
+      f(na_chr)
+    Condition <rlang_error>
       Error in `f()`:
       ! `x` must be a single string, not a character `NA`.
     Code
-      (expect_error(f(chr())))
-    Output
-      <error/rlang_error>
+      f(chr())
+    Condition <rlang_error>
       Error in `f()`:
       ! `x` must be length 1, not length 0
 

--- a/tests/testthat/_snaps/attr.md
+++ b/tests/testthat/_snaps/attr.md
@@ -1,15 +1,13 @@
 # inputs must be valid
 
     Code
-      (expect_error(set_names(environment())))
-    Output
-      <error/rlang_error>
+      set_names(environment())
+    Condition <rlang_error>
       Error in `set_names()`:
       ! `x` must be a vector
     Code
-      (expect_error(set_names(1:10, letters[1:4])))
-    Output
-      <error/rlang_error>
+      set_names(1:10, letters[1:4])
+    Condition <rlang_error>
       Error in `set_names()`:
       ! The size of `nm` (4) must be compatible with the size of `x` (10).
 

--- a/tests/testthat/_snaps/c-api.md
+++ b/tests/testthat/_snaps/c-api.md
@@ -22,9 +22,10 @@
 # re-encoding fails purposefully with any bytes
 
     Code
-      (expect_error(r_obj_encode_utf8(bytes)))
-    Output
-      <simpleError in r_obj_encode_utf8(bytes): translating strings with "bytes" encoding is not allowed>
+      r_obj_encode_utf8(bytes)
+    Condition <simpleError>
+      Error in `r_obj_encode_utf8()`:
+      ! translating strings with "bytes" encoding is not allowed
 
 ---
 

--- a/tests/testthat/_snaps/cnd-handlers.md
+++ b/tests/testthat/_snaps/cnd-handlers.md
@@ -1,9 +1,8 @@
 # try_fetch() checks inputs
 
     Code
-      (expect_error(try_fetch(NULL, function(...) NULL)))
-    Output
-      <error/rlang_error>
+      try_fetch(NULL, function(...) NULL)
+    Condition <rlang_error>
       Error in `try_fetch()`:
       ! `...` must be named with condition classes.
 

--- a/tests/testthat/_snaps/cnd-message.md
+++ b/tests/testthat/_snaps/cnd-message.md
@@ -209,18 +209,16 @@
 # parent errors prints with bullets in all cases
 
     Code
-      (expect_error(f(TRUE)))
-    Output
-      <error/rlang_error>
+      f(TRUE)
+    Condition <rlang_error>
       Error in `f()`:
       ! Wrapper
       Caused by error in `f()`:
       ! Header
       i Bullet
     Code
-      (expect_error(f(FALSE)))
-    Output
-      <error/rlang_error>
+      f(FALSE)
+    Condition <rlang_error>
       Error in `f()`:
       ! Wrapper
       Caused by error in `f()`:

--- a/tests/testthat/_snaps/cnd-signal.md
+++ b/tests/testthat/_snaps/cnd-signal.md
@@ -61,27 +61,23 @@
 # signal functions check inputs
 
     Code
-      (expect_error(abort(error_cnd("foo"))))
-    Output
-      <error/rlang_error>
+      abort(error_cnd("foo"))
+    Condition <rlang_error>
       Error in `abort()`:
       ! `message` must be a character vector, not a <foo> object.
     Code
-      (expect_error(inform(error_cnd("foo"))))
-    Output
-      <error/rlang_error>
+      inform(error_cnd("foo"))
+    Condition <rlang_error>
       Error in `inform()`:
       ! `message` must be a character vector, not a <foo> object.
     Code
-      (expect_error(warn(class = error_cnd("foo"))))
-    Output
-      <error/rlang_error>
+      warn(class = error_cnd("foo"))
+    Condition <rlang_error>
       Error in `warn()`:
       ! `class` must be a character vector, not a <foo> object.
     Code
-      (expect_error(abort("foo", call = base::call)))
-    Output
-      <error/rlang_error>
+      abort("foo", call = base::call)
+    Condition <rlang_error>
       Error in `abort()`:
       ! `call` must be a call or environment, not a primitive function.
 

--- a/tests/testthat/_snaps/dots-ellipsis.md
+++ b/tests/testthat/_snaps/dots-ellipsis.md
@@ -1,9 +1,8 @@
 # error if dots not used by another function
 
     Code
-      (expect_error(f(x = 10, c = 3), class = "rlib_error_dots_unused"))
-    Output
-      <error/rlib_error_dots_unused>
+      f(x = 10, c = 3)
+    Condition <rlib_error_dots_unused>
       Error in `f()`:
       ! Arguments in `...` must be used.
       x Problematic argument:
@@ -25,17 +24,15 @@
 # error if if dots not empty
 
     Code
-      (expect_error(f(xy = 4), class = "rlib_error_dots_nonempty"))
-    Output
-      <error/rlib_error_dots_nonempty>
+      f(xy = 4)
+    Condition <rlib_error_dots_nonempty>
       Error in `f()`:
       ! `...` must be empty.
       x Problematic argument:
       * xy = 4
     Code
-      (expect_error(f0(xy = 4), class = "rlib_error_dots_nonempty"))
-    Output
-      <error/rlib_error_dots_nonempty>
+      f0(xy = 4)
+    Condition <rlib_error_dots_nonempty>
       Error in `f0()`:
       ! `...` must be empty.
       x Problematic argument:
@@ -115,9 +112,8 @@
 # check_dots_empty() allows trailing missing arg (#1390)
 
     Code
-      (expect_error(fn(a = 1, b = )))
-    Output
-      <error/rlib_error_dots_nonempty>
+      fn(a = 1, b = )
+    Condition <rlib_error_dots_nonempty>
       Error in `fn()`:
       ! `...` must be empty.
       x Problematic argument:

--- a/tests/testthat/_snaps/env-binding.md
+++ b/tests/testthat/_snaps/env-binding.md
@@ -1,15 +1,13 @@
 # env_get() without default fails
 
     Code
-      (expect_error(env_get(env(), "foobar")))
-    Output
-      <error/rlang_error>
+      env_get(env(), "foobar")
+    Condition <rlang_error>
       Error in `env_get()`:
       ! Can't find `foobar` in environment.
     Code
-      (expect_error(env_get_list(env(), "foobar")))
-    Output
-      <error/rlang_error>
+      env_get_list(env(), "foobar")
+    Condition <rlang_error>
       Error in `env_get_list()`:
       ! Can't find `foobar` in environment.
 

--- a/tests/testthat/_snaps/eval-tidy.md
+++ b/tests/testthat/_snaps/eval-tidy.md
@@ -3,16 +3,14 @@
     Code
       # Fake pronouns
       f <- (function() .data$foo)
-      (expect_error(f(), "subset"))
-    Output
-      <error/rlang_error>
+      f()
+    Condition <rlang_error>
       Error in `f()`:
       ! Can't subset `.data` outside of a data mask context.
     Code
       f <- (function() .data[["foo"]])
-      (expect_error(f(), "subset"))
-    Output
-      <error/rlang_error>
+      f()
+    Condition <rlang_error>
       Error in `f()`:
       ! Can't subset `.data` outside of a data mask context.
 

--- a/tests/testthat/_snaps/fn.md
+++ b/tests/testthat/_snaps/fn.md
@@ -1,54 +1,46 @@
 # as_function() has nice errors
 
     Code
-      (expect_error(as_function(1)))
-    Output
-      <error/rlang_error>
+      as_function(1)
+    Condition <rlang_error>
       Error:
       ! Can't convert `1`, a double vector, to a function.
     Code
-      (expect_error(as_function(1, arg = "foo")))
-    Output
-      <error/rlang_error>
+      as_function(1, arg = "foo")
+    Condition <rlang_error>
       Error:
       ! Can't convert `foo`, a double vector, to a function.
     Code
-      (expect_error(my_function(1 + 2)))
-    Output
-      <error/rlang_error>
+      my_function(1 + 2)
+    Condition <rlang_error>
       Error in `my_function()`:
       ! Can't convert `my_arg`, a double vector, to a function.
     Code
-      (expect_error(my_function(1)))
-    Output
-      <error/rlang_error>
+      my_function(1)
+    Condition <rlang_error>
       Error in `my_function()`:
       ! Can't convert `my_arg`, a double vector, to a function.
     Code
-      (expect_error(my_function(a ~ b)))
-    Output
-      <error/rlang_error>
+      my_function(a ~ b)
+    Condition <rlang_error>
       Error in `my_function()`:
       ! Can't convert `my_arg`, a two-sided formula, to a function.
 
 # check inputs in function accessors
 
     Code
-      (expect_error(fn_fmls(1)))
-    Output
-      <error/rlang_error>
+      fn_fmls(1)
+    Condition <rlang_error>
       Error in `fn_fmls()`:
       ! `fn` must be an R function, not the number 1.
     Code
-      (expect_error(fn_body(1)))
-    Output
-      <error/rlang_error>
+      fn_body(1)
+    Condition <rlang_error>
       Error in `fn_body()`:
       ! `fn` must be an R function, not the number 1.
     Code
-      (expect_error(fn_env(1)))
-    Output
-      <error/rlang_error>
+      fn_env(1)
+    Condition <rlang_error>
       Error in `fn_env()`:
       ! `fn` must be a function, not the number 1.
 

--- a/tests/testthat/_snaps/friendly-type.md
+++ b/tests/testthat/_snaps/friendly-type.md
@@ -1,9 +1,8 @@
 # obj_type_friendly() handles NULL
 
     Code
-      (expect_error(friendly_types(NULL)))
-    Output
-      <error/rlang_error>
+      friendly_types(NULL)
+    Condition <rlang_error>
       Error in `vec_type_friendly()`:
       ! `x` must be a vector.
 

--- a/tests/testthat/_snaps/nse-inject.md
+++ b/tests/testthat/_snaps/nse-inject.md
@@ -2,58 +2,50 @@
 
     Code
       fn <- (function(x) englue(c("a", "b")))
-      (expect_error(fn()))
-    Output
-      <error/rlang_error>
+      fn()
+    Condition <rlang_error>
       Error in `englue()`:
       ! `x` must be a single string, not a character vector.
     Code
       fn <- (function(x) englue(env()))
-      (expect_error(fn()))
-    Output
-      <error/rlang_error>
+      fn()
+    Condition <rlang_error>
       Error in `englue()`:
       ! `x` must be a single string, not an environment.
     Code
       fn <- (function(x) glue_embrace("{{ x }}_foo"))
-      (expect_error(fn()))
-    Output
-      <error/rlang_error>
+      fn()
+    Condition <rlang_error>
       Error in `fn()`:
       ! `x` is absent but must be supplied.
     Code
       fn <- (function(x) englue("{{ x }}_foo"))
-      (expect_error(fn()))
-    Output
-      <error/rlang_error>
+      fn()
+    Condition <rlang_error>
       Error in `fn()`:
       ! `x` is absent but must be supplied.
     Code
       fn <- (function(x) list2("{{ x }}_foo" := NULL))
-      (expect_error(fn()))
-    Output
-      <error/rlang_error>
+      fn()
+    Condition <rlang_error>
       Error in `fn()`:
       ! `x` is absent but must be supplied.
 
 # can wrap englue() (#1565)
 
     Code
-      (expect_error(my_englue(c("a", "b"))))
-    Output
-      <error/rlang_error>
+      my_englue(c("a", "b"))
+    Condition <rlang_error>
       Error in `my_englue()`:
       ! `text` must be a single string, not a character vector.
     Code
-      (expect_error(my_englue(env())))
-    Output
-      <error/rlang_error>
+      my_englue(env())
+    Condition <rlang_error>
       Error in `my_englue()`:
       ! `text` must be a single string, not an environment.
     Code
-      (expect_error(fn()))
-    Output
-      <error/rlang_error>
+      fn()
+    Condition <rlang_error>
       Error in `fn()`:
       ! `x` is absent but must be supplied.
 
@@ -61,16 +53,14 @@
 
     Code
       fn <- (function(x) englue("{{ x }} {NULL}"))
-      (expect_error(fn(foo)))
-    Output
-      <error/rlang_error>
+      fn(foo)
+    Condition <rlang_error>
       Error in `englue()`:
       ! The glue string must be size 1, not 0.
     Code
       fn <- (function(x) list2("{{ x }} {NULL}" := NULL))
-      (expect_error(fn(foo)))
-    Output
-      <error/rlang_error>
+      fn(foo)
+    Condition <rlang_error>
       Error in `englue()`:
       ! The glue string must be size 1, not 0.
 

--- a/tests/testthat/_snaps/s3.md
+++ b/tests/testthat/_snaps/s3.md
@@ -1,15 +1,13 @@
 # as_box_if() ensures boxed value if predicate returns TRUE
 
     Code
-      (expect_error(as_box_if(NULL, ~10)))
-    Output
-      <error/rlang_error>
+      as_box_if(NULL, ~10)
+    Condition <rlang_error>
       Error in `.p()`:
       ! Predicate functions must return a single `TRUE` or `FALSE`, not the number 10
     Code
-      (expect_error(as_box_if(NULL, ~ c(TRUE, FALSE))))
-    Output
-      <error/rlang_error>
+      as_box_if(NULL, ~ c(TRUE, FALSE))
+    Condition <rlang_error>
       Error in `.p()`:
       ! Predicate functions must return a single `TRUE` or `FALSE`, not a logical vector
 

--- a/tests/testthat/_snaps/session.md
+++ b/tests/testthat/_snaps/session.md
@@ -1,171 +1,144 @@
 # check_installed() fails if packages are not installed
 
     Code
-      (expect_error(check_installed("rlangFoo")))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed("rlangFoo")
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The package "rlangFoo" is required.
     Code
-      (expect_error(check_installed(c("rlangFoo", "rlangBar"))))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed(c("rlangFoo", "rlangBar"))
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The packages "rlangFoo" and "rlangBar" are required.
     Code
-      (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.")))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed(c("rlangFoo", "rlangBar"), "to proceed.")
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The packages "rlangFoo" and "rlangBar" are required to proceed.
 
 # is_installed() checks minimal versions
 
     Code
-      (expect_error(is_installed(c("rlang", "testthat"), version = "0.1"),
-      "the same length"))
-    Output
-      <error/rlang_error>
+      is_installed(c("rlang", "testthat"), version = "0.1")
+    Condition <rlang_error>
       Error in `is_installed()`:
       ! `version` must be `NULL` or a vector of versions the same length as `pkg`.
 
 # check_installed() checks minimal versions
 
     Code
-      (expect_error(check_installed(c("rlang", "testthat"), version = "0.1")))
-    Output
-      <error/rlang_error>
+      check_installed(c("rlang", "testthat"), version = "0.1")
+    Condition <rlang_error>
       Error in `check_installed()`:
       ! `version` must be `NULL` or a vector of versions the same length as `pkg`.
     Code
-      (expect_error(check_installed("rlangFoo", version = "1.0")))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed("rlangFoo", version = "1.0")
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The package "rlangFoo" (>= 1.0) is required.
     Code
-      (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA)))
-      )
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA))
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The packages "rlangFoo" (>= 1.0) and "rlangBar" are required.
     Code
-      (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0")))
-      )
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0"))
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The packages "rlangFoo" and "rlangBar" (>= 2.0) are required.
     Code
-      (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.",
-      version = c("1.0", "2.0"))))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed(c("rlangFoo", "rlangBar"), "to proceed.", version = c("1.0",
+        "2.0"))
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The packages "rlangFoo" (>= 1.0) and "rlangBar" (>= 2.0) are required to proceed.
     Code
-      (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"),
-      "to proceed.")))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"), "to proceed.")
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The packages "rlangFoo" (>= 1.0) and "rlangBar" (> 2.0) are required to proceed.
 
 # < requirements can't be recovered with restart
 
     Code
-      (expect_error(check_installed("rlang (< 0.1)")))
-    Output
-      <error/rlib_error_package_not_found>
+      check_installed("rlang (< 0.1)")
+    Condition <rlib_error_package_not_found>
       Error in `foo()`:
       ! The package "rlang" (< 0.1) is required.
 
 # `pkg` is type-checked
 
     Code
-      (expect_error(is_installed(1)))
-    Output
-      <error/rlang_error>
+      is_installed(1)
+    Condition <rlang_error>
       Error in `is_installed()`:
       ! `pkg` must be a package name or a vector of package names.
     Code
-      (expect_error(is_installed(na_chr)))
-    Output
-      <error/rlang_error>
+      is_installed(na_chr)
+    Condition <rlang_error>
       Error in `is_installed()`:
       ! `pkg` must be a package name or a vector of package names.
     Code
-      (expect_error(check_installed(c("foo", ""))))
-    Output
-      <error/rlang_error>
+      check_installed(c("foo", ""))
+    Condition <rlang_error>
       Error in `check_installed()`:
       ! `pkg` must be a package name or a vector of package names.
     Code
-      (expect_error(check_installed(c("foo", "bar"), version = c("1", ""))))
-    Output
-      <error/rlang_error>
+      check_installed(c("foo", "bar"), version = c("1", ""))
+    Condition <rlang_error>
       Error in `check_installed()`:
       ! `version` must be `NULL` or a vector of versions the same length as `pkg`.
 
 # pkg_version_info() parses info
 
     Code
-      (expect_error(pkg_version_info("foo (1.0)"), "parse"))
-    Output
-      <error/rlang_error>
+      pkg_version_info("foo (1.0)")
+    Condition <rlang_error>
       Error in `caller()`:
       ! Can't parse version in `pkg`.
       x Problematic versions:
       * foo (1.0)
       i Example of expected version format: `rlang (>= 1.0.0)`.
     Code
-      (expect_error(pkg_version_info("foo (>= 1.0)", "1.0"), "both"))
-    Output
-      <error/rlang_error>
+      pkg_version_info("foo (>= 1.0)", "1.0")
+    Condition <rlang_error>
       Error in `caller()`:
       ! Can't supply version in both `pkg` and `version`.
       x Redundant versions:
       * "foo (>= 1.0)"
     Code
-      (expect_error(pkg_version_info(c("foo (!= 1.0)"))))
-    Output
-      <error/rlang_error>
+      pkg_version_info(c("foo (!= 1.0)"))
+    Condition <rlang_error>
       Error in `caller()`:
       ! `compare` must be one of ">", ">=", "==" ,"<", or "<=".
 
 # pkg_version_info() supports `cmp`
 
     Code
-      err(pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">=")))
-    Output
-      <error/rlang_error>
+      pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">="))
+    Condition <rlang_error>
       Error in `caller()`:
       ! `version` must be supplied when `compare` is supplied.
     Code
-      err(pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">=")))
-    Output
-      <error/rlang_error>
+      pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">="))
+    Condition <rlang_error>
       Error in `caller()`:
       ! `version` must be supplied when `compare` is supplied.
     Code
-      err(pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">=")))
-    Output
-      <error/rlang_error>
+      pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">="))
+    Condition <rlang_error>
       Error in `caller()`:
       ! Can't supply version in both `pkg` and `version`.
       x Redundant versions:
       * "bar (>= 2.0)"
     Code
-      err(pkg_version_info("foo", "1.0", "!="))
-    Output
-      <error/rlang_error>
+      pkg_version_info("foo", "1.0", "!=")
+    Condition <rlang_error>
       Error in `caller()`:
       ! `compare` must be one of ">", ">=", "==" ,"<", or "<=".
     Code
-      err(pkg_version_info("bar (== 1.0)", "1.0", "=="))
-    Output
-      <error/rlang_error>
+      pkg_version_info("bar (== 1.0)", "1.0", "==")
+    Condition <rlang_error>
       Error in `caller()`:
       ! Can't supply version in both `pkg` and `version`.
       x Redundant versions:
@@ -174,15 +147,13 @@
 # `action` is checked
 
     Code
-      err(check_installed("foo", action = "identity"))
-    Output
-      <error/rlang_error>
+      check_installed("foo", action = "identity")
+    Condition <rlang_error>
       Error in `check_installed()`:
       ! `action` must be an R function or `NULL`, not the string "identity".
     Code
-      err(check_installed("foo", action = identity))
-    Output
-      <error/rlang_error>
+      check_installed("foo", action = identity)
+    Condition <rlang_error>
       Error in `check_installed()`:
       ! `action` must take a `...` argument.
 

--- a/tests/testthat/_snaps/types.md
+++ b/tests/testthat/_snaps/types.md
@@ -1,21 +1,18 @@
 # is_string2() matches on `empty`
 
     Code
-      (expect_error(is_string2("foo", empty = 1)))
-    Output
-      <error/rlang_error>
+      is_string2("foo", empty = 1)
+    Condition <rlang_error>
       Error in `is_string2()`:
       ! `empty` must be `NULL` or a logical value.
     Code
-      (expect_error(is_string2("foo", empty = NA)))
-    Output
-      <error/rlang_error>
+      is_string2("foo", empty = NA)
+    Condition <rlang_error>
       Error in `is_string2()`:
       ! `empty` must be `NULL` or a logical value.
     Code
-      (expect_error(is_string2("foo", "foo", empty = TRUE)))
-    Output
-      <error/rlang_error>
+      is_string2("foo", "foo", empty = TRUE)
+    Condition <rlang_error>
       Error in `is_string2()`:
       ! Exactly one of `string` and `empty` must be supplied.
 

--- a/tests/testthat/test-arg.R
+++ b/tests/testthat/test-arg.R
@@ -10,21 +10,19 @@ test_that("matches arg", {
 
 test_that("gives an error with more than one arg", {
   # Interpolates `values` in the error message (#1545)
-  expect_snapshot(
-    (expect_error(arg_match0_wrapper(c("bar", "fun"), c("bar", "baz"))))
-  )
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    arg_match0_wrapper(c("bar", "fun"), c("bar", "baz"))
+  })
 })
 
 test_that("gives error with different than rearranged arg vs value", {
   f <- function(myarg = c("foo", "bar", "fun")) {
     arg_match(myarg, c("fun", "bar"))
   }
-  expect_snapshot_error(
+  expect_snapshot(error = TRUE, {
     f()
-  )
-  expect_snapshot_error(
     arg_match0_wrapper(c("foo", "foo"), c("foo", "bar"), arg_nm = "x")
-  )
+  })
 })
 
 test_that("gives no error with rearranged arg vs value", {
@@ -55,20 +53,20 @@ test_that("`arg_match()` has informative error messages", {
     arg_match0_wrapper(...)
   }
 
-  expect_snapshot({
-    (expect_error(arg_match_wrapper("continuuos", c("discrete", "continuous"), "my_arg")))
-    (expect_error(arg_match_wrapper("fou", c("bar", "foo"), "my_arg")))
-    (expect_error(arg_match_wrapper("fu", c("ba", "fo"), "my_arg")))
-    (expect_error(arg_match_wrapper("baq", c("foo", "baz", "bas"), "my_arg")))
-    (expect_error(arg_match_wrapper("", character(), "my_arg")))
-    (expect_error(arg_match_wrapper("fo", "foo", quote(f()))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    arg_match_wrapper("continuuos", c("discrete", "continuous"), "my_arg")
+    arg_match_wrapper("fou", c("bar", "foo"), "my_arg")
+    arg_match_wrapper("fu", c("ba", "fo"), "my_arg")
+    arg_match_wrapper("baq", c("foo", "baz", "bas"), "my_arg")
+    arg_match_wrapper("", character(), "my_arg")
+    arg_match_wrapper("fo", "foo", quote(f()))
   })
 })
 
 test_that("`arg_match()` provides no suggestion when the edit distance is too large", {
-  expect_snapshot({
-    (expect_error(arg_match0_wrapper("foobaz", c("fooquxs", "discrete"), "my_arg")))
-    (expect_error(arg_match0_wrapper("a", c("b", "c"), "my_arg")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    arg_match0_wrapper("foobaz", c("fooquxs", "discrete"), "my_arg")
+    arg_match0_wrapper("a", c("b", "c"), "my_arg")
   })
 })
 
@@ -80,11 +78,11 @@ test_that("`arg_match()` finds a match even with small possible typos", {
 })
 
 test_that("`arg_match()` makes case-insensitive match", {
-  expect_snapshot({
-    (expect_error(arg_match0_wrapper("a", c("A", "B"), "my_arg"), "Did you mean \"A\"?"))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    arg_match0_wrapper("a", c("A", "B"), "my_arg")
 
     # Case-insensitive match is done after case-sensitive
-    (expect_error(arg_match0_wrapper("aa", c("AA", "aA"), "my_arg"), "Did you mean \"aA\"?"))
+    arg_match0_wrapper("aa", c("AA", "aA"), "my_arg")
   })
 })
 
@@ -215,12 +213,12 @@ test_that("check_required() checks argument is supplied (#1118)", {
   f <- function(x) check_required(x)
   g <- function(y) f(y)
 
-  expect_error(f(NULL), NA)
-  expect_error(g(NULL), NA)
+  expect_no_error(f(NULL))
+  expect_no_error(g(NULL))
 
-  expect_snapshot({
-    (expect_error(f()))
-    (expect_error(g()))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f()
+    g()
   })
 })
 
@@ -234,14 +232,14 @@ test_that("arg_match() supports symbols and scalar strings", {
     "foo"
   )
 
-  expect_snapshot({
-    (expect_error(arg_match0_wrapper(chr_get("fo", 0L), c("bar", "foo"), "my_arg")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    arg_match0_wrapper(chr_get("fo", 0L), c("bar", "foo"), "my_arg")
   })
 })
 
 test_that("arg_match() requires an argument symbol", {
   wrapper <- function() arg_match("foo")
-  expect_snapshot((expect_error(wrapper())))
+  expect_snapshot(wrapper(), error = TRUE, cnd_class = TRUE)
 })
 
 test_that("can match multiple arguments", {
@@ -253,17 +251,17 @@ test_that("can match multiple arguments", {
   expect_equal(my_wrapper(c("foo", "baz")), c("foo", "baz"))
   expect_equal(my_wrapper(chr()), chr())
 
-  expect_snapshot({
-    (expect_error(my_wrapper("ba")))
-    (expect_error(my_wrapper(c("foo", "ba"))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    my_wrapper("ba")
+    my_wrapper(c("foo", "ba"))
   })
 })
 
 test_that("arg_match0() defuses argument", {
   fn <- function(arg) arg_match0(arg, c("bar", "baz"))
-  expect_snapshot({
-    (expect_error(fn("foo")))
-    (expect_error(arg_match0("foo", c("bar", "baz"))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    fn("foo")
+    arg_match0("foo", c("bar", "baz"))
   })
 })
 
@@ -273,18 +271,18 @@ test_that("check_exclusive works", {
   h <- function() check_exclusive(foo())
 
   # Internal errors
-  expect_snapshot({
-    (expect_error(f()))
-    (expect_error(g()))
-    (expect_error(h()))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f()
+    g()
+    h()
   })
 
   f <- function(foo, bar = NULL, ...) check_exclusive(foo, bar, ...)
   g <- function(foo, bar = NULL, baz, ...) check_exclusive(foo, bar, baz, ...)
 
   # Zero arguments supplied
-  expect_snapshot({
-    (expect_error(f()))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f()
   })
   expect_equal(f(.require = FALSE), "")
 
@@ -293,12 +291,12 @@ test_that("check_exclusive works", {
   expect_equal(f(, NULL), "bar")
 
   # Multiple arguments supplied
-  expect_snapshot({
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
     "All arguments supplied"
-    (expect_error(g(foo, bar, baz)))
+    g(foo, bar, baz)
 
     "Some arguments supplied"
-    (expect_error(g(foo, bar)))
+    g(foo, bar)
   })
 })
 
@@ -306,9 +304,9 @@ test_that("arg_match() mentions correct call if wrong type is supplied (#1388)",
   f <- function(my_arg) arg_match0(my_arg, "a")
   g <- function(my_arg) arg_match(my_arg, "a")
 
-  expect_snapshot({
-    (expect_error(f(1)))
-    (expect_error(g(1)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f(1)
+    g(1)
   })
 })
 
@@ -326,9 +324,9 @@ test_that("arg_match() backtrace highlights call and arg", {
 test_that("arg_match() supports `NA` (#1519)", {
   f <- function(x = c("a", "b")) arg_match(x)
 
-  expect_snapshot({
-    (expect_error(f(NA)))
-    (expect_error(f(na_chr)))
-    (expect_error(f(chr())))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f(NA)
+    f(na_chr)
+    f(chr())
   })
 })

--- a/tests/testthat/test-attr.R
+++ b/tests/testthat/test-attr.R
@@ -14,9 +14,9 @@ test_that("names2<- doesn't add missing values (#1301)", {
 })
 
 test_that("inputs must be valid", {
-  expect_snapshot({
-    (expect_error(set_names(environment())))
-    (expect_error(set_names(1:10, letters[1:4])))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    set_names(environment())
+    set_names(1:10, letters[1:4])
   })
 })
 
@@ -137,7 +137,7 @@ test_that("can zap_srcref() on functions with `[[` methods", {
     `[[<-.rlang:::not_subsettable` = function(...) stop("Can't subset!")
   )
   fn <- structure(quote(function() NULL), class = "rlang:::not_subsettable")
-  expect_error(zap_srcref(fn), NA)
+  expect_no_error(zap_srcref(fn))
 })
 
 test_that("set_names() recycles names of size 1", {
@@ -184,7 +184,7 @@ test_that("zap_srcref() works on calls", {
   call <- f()
 
   expect_null(attributes(zap_srcref(call)))
-  expect_true("srcref" %in% names(attributes(call)))
+  expect_contains(names(attributes(call)), "srcref")
 })
 
 test_that("is_dictionaryish return true if is NULL", {

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -1211,9 +1211,9 @@ test_that("re-encoding fails purposefully with any bytes", {
   bytes <- rawToChar(as.raw(0xdc))
   Encoding(bytes) <- "bytes"
 
-  expect_snapshot(
-    (expect_error(r_obj_encode_utf8(bytes)))
-  )
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    r_obj_encode_utf8(bytes)
+  })
 
   for (enc in test_encodings()) {
     expect_snapshot(

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -56,10 +56,10 @@ test_that("format_onerror_backtrace handles empty and size 1 traces", {
   local_options(rlang_backtrace_on_error = "branch")
 
   trace <- new_trace(list(), int())
-  expect_identical(format_onerror_backtrace(trace), NULL)
+  expect_null(format_onerror_backtrace(trace))
 
   trace <- new_trace(list(quote(foo)), int(0))
-  expect_identical(format_onerror_backtrace(trace), NULL)
+  expect_null(format_onerror_backtrace(trace))
 
   trace <- new_trace(list(quote(foo), quote(bar)), int(0, 1))
   expect_match(format_onerror_backtrace(error_cnd(trace = trace)), "foo.*bar")

--- a/tests/testthat/test-cnd-handlers.R
+++ b/tests/testthat/test-cnd-handlers.R
@@ -14,8 +14,8 @@ test_that("try_fetch() catches or declines values", {
 })
 
 test_that("try_fetch() checks inputs", {
-  expect_snapshot({
-    (expect_error(try_fetch(NULL, function(...) NULL)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    try_fetch(NULL, function(...) NULL)
   })
   expect_true(try_fetch(TRUE))
 })

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -321,9 +321,9 @@ test_that("parent errors prints with bullets in all cases", {
     )
   }
 
-  expect_snapshot({
-    (expect_error(f(TRUE)))
-    (expect_error(f(FALSE)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f(TRUE)
+    f(FALSE)
   })
 })
 

--- a/tests/testthat/test-cnd-signal.R
+++ b/tests/testthat/test-cnd-signal.R
@@ -183,8 +183,8 @@ test_that("messages can be silenced", {
     rlib_message_verbosity = "quiet",
     rlib_warning_verbosity = "quiet"
   )
-  expect_message(inform("foo"), NA)
-  expect_warning(warn("foo"), NA)
+  expect_no_message(inform("foo"))
+  expect_no_warning(warn("foo"))
 })
 
 test_that("`.frequency_id` is mandatory", {
@@ -283,11 +283,11 @@ test_that("can pass `use_cli_format` as condition field", {
 })
 
 test_that("signal functions check inputs", {
-  expect_snapshot({
-    (expect_error(abort(error_cnd("foo"))))
-    (expect_error(inform(error_cnd("foo"))))
-    (expect_error(warn(class = error_cnd("foo"))))
-    (expect_error(abort("foo", call = base::call)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    abort(error_cnd("foo"))
+    inform(error_cnd("foo"))
+    warn(class = error_cnd("foo"))
+    abort("foo", call = base::call)
   })
 })
 

--- a/tests/testthat/test-cnd.R
+++ b/tests/testthat/test-cnd.R
@@ -331,10 +331,10 @@ test_that("warnings and messages have `summary()` methods", {
 })
 
 test_that("cnd ctors check arguments", {
-  expect_snapshot({
-    (expect_error(warning_cnd(class = list())))
-    (expect_error(error_cnd(class = list())))
-    (expect_error(message_cnd(message = 1)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    warning_cnd(class = list())
+    error_cnd(class = list())
+    message_cnd(message = 1)
   })
 })
 

--- a/tests/testthat/test-dots-ellipsis.R
+++ b/tests/testthat/test-dots-ellipsis.R
@@ -4,7 +4,7 @@ test_that("error if dots not used", {
     x + y
   }
 
-  expect_error(f(1, 2), NA)
+  expect_no_error(f(1, 2))
   expect_error(f(1, 2, 3), class = "rlib_error_dots_unused")
 })
 
@@ -17,10 +17,10 @@ test_that("error if dots not used by another function", {
     x * g(...)
   }
 
-  expect_error(f(x = 10, a = 1), NA)
+  expect_no_error(f(x = 10, a = 1))
 
-  expect_snapshot({
-    (expect_error(f(x = 10, c = 3), class = "rlib_error_dots_unused"))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f(x = 10, c = 3)
   })
 })
 
@@ -31,13 +31,13 @@ test_that("error if dots named", {
 
   expect_null(f(1))
 
-  expect_error(f(xyz = 1), NA)
-  expect_error(f(1, 2, 3), NA)
-  expect_error(f(1, 2, 3, xyz = 4), NA)
+  expect_no_error(f(xyz = 1))
+  expect_no_error(f(1, 2, 3))
+  expect_no_error(f(1, 2, 3, xyz = 4))
   expect_error(f(1, 2, 3, xy = 4), class = "rlib_error_dots_named")
 
-  expect_snapshot({
-    (expect_error(f(1, 2, 3, xy = 4, x = 5), class = "rlib_error_dots_named"))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f(1, 2, 3, xy = 4, x = 5)
   })
 })
 
@@ -49,12 +49,12 @@ test_that("error if if dots not empty", {
     check_dots_empty0(...)
   }
 
-  expect_error(f(xyz = 1), NA)
-  expect_error(f0(xyz = 1), NA)
+  expect_no_error(f(xyz = 1))
+  expect_no_error(f0(xyz = 1))
 
-  expect_snapshot({
-    (expect_error(f(xy = 4), class = "rlib_error_dots_nonempty"))
-    (expect_error(f0(xy = 4), class = "rlib_error_dots_nonempty"))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    f(xy = 4)
+    f0(xy = 4)
   })
 })
 
@@ -84,8 +84,8 @@ test_that("warn if unused dots", {
   safe_median.numeric <- function(x, ..., na.rm = TRUE) {
     stats::median(x, na.rm = na.rm)
   }
-  expect_error(safe_median(1:10), NA)
-  expect_error(safe_median(1:10, na.rm = TRUE), NA)
+  expect_no_error(safe_median(1:10))
+  expect_no_error(safe_median(1:10, na.rm = TRUE))
   expect_error(safe_median(1:10, y = 1), class = "rlib_error_dots_unused")
 })
 
@@ -131,7 +131,7 @@ test_that("check_dots_empty() allows trailing missing arg (#1390)", {
 
   expect_null(fn(a = 1, ))
 
-  expect_snapshot({
-    (expect_error(fn(a = 1, b = )))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    fn(a = 1, b = )
   })
 })

--- a/tests/testthat/test-dots.R
+++ b/tests/testthat/test-dots.R
@@ -66,9 +66,9 @@ test_that("dots_values() handles forced dots", {
 })
 
 test_that("empty arguments trigger meaningful error", {
-  expect_snapshot({
-    (expect_error(list2(1, , 3), "empty"))
-    (expect_error(dots_list(1, , 3), "empty"))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    list2(1, , 3)
+    dots_list(1, , 3)
   })
 })
 

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -153,9 +153,9 @@ test_that("env_get() and env_get_list() accept default value", {
 })
 
 test_that("env_get() without default fails", {
-  expect_snapshot({
-    (expect_error(env_get(env(), "foobar")))
-    (expect_error(env_get_list(env(), "foobar")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    env_get(env(), "foobar")
+    env_get_list(env(), "foobar")
   })
 
   fn <- function(env, default) env_get(env, "_foobar", default = default)

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -513,14 +513,14 @@ test_that("eval_tidy() has dimnames method (#1265)", {
 })
 
 test_that("fake pronoun fails informatively", {
-  expect_snapshot({
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
     "Fake pronouns"
 
     f <- function() .data$foo
-    (expect_error(f(), "subset"))
+    f()
 
     f <- function() .data[["foo"]]
-    (expect_error(f(), "subset"))
+    f()
   })
 })
 

--- a/tests/testthat/test-fn.R
+++ b/tests/testthat/test-fn.R
@@ -314,24 +314,24 @@ test_that("as_function() has nice errors", {
     as_function(my_arg)
   }
 
-  expect_snapshot({
-    (expect_error(as_function(1)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    as_function(1)
 
-    (expect_error(as_function(1, arg = "foo")))
+    as_function(1, arg = "foo")
 
-    (expect_error(my_function(1 + 2)))
+    my_function(1 + 2)
 
-    (expect_error(my_function(1)))
+    my_function(1)
 
-    (expect_error(my_function(a ~ b)))
+    my_function(a ~ b)
   })
 })
 
 test_that("check inputs in function accessors", {
-  expect_snapshot({
-    (expect_error(fn_fmls(1)))
-    (expect_error(fn_body(1)))
-    (expect_error(fn_env(1)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    fn_fmls(1)
+    fn_body(1)
+    fn_env(1)
   })
 })
 

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -119,9 +119,8 @@ test_that("obj_type_friendly() handles scalars", {
     vector = "a list",
     vector_length = "a list of length 1"
   ))
-
-  expect_true(all(friendly_types(matrix(NA)) == "a logical matrix"))
-  expect_true(all(friendly_types(matrix(1)) == "a double matrix"))
+  expect_setequal(friendly_types(matrix(NA)), "a logical matrix")
+  expect_setequal(friendly_types(matrix(1)), "a double matrix")
 })
 
 test_that("obj_type_friendly() handles empty vectors", {
@@ -171,7 +170,7 @@ test_that("obj_type_friendly() handles empty vectors", {
 
 test_that("obj_type_friendly() handles NULL", {
   expect_true(all(friendly_types(NULL, vector = FALSE) == "`NULL`"))
-  expect_snapshot((expect_error(friendly_types(NULL))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, friendly_types(NULL))
 })
 
 test_that("obj_type_friendly() handles NaN and infinities", {

--- a/tests/testthat/test-nse-inject.R
+++ b/tests/testthat/test-nse-inject.R
@@ -647,21 +647,21 @@ test_that("englue() returns a bare string", {
 })
 
 test_that("englue() has good error messages (#1531)", {
-  expect_snapshot({
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
     fn <- function(x) englue(c("a", "b"))
-    (expect_error(fn()))
+    fn()
 
     fn <- function(x) englue(env())
-    (expect_error(fn()))
+    fn()
 
     fn <- function(x) glue_embrace("{{ x }}_foo")
-    (expect_error(fn()))
+    fn()
 
     fn <- function(x) englue("{{ x }}_foo")
-    (expect_error(fn()))
+    fn()
 
     fn <- function(x) list2("{{ x }}_foo" := NULL)
-    (expect_error(fn()))
+    fn()
   })
 })
 
@@ -683,10 +683,10 @@ test_that("can wrap englue() (#1565)", {
   expect_equal(fn(bar), "bar_QUX_FOO")
   expect_equal(my_englue("{'foo'}"), "foo")
 
-  expect_snapshot({
-    (expect_error(my_englue(c("a", "b"))))
-    (expect_error(my_englue(env())))
-    (expect_error(fn()))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    my_englue(c("a", "b"))
+    my_englue(env())
+    fn()
   })
 })
 
@@ -824,11 +824,11 @@ test_that("englue() works", {
 })
 
 test_that("englue() checks for the size of its result (#1492)", {
-  expect_snapshot({
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
     fn <- function(x) englue("{{ x }} {NULL}")
-    (expect_error(fn(foo)))
+    fn(foo)
 
     fn <- function(x) list2("{{ x }} {NULL}" := NULL)
-    (expect_error(fn(foo)))
+    fn(foo)
   })
 })

--- a/tests/testthat/test-s3.R
+++ b/tests/testthat/test-s3.R
@@ -67,9 +67,9 @@ test_that("as_box_if() ensures boxed value if predicate returns TRUE", {
 
   expect_null(as_box_if(NULL, is_vector, "null_box"))
 
-  expect_snapshot({
-    (expect_error(as_box_if(NULL, ~ 10)))
-    (expect_error(as_box_if(NULL, ~ c(TRUE, FALSE))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    as_box_if(NULL, ~ 10)
+    as_box_if(NULL, ~ c(TRUE, FALSE))
   })
 })
 

--- a/tests/testthat/test-session.R
+++ b/tests/testthat/test-session.R
@@ -6,19 +6,16 @@ test_that("check_installed() fails if packages are not installed", {
   local_options(rlang_interactive = FALSE)
   local_error_call(call("foo"))
 
-  expect_snapshot({
-    (expect_error(check_installed("rlangFoo")))
-    (expect_error(check_installed(c("rlangFoo", "rlangBar"))))
-    (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    check_installed("rlangFoo")
+    check_installed(c("rlangFoo", "rlangBar"))
+    check_installed(c("rlangFoo", "rlangBar"), "to proceed.")
   })
 })
 
 test_that("is_installed() checks minimal versions", {
-  expect_snapshot({
-    (expect_error(
-      is_installed(c("rlang", "testthat"), version = "0.1"),
-      "the same length"
-    ))
+  expect_snapshot(error = TRUE, cnd_clas = TRUE, {
+    is_installed(c("rlang", "testthat"), version = "0.1")
   })
   expect_true(is_installed(c("rlang", "testthat"), version = c("0.1", "0.1")))
   expect_false(is_installed(c("rlang", "testthat"), version = c("100.1", "0.1")))
@@ -39,21 +36,21 @@ test_that("check_installed() checks minimal versions", {
 
   expect_null(check_installed(c("rlang (>= 0.1)", "testthat (>= 0.1)")))
 
-  expect_snapshot({
-    (expect_error(check_installed(c("rlang", "testthat"), version = "0.1")))
-    (expect_error(check_installed("rlangFoo", version = "1.0")))
-    (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA))))
-    (expect_error(check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0"))))
-    (expect_error(check_installed(c("rlangFoo", "rlangBar"), "to proceed.", version = c("1.0", "2.0"))))
-    (expect_error(check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"), "to proceed.")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    check_installed(c("rlang", "testthat"), version = "0.1")
+    check_installed("rlangFoo", version = "1.0")
+    check_installed(c("rlangFoo", "rlangBar"), version = c("1.0", NA))
+    check_installed(c("rlangFoo", "rlangBar"), version = c(NA, "2.0"))
+    check_installed(c("rlangFoo", "rlangBar"), "to proceed.", version = c("1.0", "2.0"))
+    check_installed(c("rlangFoo (>= 1.0)", "rlangBar (> 2.0)"), "to proceed.")
   })
 })
 
 test_that("< requirements can't be recovered with restart", {
   local_options(rlang_interactive = TRUE)
   local_error_call(call("foo"))
-  expect_snapshot({
-    (expect_error(check_installed("rlang (< 0.1)")))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    check_installed("rlang (< 0.1)")
   })
 })
 
@@ -132,11 +129,11 @@ test_that("can handle check-installed", {
 })
 
 test_that("`pkg` is type-checked", {
-  expect_snapshot({
-    (expect_error(is_installed(1)))
-    (expect_error(is_installed(na_chr)))
-    (expect_error(check_installed(c("foo", ""))))
-    (expect_error(check_installed(c("foo", "bar"), version = c("1", ""))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    is_installed(1)
+    is_installed(na_chr)
+    check_installed(c("foo", ""))
+    check_installed(c("foo", "bar"), version = c("1", ""))
   })
 })
 
@@ -170,10 +167,10 @@ test_that("pkg_version_info() parses info", {
     ver = c("1.0", "2.0", "3.0", "4.0", "3.0")
   ))
 
-  expect_snapshot({
-    (expect_error(pkg_version_info("foo (1.0)"), "parse"))
-    (expect_error(pkg_version_info("foo (>= 1.0)", "1.0"), "both"))
-    (expect_error(pkg_version_info(c("foo (!= 1.0)"))))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    pkg_version_info("foo (1.0)")
+    pkg_version_info("foo (>= 1.0)", "1.0")
+    pkg_version_info(c("foo (!= 1.0)"))
   })
 })
 
@@ -189,19 +186,19 @@ test_that("pkg_version_info() supports `cmp`", {
     ver = c("1.0", "2.0", "3.0", "3.1")
   ))
 
-  expect_snapshot({
-    err(pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">=")))
-    err(pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">=")))
-    err(pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">=")))
-    err(pkg_version_info("foo", "1.0", "!="))
-    err(pkg_version_info("bar (== 1.0)", "1.0", "=="))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    pkg_version_info(c("foo", "bar", "baz"), NULL, c(NA, NA, ">="))
+    pkg_version_info(c("foo", "bar", "baz"), c("1", "2", NA), c(NA, NA, ">="))
+    pkg_version_info(c("foo", "bar (>= 2.0)"), c(NA, "2.0"), c(NA, ">="))
+    pkg_version_info("foo", "1.0", "!=")
+    pkg_version_info("bar (== 1.0)", "1.0", "==")
   })
 })
 
 test_that("`action` is checked", {
-  expect_snapshot({
-    err(check_installed("foo", action = "identity"))
-    err(check_installed("foo", action = identity))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    check_installed("foo", action = "identity")
+    check_installed("foo", action = identity)
   })
 })
 

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -139,10 +139,10 @@ test_that("is_string() matches on string", {
 
 test_that("is_string2() matches on `empty`", {
   # Input checking
-  expect_snapshot({
-    (expect_error(is_string2("foo", empty = 1)))
-    (expect_error(is_string2("foo", empty = NA)))
-    (expect_error(is_string2("foo", "foo", empty = TRUE)))
+  expect_snapshot(error = TRUE, cnd_class = TRUE, {
+    is_string2("foo", empty = 1)
+    is_string2("foo", empty = NA)
+    is_string2("foo", "foo", empty = TRUE)
   })
 
   expect_true(is_string2("foo", empty = NULL))


### PR DESCRIPTION
Not 100% passed through, but thought I'd send this.

Makes snapshot results more readable in general