### PR TITLE
fixing some call_modify examples w/ NULL -> zap()

### DIFF
--- a/R/call.R
+++ b/R/call.R
@@ -523,7 +523,7 @@ call_has_precedence <- function(call, parent_call, side = NULL) {
 #' call_modify(call, na.rm = )
 #'
 #' # Supply a list of new arguments with `!!!`
-#' newargs <- list(na.rm = NULL, trim = 0.1)
+#' newargs <- list(na.rm = zap(), trim = 0.1)
 #' call <- call_modify(call, !!!newargs)
 #' call
 #'
@@ -557,11 +557,11 @@ call_has_precedence <- function(call, parent_call, side = NULL) {
 #' # subtle implications, for instance you can move an argument to
 #' # last position by removing it and remapping it:
 #' call <- quote(foo(bar = , baz))
-#' call_modify(call, bar = NULL, bar = missing_arg())
+#' call_modify(call, bar = zap(), bar = missing_arg())
 #'
 #' # You can also choose to keep only the first or last homonym
 #' # arguments:
-#' args <-  list(bar = NULL, bar = missing_arg())
+#' args <-  list(bar = zap(), bar = missing_arg())
 #' call_modify(call, !!!args, .homonyms = "first")
 #' call_modify(call, !!!args, .homonyms = "last")
 call_modify <- function(.call,


### PR DESCRIPTION
Some examples in call_modify() predate the introduction of zap() and use the older `[arg] = NULL` syntax.  In particular, this made line 560's example, `call_modify(call, bar = NULL, bar = missing_arg())`, no longer illustrate its key behavior.  Changed that, plus 2 other (likely less important) examples where argument removal seems to have been intended.