### PR TITLE
perf: faster standalone compact

### DIFF
--- a/R/standalone-purrr.R
+++ b/R/standalone-purrr.R
@@ -129,7 +129,7 @@ map_if <- function(.x, .p, .f, ...) {
 }
 
 compact <- function(.x) {
-  Filter(length, .x)
+  .x[as.logical(lengths(.x))]
 }
 
 transpose <- function(.l) {


### PR DESCRIPTION
``` r
compact1 <- function(x) Filter(length, x)
compact2 <- function(x) x[as.logical(lengths(x))]
compact3 <- function(x) x[lengths(x) > 0L]

x <- list(1:100, NULL, NULL, NULL, 1:100)
bench::mark(
  compact1(x),
  compact2(x),
  compact3(x),
  iterations = 100
)
#> # A tibble: 3 × 6
#>   expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 compact1(x)   2.91µs   3.28µs    13534.        0B        0
#> 2 compact2(x) 491.97ns 574.04ns   115615.        0B        0
#> 3 compact3(x) 492.03ns 574.04ns   138659.        0B        0
```

<sup>Created on 2025-01-23 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>