### PR TITLE
Speed up `check_installed()` - faster check for whether a package is on disk

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -101,10 +101,7 @@ detect_installed <- function(info) {
 }
 
 is_on_disk <- function(pkg) {
-  # A warning is emitted if the package was removed from disk
-  suppressWarnings(
-    nzchar(system.file(package = pkg))
-  )
+  any(file.exists(file.path(.libPaths(), pkg)))
 }
 
 pkg_version_info <- function(pkg,


### PR DESCRIPTION
As suggested by @hadley in https://github.com/r-lib/rlang/issues/1776#issuecomment-2654610545. This PR leaves that issue open for further improvements.

Additionally closes https://github.com/r-lib/rlang/issues/1608 by replacing the slow call to `system.file()`.

