### PR TITLE
Speed up `check_installed()` - shortcut when package is already loaded

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -202,6 +202,8 @@ check_installed <- function(pkg,
                             call = caller_env()) {
   check_dots_empty0(...)
 
+  # use package loaded shortcut if version not supplied, otherwise proceed and
+  # check version of package
   if (is.null(version)) {
     loaded <- lapply(pkg, function(x) {
       is.character(x) && nzchar(x) && is.environment(.getNamespace(x))

--- a/R/session.R
+++ b/R/session.R
@@ -202,8 +202,8 @@ check_installed <- function(pkg,
                             call = caller_env()) {
   check_dots_empty0(...)
 
-  # use package loaded shortcut if version not supplied, otherwise proceed and
-  # check version of package
+  # Fast path. Note that if `version` is supplied, this always falls through to the
+  # more expensive check.
   if (is.null(version)) {
     loaded <- lapply(pkg, function(x) {
       is.character(x) && nzchar(x) && is.environment(.getNamespace(x))

--- a/R/session.R
+++ b/R/session.R
@@ -204,7 +204,7 @@ check_installed <- function(pkg,
 
   if (is.null(version)) {
     loaded <- lapply(pkg, function(x) {
-      nzchar(x) && is.environment(.getNamespace(x))
+      is.character(x) && nzchar(x) && is.environment(.getNamespace(x))
     })
     if (all(as.logical(loaded))) {
       return(invisible(NULL))

--- a/R/session.R
+++ b/R/session.R
@@ -201,6 +201,16 @@ check_installed <- function(pkg,
                             action = NULL,
                             call = caller_env()) {
   check_dots_empty0(...)
+
+  if (is.null(version)) {
+    loaded <- lapply(pkg, function(x) {
+      nzchar(x) && is.environment(.getNamespace(x))
+    })
+    if (all(as.logical(loaded))) {
+      return(invisible(NULL))
+    }
+  }
+
   check_action(action)
 
   info <- pkg_version_info(pkg, version = version, compare = compare)


### PR DESCRIPTION
Can safely shortcut when package versions are not specified.

This prevents the full code path being run every time the function is called within a session, and is equivalent to the user memoizing the result.

Takes 3 microseconds, which is not much to give back on the initial run when we've saved some hundreds of microseconds in #1777.

``` r
library(rlang)
bench::mark(check_installed("later"))
#> # A tibble: 1 × 6
#>   expression                        min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                   <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 "check_installed(\"later\")"   2.47µs   3.01µs   305568.    5.61MB     30.6
```

<sup>Created on 2025-02-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

This should be applied with #1777 but is independent of that.
Closes #1776.
