### PR TITLE
Don't memcpy a 0-length vector

### DIFF
--- a/src/rlang/vec.c
+++ b/src/rlang/vec.c
@@ -38,7 +38,9 @@ r_obj* r_chr_n(const char* const * strings, r_ssize n) {
     C_TYPE* p_out = DEREF(out);                                 \
                                                                 \
     r_ssize cpy_size = (size > x_size) ? x_size : size;         \
-    memcpy(p_out, p_x, cpy_size * sizeof(C_TYPE));              \
+    if (cpy_size > 0) {                                         \
+      memcpy(p_out, p_x, cpy_size * sizeof(C_TYPE));            \
+    }                                                           \
                                                                 \
     FREE(1);                                                    \
     return out;                                                 \


### PR DESCRIPTION
The same issue as here:

https://github.com/r-lib/vctrs/pull/1968

MRE traced back to:

```r
vctrs::vec_set_union(integer(), 12L)
```

I added that as a regression test in {vctrs}, if you know of a way to test that directly in {rlang} please advise.

r-devel thread:

https://stat.ethz.ch/pipermail/r-devel/2024-June/083456.html