### PR TITLE
news typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
 
 * `obj_type_friendly()` now only displays the first class of S3 objects (#1622).
 
-* `expr_label()` now has back-compatility with respect to changes made by R version 4.4 and `is.atomic(NULL)` (#1655)
+* `expr_label()` now has back-compatibility with respect to changes made by R version 4.4 and `is.atomic(NULL)` (#1655)
 
 * Performance improvement in `.rlang_cli_compat()` (#1657).
 
@@ -489,7 +489,7 @@ extensive changes to the display of error messages.
   We've added the function `is_call_simple()` to make it easier to
   work safely with `call_name()`. The invariant is that `call_name()`
   always returns a string when `is_call_simple()` returns `TRUE`.
-  Conversely it always returns `NULL` when `is_call_simple()` retuns
+  Conversely it always returns `NULL` when `is_call_simple()` returns
   `FALSE`.
 
 * `is_expression()` now returns `FALSE` for manually constructed
@@ -870,7 +870,7 @@ extensive changes to the display of error messages.
 * Added `compat-cli.R` file to format message elements consistently
   with cli in zero-deps packages.
 
-* `compat-purrr.R` now longer includes `pluck*` helpers; these used a defintion
+* `compat-purrr.R` now longer includes `pluck*` helpers; these used a definition
   of pluck that predated purrr (#1159). `*_cpl()` has also been removed.
   The `map*` wrappers now call `as_function()` so that you can pass short
   anonymous functions that use `~` (#1157).
@@ -1034,7 +1034,7 @@ extensive changes to the display of error messages.
   dplyr issue involving rowwise data frames and list-columns of
   functions (tidyverse/dplyr#5608).
 
-* `as_data_mask()` now intialises environments of the correct size to
+* `as_data_mask()` now initialises environments of the correct size to
   improve efficiency (#1048).
 
 * `eval_bare()`, `eval_tidy()` (#961), and `with_handlers()` (#518)
@@ -1091,7 +1091,7 @@ extensive changes to the display of error messages.
   is displayed.
 
   This change simplifies the display (#851) and makes it possible to
-  rethow errors from a calling handler rather than an exiting handler,
+  rethrow errors from a calling handler rather than an exiting handler,
   which we now think is more appropriate because it allows users to
   `recover()` into the error.
 
@@ -1290,7 +1290,7 @@ extensive changes to the display of error messages.
 # rlang 0.4.1
 
 * New experimental framework for creating bulleted error messages. See
-  `?cnd_message` for the motivation and an overwiew of the tools we
+  `?cnd_message` for the motivation and an overview of the tools we
   have created to support this approach. In particular, `abort()` now
   takes character vectors to assemble a bullet list. Elements named
   `x` are prefixed with a red cross, elements named `i` are prefixed
@@ -1485,7 +1485,7 @@ really a data frame.
   field of `rlang::last_error()`.
 
 * `ns_env()` and `ns_env_name()` (experimental functions) now support
-  functions and environments consisently. They also require an
+  functions and environments consistently. They also require an
   argument from now on.
 
 * `is_interactive()` is aware of the `TESTTHAT` environment variable and
@@ -2393,7 +2393,7 @@ prepared to deal with occasional backward incompatible updates.
 
 * `exprs()` and `quos()` gain a `.unquote_names` arguments to switch
   off interpretation of `:=` as a name operator. This should be useful
-  for programming on the language targetting APIs such as
+  for programming on the language targeting APIs such as
   data.table.
 
 * `exprs()` gains a `.named` option to auto-label its arguments (#267).
@@ -2479,7 +2479,7 @@ prepared to deal with occasional backward incompatible updates.
 
 ## Environments
 
-* `env_get_list()` retrieves muliple bindings from an environment into
+* `env_get_list()` retrieves multiple bindings from an environment into
   a named list.
 
 * `with_bindings()` and `scoped_bindings()` establish temporary
@@ -2657,7 +2657,7 @@ lifecycle status of exported functions.
 
 * `quo_expr()` is soft-deprecated in favour of `quo_squash()`.
   `quo_expr()` was a misnomer because it implied that it was a mere
-  expression acccessor for quosures whereas it was really a lossy
+  expression accessor for quosures whereas it was really a lossy
   operation that squashed all nested quosures.
 
 * With the renaming of the `lang` particle to `call`, all these


### PR DESCRIPTION

the following was left as is

unconditionally would be more common in modern English

in `#393` had been used the wording non-existing args rather than unexisting arguments

```
$ grep -nr inconditionally rlang
rlang/NEWS.md:2201:Deprecated functions and arguments issue a warning inconditionally,
$ grep -nr unexisting rlang
rlang/NEWS.md:2052:* `call_modify()` now supports removing unexisting arguments (#393)
rlang/tests/testthat/test-call.R:209:test_that("can remove unexisting arguments (#393)", {
$