### PR TITLE
Make pillar dependency explicit in expr_deparse() output tests

### DIFF
--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -844,6 +844,9 @@ test_that("backslashes in strings are properly escaped (#1160)", {
 })
 
 test_that("formulas are deparsed (#1169)", {
+  # test output differs slightly with/without pillar
+  skip_if_not_installed("pillar")
+
   # Evaluated formulas are treated as objects
   expect_equal(
     expr_deparse(~foo),
@@ -868,6 +871,9 @@ test_that("formulas are deparsed (#1169)", {
 })
 
 test_that("matrices and arrays are formatted (#383)", {
+  # test output differs slightly with/without pillar
+  skip_if_not_installed("pillar")
+
   mat <- matrix(1:3)
   expect_equal(as_label(mat), "<int[,1]>")
   expect_equal(expr_deparse(mat), "<int[,1]: 1L, 2L, 3L>")


### PR DESCRIPTION
Closes #1794 