### PR TITLE
fix typos

### DIFF
--- a/R/aaa-topics.R
+++ b/R/aaa-topics.R
@@ -42,7 +42,7 @@ sprintf_topic_link <- function(id, topic = NULL) {
   html_title <- gsub("{", "\\{", html_title, fixed = TRUE)
   html <- sprintf("\\link[=%s]{%s}", topic, html_title)
 
-  # Link texts can't include curly symbols because the escpaing
+  # Link texts can't include curly symbols because the escaping
   # routine of the Rd-to-TeX translators is broken
   text_title <- gsub("`", "", title)
   text_title <- gsub("{{", "curly-curly", text_title, fixed = TRUE)

--- a/R/attr.R
+++ b/R/attr.R
@@ -177,7 +177,7 @@ has_name <- function(x, name) {
 #' set_names(1:4, letters[1:4])
 #' set_names(1:4, "a", "b", "c", "d")
 #'
-#' # If the second argument is ommitted a vector is named with itself
+#' # If the second argument is omitted a vector is named with itself
 #' set_names(letters[1:5])
 #'
 #' # Alternatively you can supply a function

--- a/R/cnd-abort.R
+++ b/R/cnd-abort.R
@@ -168,7 +168,7 @@
 #'   output by redirecting `stderr`.
 #'
 #' - If a sink is active (either on output or on messages) messages
-#'   are always streamd to `stderr`.
+#'   are always streamed to `stderr`.
 #'
 #' These exceptions ensure consistency of behaviour in interactive and
 #' non-interactive sessions, and when sinks are active.
@@ -254,7 +254,7 @@
 #' g <- function() {
 #'   f()
 #' }
-#' # Shows that the error occured in `my_function()`
+#' # Shows that the error occurred in `my_function()`
 #' try(g())
 #'
 #' }

--- a/R/cnd-entrace.R
+++ b/R/cnd-entrace.R
@@ -115,7 +115,7 @@ environment(hnd_entrace) <- baseenv()
 #' `entrace()` also works as an `option(error = )` handler for
 #' compatibility with versions of R older than 4.0.
 #'
-#' When used as calling handler, rlang trims the handler invokation
+#' When used as calling handler, rlang trims the handler invocation
 #' context from the backtrace.
 #'
 #' @inheritParams trace_back
@@ -155,7 +155,7 @@ entrace <- function(cnd, ..., top = NULL, bottom = NULL) {
     }
   }
 
-  # Remove handler invokation context from the trace
+  # Remove handler invocation context from the trace
   if (is_environment(bottom)) {
     nframe <- eval_bare(quote(base::sys.nframe()), bottom) - 1
     info <- signal_context_info(nframe)

--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -275,7 +275,7 @@ catch_cnd <- function(expr, classes = "condition") {
 #'
 #' @section Mufflable conditions:
 #'
-#' Most conditions signalled by base R are muffable, although the name
+#' Most conditions signalled by base R are mufflable, although the name
 #' of the restart varies. cnd_muffle() will automatically call the
 #' correct restart for you. It is compatible with the following
 #' conditions:

--- a/R/cnd-message.R
+++ b/R/cnd-message.R
@@ -389,7 +389,7 @@ on_load({
 #' The bullet formatting for errors follows the idea that sentences in
 #' error messages are best kept short and simple. The best way to
 #' present the information is in the [cnd_body()] method of an error
-#' conditon as a bullet list of simple sentences containing a single
+#' condition as a bullet list of simple sentences containing a single
 #' clause. The info and cross symbols of the bullets provide hints on
 #' how to interpret the bullet relative to the general error issue,
 #' which should be supplied as [cnd_header()].

--- a/R/env.R
+++ b/R/env.R
@@ -603,7 +603,7 @@ env_unlock <- function(env) {
 #' * Whether the environment is [locked][env_lock].
 #'
 #' * The bindings in the environment (up to 20 bindings). They are
-#'   printed succintly using `pillar::type_sum()` (if available,
+#'   printed succinctly using `pillar::type_sum()` (if available,
 #'   otherwise uses an internal version of that generic). In addition
 #'   [fancy bindings][env_bind_lazy] (actives and promises) are
 #'   indicated as such.

--- a/R/eval.R
+++ b/R/eval.R
@@ -24,7 +24,7 @@
 #' practical implications for `eval_bare()`:
 #'
 #' * `return()` calls are evaluated in frame environments that might
-#'   be burried deep in the call stack. This causes a long return that
+#'   be buried deep in the call stack. This causes a long return that
 #'   unwinds multiple frames (triggering the `on.exit()` event for
 #'   each frame). By contrast `eval()` only returns from the `eval()`
 #'   call, one level up.

--- a/R/formula.R
+++ b/R/formula.R
@@ -100,7 +100,7 @@ is_bare_formula <- function(x, scoped = TRUE, lhs = NULL) {
 
 #' Get or set formula components
 #'
-#' `f_rhs` extracts the righthand side, `f_lhs` extracts the lefthand
+#' `f_rhs` extracts the right-hand side, `f_lhs` extracts the left-hand
 #' side, and `f_env` extracts the environment. All functions throw an
 #' error if `f` is not a formula.
 #'

--- a/R/lifecycle-deprecated.R
+++ b/R/lifecycle-deprecated.R
@@ -643,7 +643,7 @@ invoke <- function(
 #' # list without either triggering method dispatch, or changing the
 #' # original environment. as_list() makes it easy:
 #' x <- structure(as_environment(mtcars[1:2]), class = "foobar")
-#' as.list.foobar <- function(x) abort("dont call me")
+#' as.list.foobar <- function(x) abort("don't call me")
 #' as_list(x)
 #' @name vector-coercion
 NULL

--- a/man/abort.Rd
+++ b/man/abort.Rd
@@ -272,7 +272,7 @@ There are two situations where messages are streamed to \code{stderr}:
 error so that R scripts can easily filter them out from normal
 output by redirecting \code{stderr}.
 \item If a sink is active (either on output or on messages) messages
-are always streamd to \code{stderr}.
+are always streamed to \code{stderr}.
 }
 
 These exceptions ensure consistency of behaviour in interactive and
@@ -346,7 +346,7 @@ try(
 g <- function() {
   f()
 }
-# Shows that the error occured in `my_function()`
+# Shows that the error occurred in `my_function()`
 try(g())
 
 }

--- a/man/cnd_muffle.Rd
+++ b/man/cnd_muffle.Rd
@@ -23,7 +23,7 @@ being called for that condition.
 \section{Mufflable conditions}{
 
 
-Most conditions signalled by base R are muffable, although the name
+Most conditions signalled by base R are mufflable, although the name
 of the restart varies. cnd_muffle() will automatically call the
 correct restart for you. It is compatible with the following
 conditions:

--- a/man/entrace.Rd
+++ b/man/entrace.Rd
@@ -56,7 +56,7 @@ any other effect. It should be called from a condition handler.
 \code{entrace()} also works as an \code{option(error = )} handler for
 compatibility with versions of R older than 4.0.
 
-When used as calling handler, rlang trims the handler invokation
+When used as calling handler, rlang trims the handler invocation
 context from the backtrace.
 }
 \examples{

--- a/man/env_print.Rd
+++ b/man/env_print.Rd
@@ -16,7 +16,7 @@ This prints:
 \item The \link[=env_label]{label} and the parent label.
 \item Whether the environment is \link[=env_lock]{locked}.
 \item The bindings in the environment (up to 20 bindings). They are
-printed succintly using \code{pillar::type_sum()} (if available,
+printed succinctly using \code{pillar::type_sum()} (if available,
 otherwise uses an internal version of that generic). In addition
 \link[=env_bind_lazy]{fancy bindings} (actives and promises) are
 indicated as such.

--- a/man/eval_bare.Rd
+++ b/man/eval_bare.Rd
@@ -34,7 +34,7 @@ Evaluating expressions in the actual frame environment has useful
 practical implications for \code{eval_bare()}:
 \itemize{
 \item \code{return()} calls are evaluated in frame environments that might
-be burried deep in the call stack. This causes a long return that
+be buried deep in the call stack. This causes a long return that
 unwinds multiple frames (triggering the \code{on.exit()} event for
 each frame). By contrast \code{eval()} only returns from the \code{eval()}
 call, one level up.

--- a/man/f_rhs.Rd
+++ b/man/f_rhs.Rd
@@ -32,7 +32,7 @@ vectors of length 1, a name, or a call). \code{f_env} returns an
 environment.
 }
 \description{
-\code{f_rhs} extracts the righthand side, \code{f_lhs} extracts the lefthand
+\code{f_rhs} extracts the right-hand side, \code{f_lhs} extracts the left-hand
 side, and \code{f_env} extracts the environment. All functions throw an
 error if \code{f} is not a formula.
 }

--- a/man/format_error_bullets.Rd
+++ b/man/format_error_bullets.Rd
@@ -33,7 +33,7 @@ formatted as "*" bullets.
 The bullet formatting for errors follows the idea that sentences in
 error messages are best kept short and simple. The best way to
 present the information is in the \code{\link[=cnd_body]{cnd_body()}} method of an error
-conditon as a bullet list of simple sentences containing a single
+condition as a bullet list of simple sentences containing a single
 clause. The info and cross symbols of the bullets provide hints on
 how to interpret the bullet relative to the general error issue,
 which should be supplied as \code{\link[=cnd_header]{cnd_header()}}.

--- a/man/notes/handling-introspection.R
+++ b/man/notes/handling-introspection.R
@@ -9,7 +9,7 @@
 #   be a user frame as well when the condition is signalled from C,
 #   e.g. with `Rf_error()`.
 #
-# - Handler frame. This is adjascent to the signal frame but may have
+# - Handler frame. This is adjacent to the signal frame but may have
 #   various intervening frames in between. Mostly this is about
 #   detecting that we rethrowing from a handler.
 #

--- a/man/rmd/topic-error-chaining.Rmd
+++ b/man/rmd/topic-error-chaining.Rmd
@@ -3,9 +3,9 @@
 
 Error chaining is a mechanism for providing contextual information when an error occurs. There are multiple situations in which you might be able to provide context that is helpful to quickly understand the cause or origin of an error:
 
-- Mentioning the _high level context_ in which a low level error arised. E.g. chaining a low-level HTTP error to a high-level download error.
+- Mentioning the _high level context_ in which a low level error arose. E.g. chaining a low-level HTTP error to a high-level download error.
 
-- Mentioning the _pipeline step_ in which a user error occured. This is a major use-case for NSE interfaces in the tidyverse, e.g. in dplyr, tidymodels or ggplot2.
+- Mentioning the _pipeline step_ in which a user error occurred. This is a major use-case for NSE interfaces in the tidyverse, e.g. in dplyr, tidymodels or ggplot2.
 
 - Mentioning the _iteration context_ in which a user error occurred. For instance, the input file when processing documents, or the iteration number or key when running user code in a loop.
 
@@ -78,7 +78,7 @@ with_chained_errors <- function(expr, call = caller_env()) {
 }
 ```
 
-Now that we've passed the caller environment as `call` argument, `abort()` automatically picks up the correspondin function call from the execution frame:
+Now that we've passed the caller environment as `call` argument, `abort()` automatically picks up the corresponding function call from the execution frame:
 
 ```{r, error = TRUE}
 my_verb(add(1, ""))
@@ -115,7 +115,7 @@ It is also possible to completely take ownership of a causal error and rethrow i
 
 - Hiding causal errors indiscriminately should likely be avoided because it may suppress information about unexpected errors. In general, rethrowing an unchained errors should only be done with specific error classes.
 
-To rethow an error without chaining it, and completely take over the causal error from the user point of view, fetch it with `try_fetch()` and throw a new error. The only difference with throwing a chained error is that the `parent` argument is set to `NA`. You could also omit the `parent` argument entirely, but passing `NA` lets `abort()` know it is rethrowing an error from a handler and that it should hide the corresponding error helpers in the backtrace.
+To rethrow an error without chaining it, and completely take over the causal error from the user point of view, fetch it with `try_fetch()` and throw a new error. The only difference with throwing a chained error is that the `parent` argument is set to `NA`. You could also omit the `parent` argument entirely, but passing `NA` lets `abort()` know it is rethrowing an error from a handler and that it should hide the corresponding error helpers in the backtrace.
 
 ```{r, error = TRUE}
 with_own_scalar_errors <- function(expr, call = caller_env()) {

--- a/man/set_names.Rd
+++ b/man/set_names.Rd
@@ -38,7 +38,7 @@ set_names(1:4, c("a", "b", "c", "d"))
 set_names(1:4, letters[1:4])
 set_names(1:4, "a", "b", "c", "d")
 
-# If the second argument is ommitted a vector is named with itself
+# If the second argument is omitted a vector is named with itself
 set_names(letters[1:5])
 
 # Alternatively you can supply a function

--- a/man/topic-error-chaining.Rd
+++ b/man/topic-error-chaining.Rd
@@ -6,8 +6,8 @@
 \description{
 Error chaining is a mechanism for providing contextual information when an error occurs. There are multiple situations in which you might be able to provide context that is helpful to quickly understand the cause or origin of an error:
 \itemize{
-\item Mentioning the \emph{high level context} in which a low level error arised. E.g. chaining a low-level HTTP error to a high-level download error.
-\item Mentioning the \emph{pipeline step} in which a user error occured. This is a major use-case for NSE interfaces in the tidyverse, e.g. in dplyr, tidymodels or ggplot2.
+\item Mentioning the \emph{high level context} in which a low level error arose. E.g. chaining a low-level HTTP error to a high-level download error.
+\item Mentioning the \emph{pipeline step} in which a user error occurred. This is a major use-case for NSE interfaces in the tidyverse, e.g. in dplyr, tidymodels or ggplot2.
 \item Mentioning the \emph{iteration context} in which a user error occurred. For instance, the input file when processing documents, or the iteration number or key when running user code in a loop.
 }
 
@@ -87,7 +87,7 @@ If you've read \ifelse{html}{\link[=topic-error-call]{Including function calls i
 \}
 }\if{html}{\out{</div>}}
 
-Now that we've passed the caller environment as \code{call} argument, \code{abort()} automatically picks up the correspondin function call from the execution frame:
+Now that we've passed the caller environment as \code{call} argument, \code{abort()} automatically picks up the corresponding function call from the execution frame:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{my_verb(add(1, ""))
 #> Error in `my_verb()`:
@@ -128,7 +128,7 @@ It is also possible to completely take ownership of a causal error and rethrow i
 \item Hiding causal errors indiscriminately should likely be avoided because it may suppress information about unexpected errors. In general, rethrowing an unchained errors should only be done with specific error classes.
 }
 
-To rethow an error without chaining it, and completely take over the causal error from the user point of view, fetch it with \code{try_fetch()} and throw a new error. The only difference with throwing a chained error is that the \code{parent} argument is set to \code{NA}. You could also omit the \code{parent} argument entirely, but passing \code{NA} lets \code{abort()} know it is rethrowing an error from a handler and that it should hide the corresponding error helpers in the backtrace.
+To rethrow an error without chaining it, and completely take over the causal error from the user point of view, fetch it with \code{try_fetch()} and throw a new error. The only difference with throwing a chained error is that the \code{parent} argument is set to \code{NA}. You could also omit the \code{parent} argument entirely, but passing \code{NA} lets \code{abort()} know it is rethrowing an error from a handler and that it should hide the corresponding error helpers in the backtrace.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{with_own_scalar_errors <- function(expr, call = caller_env()) \{
   try_fetch(

--- a/man/vector-coercion.Rd
+++ b/man/vector-coercion.Rd
@@ -130,7 +130,7 @@ as_integer("33")
 # list without either triggering method dispatch, or changing the
 # original environment. as_list() makes it easy:
 x <- structure(as_environment(mtcars[1:2]), class = "foobar")
-as.list.foobar <- function(x) abort("dont call me")
+as.list.foobar <- function(x) abort("don't call me")
 as_list(x)
 }
 \keyword{internal}

--- a/src/internal/ast-rotate.c
+++ b/src/internal/ast-rotate.c
@@ -489,7 +489,7 @@ void find_lower_pivot(r_obj* x,
 /**
  * node_list_interp_fixup() - Expansion for binary operators that might need fixup
  *
- * @x A call to a binary operator whith problematic precedence
+ * @x A call to a binary operator with problematic precedence
  *   (between prec(`!`) and prec(`!!`)).
  * @env The environment where to unquote the `!!` target.
  * @parent Needed to handle a mix of unary and binary operators
@@ -559,7 +559,7 @@ void node_list_interp_fixup_rhs(r_obj* rhs,
     info->lower_root = rhs_node;
 
     // There might be a lower pivot, so we need to find it. Also find
-    // the target of unquoting (leftmost leaf whose predecence is
+    // the target of unquoting (leftmost leaf whose precedence is
     // greater than prec(`!!`)) and unquote it.
     info->lower_pivot = info->upper_pivot;
     info->lower_pivot_op = info->upper_pivot_op;


### PR DESCRIPTION
Closes https://github.com/r-lib/rlang/issues/1798

Running `roxygen2::roxygenise()` output the following.

```
✖ utils.R:111: S3 method `$.r6lite` needs @export or @exportS3method tag.
✖ trace.R:422: S3 method `c.rlang_trace` needs @export or @exportS3method tag.
✖ s3.R:121: S3 method `print.box` needs @export or @exportS3method tag.
```