### PR TITLE
Format with autobracing version of Air

### DIFF
--- a/R/call.R
+++ b/R/call.R
@@ -987,12 +987,18 @@ call_args_names <- function(call) {
 }
 
 is_qualified_call <- function(x) {
-  if (typeof(x) != "language") return(FALSE)
+  if (typeof(x) != "language") {
+    return(FALSE)
+  }
   is_qualified_symbol(node_car(x))
 }
 is_namespaced_call <- function(x, ns = NULL, private = NULL) {
-  if (typeof(x) != "language") return(FALSE)
-  if (!is_namespaced_symbol(node_car(x), ns, private)) return(FALSE)
+  if (typeof(x) != "language") {
+    return(FALSE)
+  }
+  if (!is_namespaced_symbol(node_car(x), ns, private)) {
+    return(FALSE)
+  }
   TRUE
 }
 
@@ -1008,10 +1014,14 @@ call_unnamespace <- function(x) {
 
 # Qualified and namespaced symbols are actually calls
 is_qualified_symbol <- function(x) {
-  if (typeof(x) != "language") return(FALSE)
+  if (typeof(x) != "language") {
+    return(FALSE)
+  }
 
   head <- node_cadr(node_cdr(x))
-  if (typeof(head) != "symbol") return(FALSE)
+  if (typeof(head) != "symbol") {
+    return(FALSE)
+  }
 
   qualifier <- node_car(x)
   identical(qualifier, namespace_sym) ||
@@ -1020,8 +1030,12 @@ is_qualified_symbol <- function(x) {
     identical(qualifier, at_sym)
 }
 is_namespaced_symbol <- function(x, ns = NULL, private = NULL) {
-  if (typeof(x) != "language") return(FALSE)
-  if (!is_null(ns) && !identical(node_cadr(x), sym(ns))) return(FALSE)
+  if (typeof(x) != "language") {
+    return(FALSE)
+  }
+  if (!is_null(ns) && !identical(node_cadr(x), sym(ns))) {
+    return(FALSE)
+  }
 
   head <- node_car(x)
   if (is_null(private)) {

--- a/R/cnd.R
+++ b/R/cnd.R
@@ -574,8 +574,11 @@ cnd_format <- function(
   }
 
   is_same_trace <- function() {
-    compare <- if (is_null(pending_trace)) last_trace else
+    compare <- if (is_null(pending_trace)) {
+      last_trace
+    } else {
       pending_trace[["trace"]]
+    }
     if (!is_trace(trace) || !is_trace(compare)) {
       return(FALSE)
     }

--- a/R/standalone-cli.R
+++ b/R/standalone-cli.R
@@ -91,14 +91,24 @@
 #' functions apply default ANSI colours to these symbols if possible.
 #'
 #' @noRd
-symbol_info <- function() if (.rlang_cli_has_cli()) cli::symbol$info else "i"
-symbol_cross <- function() if (.rlang_cli_has_cli()) cli::symbol$cross else "x"
-symbol_tick <- function() if (.rlang_cli_has_cli()) cli::symbol$tick else "v"
-symbol_bullet <- function()
+symbol_info <- function() {
+  if (.rlang_cli_has_cli()) cli::symbol$info else "i"
+}
+symbol_cross <- function() {
+  if (.rlang_cli_has_cli()) cli::symbol$cross else "x"
+}
+symbol_tick <- function() {
+  if (.rlang_cli_has_cli()) cli::symbol$tick else "v"
+}
+symbol_bullet <- function() {
   if (.rlang_cli_has_cli()) cli::symbol$bullet else "*"
-symbol_arrow <- function()
+}
+symbol_arrow <- function() {
   if (.rlang_cli_has_cli()) cli::symbol$arrow_right else ">"
-symbol_alert <- function() "!"
+}
+symbol_alert <- function() {
+  "!"
+}
 
 ansi_info <- function() col_blue(symbol_info())
 ansi_cross <- function() col_red(symbol_cross())
@@ -117,98 +127,167 @@ ansi_alert <- function() col_yellow(symbol_alert())
 #' @param x A string.
 #'
 #' @noRd
-col_black <- function(x)
+col_black <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_black(x)) else x
-col_blue <- function(x)
+}
+col_blue <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_blue(x)) else x
-col_cyan <- function(x)
+}
+col_cyan <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_cyan(x)) else x
-col_green <- function(x)
+}
+col_green <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_green(x)) else x
-col_magenta <- function(x)
+}
+col_magenta <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_magenta(x)) else x
-col_red <- function(x)
+}
+col_red <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_red(x)) else x
-col_white <- function(x)
+}
+col_white <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_white(x)) else x
-col_yellow <- function(x)
+}
+col_yellow <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_yellow(x)) else x
-col_grey <- function(x)
+}
+col_grey <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_grey(x)) else x
-col_silver <- function(x)
+}
+col_silver <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_silver(x)) else x
-col_none <- function(x)
+}
+col_none <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::col_none(x)) else x
+}
 
-bg_black <- function(x)
+bg_black <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_black(x)) else x
-bg_blue <- function(x)
+}
+bg_blue <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_blue(x)) else x
-bg_cyan <- function(x)
+}
+bg_cyan <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_cyan(x)) else x
-bg_green <- function(x)
+}
+bg_green <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_green(x)) else x
-bg_magenta <- function(x)
+}
+bg_magenta <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_magenta(x)) else x
-bg_red <- function(x)
+}
+bg_red <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_red(x)) else x
-bg_white <- function(x)
+}
+bg_white <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_white(x)) else x
-bg_yellow <- function(x)
+}
+bg_yellow <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_yellow(x)) else x
-bg_none <- function(x)
+}
+bg_none <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::bg_none(x)) else x
+}
 
-style_dim <- function(x)
+style_dim <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_dim(x)) else x
-style_blurred <- function(x)
+}
+style_blurred <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_blurred(x)) else x
-style_bold <- function(x)
+}
+style_bold <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_bold(x)) else x
-style_hidden <- function(x)
+}
+style_hidden <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_hidden(x)) else x
-style_inverse <- function(x)
+}
+style_inverse <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_inverse(x)) else x
-style_italic <- function(x)
+}
+style_italic <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_italic(x)) else x
-style_strikethrough <- function(x)
-  if (.rlang_cli_has_cli())
-    .rlang_cli_unstructure(cli::style_strikethrough(x)) else x
-style_underline <- function(x)
-  if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_underline(x)) else
+}
+style_strikethrough <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_strikethrough(x))
+  } else {
     x
+  }
+}
+style_underline <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_underline(x))
+  } else {
+    x
+  }
+}
 
-style_no_dim <- function(x)
+style_no_dim <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_dim(x)) else x
-style_no_blurred <- function(x)
-  if (.rlang_cli_has_cli())
-    .rlang_cli_unstructure(cli::style_no_blurred(x)) else x
-style_no_bold <- function(x)
+}
+style_no_blurred <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_blurred(x))
+  } else {
+    x
+  }
+}
+style_no_bold <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_bold(x)) else x
-style_no_hidden <- function(x)
-  if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_hidden(x)) else
+}
+style_no_hidden <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_hidden(x))
+  } else {
     x
-style_no_inverse <- function(x)
-  if (.rlang_cli_has_cli())
-    .rlang_cli_unstructure(cli::style_no_inverse(x)) else x
-style_no_italic <- function(x)
-  if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_italic(x)) else
+  }
+}
+style_no_inverse <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_inverse(x))
+  } else {
     x
-style_no_strikethrough <- function(x)
-  if (.rlang_cli_has_cli())
-    .rlang_cli_unstructure(cli::style_no_strikethrough(x)) else x
-style_no_underline <- function(x)
-  if (.rlang_cli_has_cli())
-    .rlang_cli_unstructure(cli::style_no_underline(x)) else x
+  }
+}
+style_no_italic <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_italic(x))
+  } else {
+    x
+  }
+}
+style_no_strikethrough <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_strikethrough(x))
+  } else {
+    x
+  }
+}
+style_no_underline <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_underline(x))
+  } else {
+    x
+  }
+}
 
-style_reset <- function(x)
+style_reset <- function(x) {
   if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_reset(x)) else x
-style_no_colour <- function(x)
-  if (.rlang_cli_has_cli()) .rlang_cli_unstructure(cli::style_no_color(x)) else
+}
+style_no_colour <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_color(x))
+  } else {
     x
-style_no_bg_colour <- function(x)
-  if (.rlang_cli_has_cli())
-    .rlang_cli_unstructure(cli::style_no_bg_color(x)) else x
+  }
+}
+style_no_bg_colour <- function(x) {
+  if (.rlang_cli_has_cli()) {
+    .rlang_cli_unstructure(cli::style_no_bg_color(x))
+  } else {
+    x
+  }
+}
 
 CLI_SUPPORT_HYPERLINK <- "2.2.0"
 CLI_SUPPORT_HYPERLINK_PARAMS <- "3.1.1"
@@ -289,10 +368,12 @@ format_url <- function(x) .rlang_cli_format_inline(x, "url", "<%s>")
 format_var <- function(x) .rlang_cli_format_inline(x, "var", "`%s`")
 format_envvar <- function(x) .rlang_cli_format_inline(x, "envvar", "`%s`")
 format_field <- function(x) .rlang_cli_format_inline(x, "field", NULL)
-format_href <- function(x, target = NULL)
+format_href <- function(x, target = NULL) {
   .rlang_cli_format_inline_link(x, target, "href", "<%s>")
-format_run <- function(x, target = NULL)
+}
+format_run <- function(x, target = NULL) {
   .rlang_cli_format_inline_link(x, target, "run", "`%s`")
+}
 
 format_error_arg_highlight <- function(x, quote = TRUE) {
   if (is_true(peek_option("rlang:::trace_test_highlight"))) {

--- a/R/standalone-lazyeval.R
+++ b/R/standalone-lazyeval.R
@@ -24,7 +24,9 @@ warn_text_se <- function() {
 }
 
 compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
-  if (warn) warn_underscored()
+  if (warn) {
+    warn_underscored()
+  }
 
   if (missing(lazy)) {
     return(quo())
@@ -41,7 +43,9 @@ compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
     symbol = ,
     language = new_quosure(lazy, env),
     character = {
-      if (warn) warn_text_se()
+      if (warn) {
+        warn_text_se()
+      }
       parse_quo(lazy[[1]], env)
     },
     logical = ,

--- a/R/utils-cli-tree.R
+++ b/R/utils-cli-tree.R
@@ -139,6 +139,8 @@ cli_is_utf8_output <- function() {
 }
 
 cli_is_latex_output <- function() {
-  if (!("knitr" %in% loadedNamespaces())) return(FALSE)
+  if (!("knitr" %in% loadedNamespaces())) {
+    return(FALSE)
+  }
   get("is_latex_output", asNamespace("knitr"))()
 }

--- a/man/notes/handling-introspection.R
+++ b/man/notes/handling-introspection.R
@@ -36,7 +36,6 @@
 # currently no way of finding the setup frame with 100% reliability
 # (there might be several on the stack).
 
-
 f <- function() {
   throw()
 }
@@ -50,7 +49,7 @@ handler_helper <- function() {
 }
 
 
-#  Errors - Calling handlers
+#  Errors - Calling handlers
 
 foo <- function(...) {
   withCallingHandlers(f(), ...)
@@ -73,7 +72,6 @@ foo(error = handle)
 #> >7.   └─global h(simpleError(msg, call))
 #>  8.     └─global handler_helper()
 
-
 ### Condition error
 
 # Setup: 2
@@ -90,7 +88,6 @@ foo(error = handle)
 #> >6. └─global `<fn>`(`<smplErrr>`)
 #>  7.   └─global handler_helper()
 
-
 ### Condition error, simple signal
 
 # Setup: 2
@@ -106,7 +103,6 @@ foo(error = handle)
 #> >5. │     └─base::signalCondition(simpleError("foo"))
 #> >6. └─global `<fn>`(`<smplErrr>`)
 #>  7.   └─global handler_helper()
-
 
 ### Condition error, demoted to warning
 
@@ -126,7 +122,6 @@ foo(error = handle)
 #>   8. │           └─base doWithOneRestart(return(expr), restart)
 #>  >9. └─global `<fn>`(`<smplErrr>`)
 #>  10.   └─global handler_helper()
-
 
 ### Condition error, demoted to message
 
@@ -148,7 +143,6 @@ foo(error = handle)
 #>  10. └─global `<fn>`(`<smplErrr>`)
 #>  11.   └─global handler_helper()
 
-
 ### C-level error
 
 # In this case, the signal frame is a user function.
@@ -167,7 +161,6 @@ foo(error = handle)
 #>  6. └─base::.handleSimpleError(`<fn>`, "foo", base::quote(NULL))
 #> >7.   └─global h(simpleError(msg, call))
 #>  8.     └─global handler_helper()
-
 
 ### Text warning promoted to error
 
@@ -196,7 +189,6 @@ foo(error = handle)
 #> >11.   └─global h(simpleError(msg, call))
 #>  12.     └─global handler_helper()
 
-
 ### Condition warning promoted to error
 
 # Setup: 2
@@ -220,7 +212,6 @@ foo(error = handle)
 #> >10.   └─global h(simpleError(msg, call))
 #>  11.     └─global handler_helper()
 
-
 ### rlang error
 
 # Setup: 2
@@ -239,8 +230,7 @@ foo(error = handle)
 #>  8. └─global `<fn>`(`<rlng_rrr>`)
 #>  9.   └─global handler_helper()
 
-
-#  Errors - Exiting handlers
+#  Errors - Exiting handlers
 
 # This is much easier, all the stacks look the same!
 

--- a/tests/testthat/_snaps/current/cnd-abort.md
+++ b/tests/testthat/_snaps/current/cnd-abort.md
@@ -176,8 +176,12 @@
        16.             \-base::stop("bar")
     Code
       # Wrapped handler
-      handler1 <- (function(cnd, call = caller_env()) handler2(cnd, call))
-      handler2 <- (function(cnd, call) abort(cnd_header(cnd), parent = NA, call = call))
+      handler1 <- (function(cnd, call = caller_env()) {
+        handler2(cnd, call)
+      })
+      handler2 <- (function(cnd, call) {
+        abort(cnd_header(cnd), parent = NA, call = call)
+      })
       hh <- (function() {
         withCallingHandlers(foo(), error = function(cnd) handler1(cnd))
       })

--- a/tests/testthat/helper-locale.R
+++ b/tests/testthat/helper-locale.R
@@ -18,15 +18,17 @@ get_lang_strings <- function() {
 
 get_native_lang_string <- function() {
   lang_strings <- get_lang_strings()
-  if (length(lang_strings$same) == 0)
+  if (length(lang_strings$same) == 0) {
     testthat::skip("No native language string available")
+  }
   lang_strings$same[[1L]]
 }
 
 get_alien_lang_string <- function() {
   lang_strings <- get_lang_strings()
-  if (length(lang_strings$different) == 0)
+  if (length(lang_strings$different) == 0) {
     testthat::skip("No alien language string available")
+  }
   lang_strings$different[[1L]]
 }
 

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -83,9 +83,30 @@ test_that("r_which_operator() returns correct tokens", {
   expect_identical(call_parse_type(quote(?a)), "?unary")
   expect_identical(call_parse_type(quote(a?b)), "?")
 
-  expect_identical(call_parse_type(quote(while (a) b)), "while")
-  expect_identical(call_parse_type(quote(for (a in b) b)), "for")
-  expect_identical(call_parse_type(quote(repeat a)), "repeat")
+  expect_identical(
+    call_parse_type(quote(
+      while (a) {
+        b
+      }
+    )),
+    "while"
+  )
+  expect_identical(
+    call_parse_type(quote(
+      for (a in b) {
+        b
+      }
+    )),
+    "for"
+  )
+  expect_identical(
+    call_parse_type(quote(
+      repeat {
+        a
+      }
+    )),
+    "repeat"
+  )
   expect_identical(call_parse_type(quote(if (a) b)), "if")
   expect_identical(call_parse_type(quote(break)), "break")
   expect_identical(call_parse_type(quote(next)), "next")

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -450,9 +450,30 @@ test_that("call_print_type() returns correct enum", {
   expect_identical(call_print_type(quote(+a)), "prefix")
   expect_identical(call_print_type(quote(-a)), "prefix")
 
-  expect_identical(call_print_type(quote(while (a) b)), "special")
-  expect_identical(call_print_type(quote(for (a in b) b)), "special")
-  expect_identical(call_print_type(quote(repeat a)), "special")
+  expect_identical(
+    call_print_type(quote(
+      while (a) {
+        b
+      }
+    )),
+    "special"
+  )
+  expect_identical(
+    call_print_type(quote(
+      for (a in b) {
+        b
+      }
+    )),
+    "special"
+  )
+  expect_identical(
+    call_print_type(quote(
+      repeat {
+        a
+      }
+    )),
+    "special"
+  )
   expect_identical(call_print_type(quote(if (a) b)), "special")
   expect_identical(call_print_type(quote((a))), "special")
   expect_identical(
@@ -534,9 +555,30 @@ test_that("call_print_fine_type() returns correct enum", {
   expect_identical(call_print_fine_type(quote(+a)), "prefix")
   expect_identical(call_print_fine_type(quote(-a)), "prefix")
 
-  expect_identical(call_print_fine_type(quote(while (a) b)), "control")
-  expect_identical(call_print_fine_type(quote(for (a in b) b)), "control")
-  expect_identical(call_print_fine_type(quote(repeat a)), "control")
+  expect_identical(
+    call_print_fine_type(quote(
+      while (a) {
+        b
+      }
+    )),
+    "control"
+  )
+  expect_identical(
+    call_print_fine_type(quote(
+      for (a in b) {
+        b
+      }
+    )),
+    "control"
+  )
+  expect_identical(
+    call_print_fine_type(quote(
+      repeat {
+        a
+      }
+    )),
+    "control"
+  )
   expect_identical(call_print_fine_type(quote(if (a) b)), "control")
   expect_identical(call_print_fine_type(quote((a))), "delim")
   expect_identical(

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -414,10 +414,12 @@ test_that("error_call() and format_error_call() preserve special syntax ops", {
   )
   expect_snapshot(format_error_call(quote(1 + 2)))
 
+  # fmt: skip
   expect_equal(
     error_call(quote(for (x in y) NULL)),
     quote(for (x in y) NULL)
   )
+  # fmt: skip
   expect_snapshot(format_error_call(quote(for (x in y) NULL)))
 
   expect_snapshot(format_error_call(quote(a %||% b)))

--- a/tests/testthat/test-cnd-abort.R
+++ b/tests/testthat/test-cnd-abort.R
@@ -743,9 +743,12 @@ test_that("`parent = NA` signals a non-chained rethrow", {
     print(err(ff()))
 
     "Wrapped handler"
-    handler1 <- function(cnd, call = caller_env()) handler2(cnd, call)
-    handler2 <- function(cnd, call)
+    handler1 <- function(cnd, call = caller_env()) {
+      handler2(cnd, call)
+    }
+    handler2 <- function(cnd, call) {
       abort(cnd_header(cnd), parent = NA, call = call)
+    }
     hh <- function() {
       withCallingHandlers(
         foo(),
@@ -796,12 +799,13 @@ test_that("if `call` is older than handler caller, use that as bottom", {
   helper <- function(call = caller_env()) {
     try_fetch(
       low_level(call),
-      error = function(cnd)
+      error = function(cnd) {
         abort(
           "Problem.",
           parent = cnd,
           call = call
         )
+      }
     )
   }
 

--- a/tests/testthat/test-cnd-entrace.R
+++ b/tests/testthat/test-cnd-entrace.R
@@ -390,7 +390,9 @@ test_that("only the first n warnings are entraced (#1473)", {
         entrace(cnd)
         zap()
       },
-      for (i in 1:5) f()
+      for (i in 1:5) {
+        f()
+      }
     )
 
     expect_equal(

--- a/tests/testthat/test-cnd-message.R
+++ b/tests/testthat/test-cnd-message.R
@@ -472,8 +472,9 @@ test_that("as.character() and conditionMessage() methods for errors, warnings, a
 })
 
 test_that("multiline operator calls are preserved", {
-  err <- function(expr)
+  err <- function(expr) {
     error_cnd(message = "This is the error message.", call = enexpr(expr))
+  }
 
   expect_snapshot_output(err(
     1 +
@@ -569,13 +570,14 @@ test_that("arguments are highlighted but code spans are not", {
   local_options("rlang:::trace_test_highlight" = TRUE)
 
   err <- error_cnd(
-    header = function(cnd)
+    header = function(cnd) {
       sprintf(
         "%s - %s - %s",
         format_arg("arg1"),
         format_code("code"),
         format_arg("arg2")
       )
+    }
   )
 
   expect_snapshot({

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -87,9 +87,13 @@ test_that("control flow is deparsed", {
     })),
     c("function(a = 1, b = 2) {", "  3", "  4", "  5", "}")
   )
+  # fmt: skip
   expect_identical(while_deparse(quote(while (1) 2)), "while (1) 2")
+  # fmt: skip
   expect_identical(for_deparse(quote(for (a in 2) 3)), "for (a in 2) 3")
+  # fmt: skip
   expect_identical(repeat_deparse(quote(repeat 1)), "repeat 1")
+  # fmt: skip
   expect_identical(
     if_deparse(quote(
       if (1) 2 else {
@@ -364,6 +368,7 @@ test_that("call_deparse() delimits CAR when needed", {
   expect_identical(call_deparse(call), "`+`(f)(x)")
   expect_identical(parse_expr(expr_deparse(call)), call)
 
+  # fmt: skip
   call <- expr((!!quote(while (TRUE) NULL))(x))
   expect_identical(call_deparse(call), "`while`(TRUE, NULL)(x)")
   expect_identical(parse_expr(expr_deparse(call)), call)

--- a/tests/testthat/test-lifecycle.R
+++ b/tests/testthat/test-lifecycle.R
@@ -44,8 +44,9 @@ test_that("deprecate_soft() warns when called from package being tested", {
   reset_warning_verbosity("rlang_test")
 
   withr::local_envvar(c("TESTTHAT_PKG" = "rlang"))
-  depr <- function()
+  depr <- function() {
     deprecate_soft("warns from package being tested", id = "rlang_test")
+  }
   expect_warning(depr(), "warns from")
   expect_warning(depr(), "warns from")
 })

--- a/tests/testthat/test-nse-inject.R
+++ b/tests/testthat/test-nse-inject.R
@@ -681,14 +681,16 @@ test_that("`:=` chaining is detected at dots capture", {
 # --------------------------------------------------------------------
 
 test_that("Unquote operators fail when called outside quasiquoted arguments", {
-  expect_qq_error <- function(object)
+  expect_qq_error <- function(object) {
     expect_error(object, regexp = "within a defused argument")
+  }
   expect_qq_error(UQ())
   expect_qq_error(UQS())
   expect_qq_error(`!!`())
 
-  expect_dyn_error <- function(object)
+  expect_dyn_error <- function(object) {
     expect_error(object, regexp = "within dynamic dots")
+  }
   expect_dyn_error(`!!!`())
   expect_dyn_error(a := b)
 })

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -450,8 +450,9 @@ test_that("can trim layers of backtraces", {
   e <- current_env()
   f <- function(n) identity(identity(g(n)))
   g <- function(n) identity(identity(h(n)))
-  h <- function(n)
+  h <- function(n) {
     identity(identity(trace_back(e, bottom = caller_env(n - 1L))))
+  }
 
   trace1_env <- f(1)
   trace2_env <- f(2)
@@ -754,7 +755,7 @@ test_that("namespaced calls are highlighted", {
 })
 
 test_that("can highlight long lists of arguments in backtrace (#1456)", {
-  f <- function(...)
+  f <- function(...) {
     g(
       aaaaaaaaaaaa = aaaaaaaaaaaa,
       bbbbbbbbbbbb = bbbbbbbbbbbb,
@@ -763,6 +764,7 @@ test_that("can highlight long lists of arguments in backtrace (#1456)", {
       eeeeeeeeeeee = eeeeeeeeeeee,
       ...
     )
+  }
   g <- function(
     aaaaaaaaaaaa,
     bbbbbbbbbbbb,
@@ -786,7 +788,7 @@ test_that("can highlight long lists of arguments in backtrace (#1456)", {
 })
 
 test_that("can highlight multi-line arguments in backtrace (#1456)", {
-  f <- function(...)
+  f <- function(...) {
     g(
       x = {
         a
@@ -794,6 +796,7 @@ test_that("can highlight multi-line arguments in backtrace (#1456)", {
       },
       ...
     )
+  }
   g <- function(x, ...) {
     rlang::abort("foo", ...)
   }


### PR DESCRIPTION
Everything looks good but there are two notes:
- A snapshot test that captured a function definition body had to be updated
- Some sensitive deparse related tests were marked with `# fmt: skip` to avoid reformatting them. We could update these tests to expect the new result if you'd like. I'm not sure if the exact form the test expects is meaningful or not.

rlang is a particularly low level package, so it's not totally surprising that running Air on rlang broke a few very sensitive tests. But it's worth keeping in mind that we can't 100% guarantee that you won't have to change your tests after using Air.