### PR TITLE
Format with Air 0.7.0

### DIFF
--- a/R/types.R
+++ b/R/types.R
@@ -32,7 +32,13 @@ is_list <- function(x, n = NULL) {
   .Call(ffi_is_list, x, n)
 }
 
-parsable_atomic_types <- c("logical", "integer", "double", "complex", "character")
+parsable_atomic_types <- c(
+  "logical",
+  "integer",
+  "double",
+  "complex",
+  "character"
+)
 atomic_types <- c(parsable_atomic_types, "raw")
 #' @export
 #' @rdname type-predicates
@@ -70,11 +76,7 @@ is_complex <- function(x, n = NULL, finite = NULL) {
 is_character <- function(x, n = NULL) {
   .Call(ffi_is_character, x, n, NULL, NULL)
 }
-is_character2 <- function(x,
-                          n = NULL,
-                          ...,
-                          missing = TRUE,
-                          empty = TRUE) {
+is_character2 <- function(x, n = NULL, ..., missing = TRUE, empty = TRUE) {
   check_dots_empty0(...)
 
   # FIXME: Change API at C-level so that `TRUE` means no restriction
@@ -241,7 +243,9 @@ is_bare_integer <- function(x, n = NULL) {
 #' @export
 #' @rdname bare-type-predicates
 is_bare_numeric <- function(x, n = NULL) {
-  if (!is_null(n) && length(x) != n) return(FALSE)
+  if (!is_null(n) && length(x) != n) {
+    return(FALSE)
+  }
   !is.object(x) && typeof(x) %in% c("double", "integer")
 }
 #' @export
@@ -402,15 +406,15 @@ type_of_ <- function(x) {
 #' # copyable:
 #' is_copyable(env)
 is_copyable <- function(x) {
-  switch(typeof(x),
+  switch(
+    typeof(x),
     NULL = ,
     char = ,
     symbol = ,
     special = ,
     builtin = ,
     environment = ,
-    externalptr =
-      FALSE,
+    externalptr = FALSE,
     TRUE
   )
 }
@@ -491,7 +495,8 @@ rlang_type_sum.data.frame <- function(x) class(x)[[1]]
 #' @export
 rlang_type_sum.default <- function(x) {
   if (!is.object(x)) {
-    switch(typeof(x),
+    switch(
+      typeof(x),
       logical = "lgl",
       integer = "int",
       double = "dbl",
@@ -501,12 +506,11 @@ rlang_type_sum.default <- function(x) {
       special = ,
       closure = "fn",
       environment = "env",
-      symbol =
-        if (is_missing(x)) {
-          "missing"
-        } else {
-          "sym"
-        },
+      symbol = if (is_missing(x)) {
+        "missing"
+      } else {
+        "sym"
+      },
       typeof(x)
     )
   } else if (!isS4(x)) {

--- a/tests/testthat/test-call.R
+++ b/tests/testthat/test-call.R
@@ -355,8 +355,7 @@ test_that("call_name() handles formulas", {
 
 test_that("Inlined functions return NULL name", {
   call <- quote(fn())
-  call[[1]] <- function() {
-  }
+  call[[1]] <- function() {}
   expect_null(call_name(call))
 })
 

--- a/tests/testthat/test-deparse.R
+++ b/tests/testthat/test-deparse.R
@@ -689,16 +689,14 @@ test_that("symbols with unicode are deparsed consistently (#691)", {
 
 test_that("formal parameters are backticked if needed", {
   expect_identical(
-    expr_deparse(function(`^`) {
-    }),
+    expr_deparse(function(`^`) {}),
     c("<function(`^`) { }>")
   )
 })
 
 test_that("empty blocks are deparsed on the same line", {
   expect_identical(
-    expr_deparse(quote({
-    })),
+    expr_deparse(quote({})),
     "{ }"
   )
 })
@@ -706,8 +704,7 @@ test_that("empty blocks are deparsed on the same line", {
 test_that("top-level S3 objects are deparsed", {
   skip_on_cran()
   f <- structure(
-    function() {
-    },
+    function() {},
     class = "lambda"
   )
   expect_identical(expr_deparse(f), "<lambda>")

--- a/tests/testthat/test-types.R
+++ b/tests/testthat/test-types.R
@@ -101,8 +101,7 @@ test_that("scalar predicates heed type and length", {
   expect_true_false(is_scalar_list, list(1), list(1, 2), logical(1))
   expect_true_false(is_scalar_atomic, logical(1), logical(2), list(1))
   expect_true_false(is_scalar_vector, list(1), list(1, 2), quote(x))
-  expect_true_false(is_scalar_vector, logical(1), logical(2), function() {
-  })
+  expect_true_false(is_scalar_vector, logical(1), logical(2), function() {})
   expect_true_false(is_scalar_integer, integer(1), integer(2), double(1))
   expect_true_false(is_scalar_double, double(1), double(2), integer(1))
   expect_true_false(is_scalar_character, character(1), character(2), logical(1))


### PR DESCRIPTION
- `{}` are no longer expanded
- `types.R` can now actually be formatted since `NULL =` is now allowed in call argument position