### PR TITLE
Update cnd.R: `is_error()` to also check for `try-error`

### DIFF
--- a/R/cnd.R
+++ b/R/cnd.R
@@ -248,7 +248,7 @@ is_condition <- function(x) {
 #' @rdname is_condition
 #' @export
 is_error <- function(x) {
-  inherits(x, "error")
+  inherits(x, c("error", "try-error"))
 }
 #' @rdname is_condition
 #' @export


### PR DESCRIPTION
`is_error()` to also check for `try-error` such that it can check for errors resulting from expressions like:

```R
try( 1 / "1" )
```

### Before:

```R
> rlang::is_error(try(1/"1"))
Error in 1/"1" : non-numeric argument to binary operator
[1] FALSE
```

### After:

```R
> rlang::is_error(try(1/"1"))
Error in 1/"1" : non-numeric argument to binary operator
[1] TRUE
```