### PR TITLE
move `deprecated()` to the standalone file, and add `is_present()`

### DIFF
--- a/R/standalone-lifecycle.R
+++ b/R/standalone-lifecycle.R
@@ -14,6 +14,12 @@
 #
 # ## Changelog
 #
+# 2025-08-02
+#
+# - Added `deprecated()` and `is_present()`, intended to use as
+#   deprecated arguments' default value.
+#   Same as `lifecycle::deprecated()` and `lifecycle::is_present()`.
+#
 # 2024-09-27
 #
 # - Depends on `standalone-cli.R` instead of the cli package.
@@ -251,6 +257,12 @@ with_lifecycle_errors <- function(expr) {
   }
 
   opt
+}
+
+deprecated <- function() missing_arg()
+
+is_present <- function(arg) {
+  !is_missing(maybe_missing(arg))
 }
 
 # nocov end

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,3 @@
-deprecated <- function() missing_arg()
-
 abort_coercion <- function(
   x,
   to_type,


### PR DESCRIPTION
I founded that these functions are useful, and can be moved to the standalone file.