### PR TITLE
Make `is_syntactic_literal()` more strict

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * C code no longer calls `memcpy()` and `memset()` on 0-length R object memory
   (#1797).
+* `is_syntactic_literal()` returns `FALSE` for objects with attributes, such as `array(1)` or `factor("x")` (#1817, @jonthegeek).
 
 
 # rlang 1.1.6

--- a/R/expr.R
+++ b/R/expr.R
@@ -129,7 +129,7 @@ is_syntactic_literal <- function(x) {
     integer = ,
     double = ,
     character = {
-      length(x) == 1
+      length(x) == 1 && is.null(attributes(x))
     },
 
     complex = {

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -130,3 +130,11 @@ test_that("is_expression() detects attributes (#1475)", {
     NULL
   })))
 })
+
+test_that("arrays are not syntactic", {
+  expect_false(is_syntactic_literal(array(1)))
+})
+
+test_that("factors are not syntactic", {
+  expect_false(is_syntactic_literal(factor("x")))
+})


### PR DESCRIPTION
Add an `attributes()` check to `is_syntactic_literal()` to ensure that syntactic-literal-like objects such as factors and arrays are not treated as syntactic literals.

Fixes #1817.