### PR TITLE
More `is_syntactic_literal()` strictness

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * C code no longer calls `memcpy()` and `memset()` on 0-length R object memory
   (#1797).
 * `is_syntactic_literal()` returns `FALSE` for objects with attributes, such as `array(1)` or `factor("x")` (#1817, @jonthegeek).
+* `is_syntactic_literal()` returns `FALSE` for negative numbers and complex numbers with negative imaginary components (#1799, @jonthegeek).
 
 
 # rlang 1.1.6

--- a/R/expr.R
+++ b/R/expr.R
@@ -119,27 +119,22 @@ is_expression <- function(x) {
 #' @export
 #' @rdname is_expression
 is_syntactic_literal <- function(x) {
-  switch(
-    typeof(x),
-    NULL = {
-      TRUE
-    },
-
-    logical = ,
-    integer = ,
-    double = ,
-    character = {
-      length(x) == 1 && is.null(attributes(x))
-    },
-
-    complex = {
-      if (length(x) != 1) {
-        return(FALSE)
-      }
-      is_na(x) || Re(x) == 0
-    },
-
-    FALSE
+  is.null(x) || (
+    length(x) == 1 && is.null(attributes(x)) && (
+      is.na(x) || switch(
+        typeof(x),
+        character = ,
+        logical = TRUE,
+        integer = ,
+        double = {
+          x >= 0
+        },
+        complex = {
+          Re(x) == 0 && Im(x) >= 0
+        },
+        FALSE
+      )
+    ) 
   )
 }
 #' @export

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -100,6 +100,7 @@ test_that("expressions are deparsed and printed", {
 
 test_that("imaginary numbers with real part are not syntactic", {
   expect_true(is_syntactic_literal(0i))
+  expect_true(is_syntactic_literal(1i))
   expect_true(is_syntactic_literal(na_cpl))
   expect_false(is_syntactic_literal(1 + 1i))
 })
@@ -137,4 +138,10 @@ test_that("arrays are not syntactic", {
 
 test_that("factors are not syntactic", {
   expect_false(is_syntactic_literal(factor("x")))
+})
+
+test_that("negative numbers are not syntactic", {
+  expect_false(is_syntactic_literal(-1))
+  expect_false(is_syntactic_literal(-1L))
+  expect_false(is_syntactic_literal(-1i))
 })


### PR DESCRIPTION
Reject negative numbers and restructure `is_syntactic_literal()` to hopefully make it easier to deal with any other strangeness we encounter.

Fixes #1799.