### PR TITLE
NA + 1i is not syntactic literal

### DIFF
--- a/R/expr.R
+++ b/R/expr.R
@@ -133,7 +133,12 @@ is_syntactic_literal <- function(x) {
       length(x) == 1 && is.null(attributes(x)) && (is.na(x) || x >= 0)
     },
     complex = {
-      length(x) == 1 && is.null(attributes(x)) && (is.na(x) || (Re(x) == 0 && Im(x) >= 0))
+      length(x) == 1 && 
+        is.null(attributes(x)) && 
+        (
+          (is.na(Re(x)) && is.na(Im(x))) || 
+            (!is.na(x) && Re(x) == 0 && Im(x) >= 0)
+        )
     },
     FALSE
   )

--- a/tests/testthat/test-expr.R
+++ b/tests/testthat/test-expr.R
@@ -145,3 +145,8 @@ test_that("negative numbers are not syntactic", {
   expect_false(is_syntactic_literal(-1L))
   expect_false(is_syntactic_literal(-1i))
 })
+
+test_that("NA + 1i is not syntactic", {
+  expect_false(is_syntactic_literal(NA + 1i))
+  expect_false(is_syntactic_literal(NA - 1i))
+})


### PR DESCRIPTION
Fixes #1828.