### PR TITLE
Inline `r_pairlist_find()`

### DIFF
--- a/src/rlang/node.c
+++ b/src/rlang/node.c
@@ -52,17 +52,6 @@ r_obj* r_node_tree_clone(r_obj* x) {
   return x;
 }
 
-r_obj* r_pairlist_find(r_obj* node, r_obj* tag) {
-  while (node != r_null) {
-    if (r_node_tag(node) == tag) {
-      return node;
-    }
-    node = r_node_cdr(node);
-  }
-
-  return r_null;
-}
-
 r_obj* r_pairlist_rev(r_obj* node) {
   if (node == r_null) {
     return node;

--- a/src/rlang/node.h
+++ b/src/rlang/node.h
@@ -40,8 +40,20 @@ r_obj* r_new_pairlist(const struct r_pair* args, int n, r_obj** tail);
 #define r_pairlist4 Rf_list4
 #define r_pairlist5 Rf_list5
 
-r_obj* r_pairlist_find(r_obj* node, r_obj* tag);
 r_obj* r_pairlist_rev(r_obj* node);
+
+// Used by `r_attrib_get()` via `r_pairlist_get()`,
+// so we want it to be fully inlined
+static inline
+r_obj* r_pairlist_find(r_obj* node, r_obj* tag) {
+  while (node != r_null) {
+    if (r_node_tag(node) == tag) {
+      return node;
+    }
+    node = r_node_cdr(node);
+  }
+  return r_null;
+}
 
 static inline
 r_obj* r_pairlist_get(r_obj* node, r_obj* tag) {


### PR DESCRIPTION
`r_pairlist_find()` was showing up in my Instruments profiles as not being inlined. It is used in some of the deepest layers of vctrs via `r_dim()` and `r_class()` through the following:
- `r_dim()`
- calls `r_attrib_get()`
- calls `r_pairlist_get()`
- calls `r_pairlist_find()`

`r_dim()` itself is used on every iteration of `vec_size_common()` when computing the `vec_size()` of an object.

It's definitely a simple enough loop that we can inline it, and after inlining it does disappear from the Instruments profile