### PR TITLE
Report array dimensionality in `obj_type_friendly()`

### DIFF
--- a/R/standalone-obj-type.R
+++ b/R/standalone-obj-type.R
@@ -188,12 +188,12 @@ vec_type_friendly <- function(x, length = FALSE) {
   if (type == "list") {
     if (n_dim == 0) {
       return(add_length("a list"))
-    } else if (n_dim == 1) {
-      return("a list 1D array")
-    } else if (is.data.frame(x)) {
-      return("a data frame")
     } else if (n_dim == 2) {
-      return("a list matrix")
+      if (is.data.frame(x)) {
+        return("a data frame")
+      } else {
+        return("a list matrix")
+      }
     } else {
       return(sprintf("a list %sD array", n_dim))
     }
@@ -213,8 +213,6 @@ vec_type_friendly <- function(x, length = FALSE) {
 
   if (n_dim == 0) {
     kind <- "vector"
-  } else if (n_dim == 1) {
-    kind <- "1D array"
   } else if (n_dim == 2) {
     kind <- "matrix"
   } else {

--- a/R/standalone-obj-type.R
+++ b/R/standalone-obj-type.R
@@ -8,8 +8,8 @@
 #
 # ## Changelog
 #
-# 2025-09-30:
-# - `obj_type_friendly()` now handles 1D arrays differently from vectors.
+# 2025-10-02:
+# - `obj_type_friendly()` now shows the dimensionality of arrays.
 #
 # 2024-02-14:
 # - `obj_type_friendly()` now works for S7 objects.
@@ -189,13 +189,13 @@ vec_type_friendly <- function(x, length = FALSE) {
     if (n_dim == 0) {
       return(add_length("a list"))
     } else if (n_dim == 1) {
-      return("a list array")
+      return("a list 1D array")
     } else if (is.data.frame(x)) {
       return("a data frame")
     } else if (n_dim == 2) {
       return("a list matrix")
     } else {
-      return("a list array")
+      return(sprintf("a list %sD array", n_dim))
     }
   }
 
@@ -214,11 +214,11 @@ vec_type_friendly <- function(x, length = FALSE) {
   if (n_dim == 0) {
     kind <- "vector"
   } else if (n_dim == 1) {
-    kind <- "array"
+    kind <- "1D array"
   } else if (n_dim == 2) {
     kind <- "matrix"
   } else {
-    kind <- "array"
+    kind <- sprintf("%sD array", n_dim)
   }
   out <- sprintf(type, kind)
 

--- a/R/standalone-obj-type.R
+++ b/R/standalone-obj-type.R
@@ -8,6 +8,9 @@
 #
 # ## Changelog
 #
+# 2025-09-30:
+# - `obj_type_friendly()` now handles 1D arrays differently from vectors.
+#
 # 2024-02-14:
 # - `obj_type_friendly()` now works for S7 objects.
 #
@@ -183,8 +186,10 @@ vec_type_friendly <- function(x, length = FALSE) {
   }
 
   if (type == "list") {
-    if (n_dim < 2) {
+    if (n_dim == 0) {
       return(add_length("a list"))
+    } else if (n_dim == 1) {
+      return("a list array")
     } else if (is.data.frame(x)) {
       return("a data frame")
     } else if (n_dim == 2) {
@@ -206,8 +211,10 @@ vec_type_friendly <- function(x, length = FALSE) {
     type = paste0("a ", type, " %s")
   )
 
-  if (n_dim < 2) {
+  if (n_dim == 0) {
     kind <- "vector"
+  } else if (n_dim == 1) {
+    kind <- "array"
   } else if (n_dim == 2) {
     kind <- "matrix"
   } else {

--- a/tests/testthat/_snaps/standalone-obj-type.md
+++ b/tests/testthat/_snaps/standalone-obj-type.md
@@ -7,3 +7,21 @@
       Error in `checker()`:
       ! Element 1 of `x` must be a logical, not the number 1.
 
+# stop_input_type() reports 1D arrays differently from vectors
+
+    Code
+      err(checker(array(1), stop_input_type, what = "a double vector", arg = "x"))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `x` must be a double vector, not a double array.
+
+---
+
+    Code
+      err(checker(array(list(1)), stop_input_type, what = "a list", arg = "x"))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `x` must be a list, not a list array.
+

--- a/tests/testthat/_snaps/standalone-obj-type.md
+++ b/tests/testthat/_snaps/standalone-obj-type.md
@@ -14,7 +14,7 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `x` must be a double vector, not a double array.
+      ! `x` must be a double vector, not a double 1D array.
 
 ---
 
@@ -23,5 +23,25 @@
     Output
       <error/rlang_error>
       Error in `checker()`:
-      ! `x` must be a list, not a list array.
+      ! `x` must be a list, not a list 1D array.
+
+# stop_input_type() can differentiate between arrays by dimensionality
+
+    Code
+      err(checker(array(1, dim = c(1, 1, 1, 1)), stop_input_type, what = "a double 3D array",
+      arg = "x"))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `x` must be a double 3D array, not a double 4D array.
+
+---
+
+    Code
+      err(checker(array(list(1), dim = c(1, 1, 1, 1)), stop_input_type, what = "a list 3D array",
+      arg = "x"))
+    Output
+      <error/rlang_error>
+      Error in `checker()`:
+      ! `x` must be a list 3D array, not a list 4D array.
 

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -19,15 +19,20 @@ test_that("obj_type_friendly() only displays the first class of objects", {
 })
 
 test_that("obj_type_friendly() supports matrices and arrays (#141)", {
-  expect_true(all(friendly_types(matrix(list(1, 2))) == "a list matrix"))
+  # 1D, 2D, and >=3D all vary!
+
+  expect_true(all(friendly_types(array(list(1, 2, 3))) == "a list array"))
+  expect_true(all(friendly_types(matrix(list(1, 2, 3))) == "a list matrix"))
   expect_true(all(
     friendly_types(array(list(1, 2, 3), dim = 1:3)) == "a list array"
   ))
 
+  expect_true(all(friendly_types(array(1:3)) == "an integer array"))
   expect_true(all(friendly_types(matrix(1:3)) == "an integer matrix"))
   expect_true(all(friendly_types(array(1:3, dim = 1:3)) == "an integer array"))
 
-  expect_true(all(friendly_types(matrix(letters)) == "a character matrix"))
+  expect_true(all(friendly_types(array(letters[1:3])) == "a character array"))
+  expect_true(all(friendly_types(matrix(letters[1:3])) == "a character matrix"))
   expect_true(all(
     friendly_types(array(letters[1:3], dim = 1:3)) == "a character array"
   ))

--- a/tests/testthat/test-friendly-type.R
+++ b/tests/testthat/test-friendly-type.R
@@ -21,20 +21,24 @@ test_that("obj_type_friendly() only displays the first class of objects", {
 test_that("obj_type_friendly() supports matrices and arrays (#141)", {
   # 1D, 2D, and >=3D all vary!
 
-  expect_true(all(friendly_types(array(list(1, 2, 3))) == "a list array"))
+  expect_true(all(friendly_types(array(list(1, 2, 3))) == "a list 1D array"))
   expect_true(all(friendly_types(matrix(list(1, 2, 3))) == "a list matrix"))
   expect_true(all(
-    friendly_types(array(list(1, 2, 3), dim = 1:3)) == "a list array"
+    friendly_types(array(list(1, 2, 3), dim = 1:3)) == "a list 3D array"
   ))
 
-  expect_true(all(friendly_types(array(1:3)) == "an integer array"))
+  expect_true(all(friendly_types(array(1:3)) == "an integer 1D array"))
   expect_true(all(friendly_types(matrix(1:3)) == "an integer matrix"))
-  expect_true(all(friendly_types(array(1:3, dim = 1:3)) == "an integer array"))
+  expect_true(all(
+    friendly_types(array(1:3, dim = 1:3)) == "an integer 3D array"
+  ))
 
-  expect_true(all(friendly_types(array(letters[1:3])) == "a character array"))
+  expect_true(all(
+    friendly_types(array(letters[1:3])) == "a character 1D array"
+  ))
   expect_true(all(friendly_types(matrix(letters[1:3])) == "a character matrix"))
   expect_true(all(
-    friendly_types(array(letters[1:3], dim = 1:3)) == "a character array"
+    friendly_types(array(letters[1:3], dim = 1:3)) == "a character 3D array"
   ))
 })
 

--- a/tests/testthat/test-standalone-obj-type.R
+++ b/tests/testthat/test-standalone-obj-type.R
@@ -50,3 +50,22 @@ test_that("stop_input_type() reports 1D arrays differently from vectors", {
     ))
   })
 })
+
+test_that("stop_input_type() can differentiate between arrays by dimensionality", {
+  expect_snapshot({
+    err(checker(
+      array(1, dim = c(1, 1, 1, 1)),
+      stop_input_type,
+      what = "a double 3D array",
+      arg = "x"
+    ))
+  })
+  expect_snapshot({
+    err(checker(
+      array(list(1), dim = c(1, 1, 1, 1)),
+      stop_input_type,
+      what = "a list 3D array",
+      arg = "x"
+    ))
+  })
+})

--- a/tests/testthat/test-standalone-obj-type.R
+++ b/tests/testthat/test-standalone-obj-type.R
@@ -31,3 +31,22 @@ test_that("stop_input_type() handles I() in `arg` (#1607)", {
     ))
   })
 })
+
+test_that("stop_input_type() reports 1D arrays differently from vectors", {
+  expect_snapshot({
+    err(checker(
+      array(1),
+      stop_input_type,
+      what = "a double vector",
+      arg = "x"
+    ))
+  })
+  expect_snapshot({
+    err(checker(
+      array(list(1)),
+      stop_input_type,
+      what = "a list",
+      arg = "x"
+    ))
+  })
+})


### PR DESCRIPTION
In vctrs, we are trying to be fairly strict about the type of `condition` in `vec_if_else()`. In particular, we disallow arrays from being passed as `condition`, even 1D arrays (we do this consistently across `vec_if_else()`, `list_combine()`, vec_case_when()`, and `vec_replace_when()`, all of which can take logical "condition" indices).

https://github.com/r-lib/vctrs/blob/f27ab24c7eb0b1d78d48bd1d39175a1ecf7d4411/src/slice-assign.c#L964-L971

Unfortunately, `obj_type_friendly()` currently reports 1D arrays as identical to vectors resulting in the following not-useful error message

```r
     Error in `if_else()`:
     ! `condition` must be a logical vector, not a logical vector.
```

I'd argue that 1D arrays should be reported _as arrays_ by `obj_type_friendly()`. In other words, we'd have:

- `n_dim = 0` gives `vector`
- `n_dim = 1` gives `array`
- `n_dim = 2` gives `matrix`
- `n_dim = 3+` gives `array`

This feels right to me and allows us to report a useful distinction between vectors and 1D arrays.