### PR TITLE
Remove `SET_CLOENV()` usage

### DIFF
--- a/src/internal/eval-tidy.c
+++ b/src/internal/eval-tidy.c
@@ -144,14 +144,15 @@ static r_obj* mask_sym = NULL;
 
 static r_obj* tilde_fn = NULL;
 static r_obj* restore_mask_fn = NULL;
+static r_obj* restore_mask_formals = NULL;
+static r_obj* restore_mask_body = NULL;
 
 static void on_exit_restore_lexical_env(r_obj* mask, r_obj* old, r_obj* frame) {
-  r_obj* fn = KEEP(r_clone(restore_mask_fn));
-
   r_obj* env = KEEP(r_alloc_environment(2, r_envs.base));
   r_env_poke(env, mask_sym, mask);
   r_env_poke(env, old_sym, old);
-  r_fn_poke_env(fn, env);
+
+  r_obj* fn = KEEP(r_new_function(restore_mask_formals, restore_mask_body, env));
 
   r_obj* call = KEEP(r_new_call(fn, r_null));
   r_on_exit(call, frame);
@@ -599,6 +600,12 @@ void rlang_init_eval_tidy(void) {
     r_envs.base
   );
   r_preserve(restore_mask_fn);
+
+  restore_mask_formals = r_fn_formals(restore_mask_fn);
+  r_preserve(restore_mask_formals);
+
+  restore_mask_body = r_fn_body(restore_mask_fn);
+  r_preserve(restore_mask_body);
 
   FREE(1);
 }

--- a/src/rlang/fn.h
+++ b/src/rlang/fn.h
@@ -31,12 +31,6 @@ r_obj* r_fn_env(r_obj* fn) {
 #endif
 }
 
-// TODO: C API compliance
-static inline
-void r_fn_poke_env(r_obj* fn, r_obj* env) {
-  SET_CLOENV(fn, env);
-}
-
 static inline
 r_obj* r_new_function(r_obj* formals, r_obj* body, r_obj* env) {
 #if R_VERSION >= R_Version(4, 5, 0)


### PR DESCRIPTION
Branched from #1844 

Like with #1845, instead of `r_clone(fn)` followed by `r_poke_fn_env(fn, env)`, we now just create a whole new function.