### PR TITLE
Use string encoding utilities from vctrs

### DIFF
--- a/src/internal/decl/encoding-decl.h
+++ b/src/internal/decl/encoding-decl.h
@@ -14,10 +14,7 @@ static
 r_obj* attrib_encode_utf8(r_obj* x);
 
 static inline
-r_obj* str_encode_utf8(r_obj* x);
-
-static inline
-bool str_needs_encoding(r_obj* x);
-
-static inline
 bool str_is_ascii_or_utf8(r_obj* x);
+
+static inline
+r_obj* str_as_utf8(r_obj* x);

--- a/tests/testthat/_snaps/c-api.md
+++ b/tests/testthat/_snaps/c-api.md
@@ -41,3 +41,10 @@
     Output
       <simpleError in r_obj_encode_utf8(c(enc, bytes)): translating strings with "bytes" encoding is not allowed>
 
+---
+
+    Code
+      (expect_error(r_obj_encode_utf8(c(enc, bytes))))
+    Output
+      <simpleError in r_obj_encode_utf8(c(enc, bytes)): translating strings with "bytes" encoding is not allowed>
+

--- a/tests/testthat/helper-c-api.R
+++ b/tests/testthat/helper-c-api.R
@@ -23,18 +23,10 @@ test_encodings <- function() {
   string <- "\u00B0C"
 
   utf8 <- iconv(string, from = Encoding(string), to = "UTF-8")
+  unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
   latin1 <- iconv(string, from = Encoding(string), to = "latin1")
 
-  # We used to be able to detect unknown encodings via `LEVELS()`. In recent
-  # versions of R we need to use `Rf_charIsUTF8` instead to be conformant to the
-  # public API but unfortunately it treats unknown encodings as UTF-8. So we
-  # no longer support this case:
-  #
-  # ```
-  # unknown <- iconv(string, from = Encoding(string), to = "", mark = FALSE)
-  # ```
-
-  list(utf8 = utf8, latin1 = latin1)
+  list(utf8 = utf8, unknown = unknown, latin1 = latin1)
 }
 expect_utf8_encoded <- function(object) {
   expect_identical(Encoding(object), rep("UTF-8", length(object)))


### PR DESCRIPTION
Modification of https://github.com/r-lib/rlang/pull/1728/, in particular we get to add back `unknown` encodings into our test suite since we can now recognize and translate them again.

Uses the same tooling as https://github.com/r-lib/vctrs/pull/2085, see notes there for full details