### PR TITLE
Use new resizable API in `r_vec_resize()` and friends

### DIFF
--- a/R/c-lib.R
+++ b/R/c-lib.R
@@ -397,6 +397,10 @@ list_compact <- function(x) {
   .Call(ffi_list_compact, x)
 }
 
+vec_alloc <- function(type, n) {
+  .Call(ffi_vec_alloc, type, n)
+}
+
 vec_resize <- function(x, n) {
   .Call(ffi_vec_resize, x, n)
 }

--- a/src/internal/exported.c
+++ b/src/internal/exported.c
@@ -817,7 +817,7 @@ r_obj* ffi_unpreserve(r_obj* x) {
 // vec.h
 
 r_obj* ffi_vec_alloc(r_obj* type, r_obj* n) {
-  return Rf_allocVector(Rf_str2type(r_chr_get_c_string(type, 0)), r_int_get(n, 0));
+  return r_alloc_vector(Rf_str2type(r_chr_get_c_string(type, 0)), r_int_get(n, 0));
 }
 r_obj* ffi_vec_coerce(r_obj* x, r_obj* type) {
   return Rf_coerceVector(x, Rf_str2type(r_chr_get_c_string(type, 0)));

--- a/src/rlang/vec.c
+++ b/src/rlang/vec.c
@@ -14,76 +14,88 @@ r_obj* r_chr_n(const char* const * strings, r_ssize n) {
   return out;
 }
 
-#define RESIZE(R_TYPE, C_TYPE, CONST_DEREF, DEREF)              \
-  do {                                                          \
-    r_ssize x_size = r_length(x);                               \
-    if (x_size == size) {                                       \
-      return x;                                                 \
-    }                                                           \
-    if (!ALTREP(x) && size < x_size) {                          \
-      SETLENGTH(x, size);                                       \
-      SET_TRUELENGTH(x, x_size);                                \
-      SET_GROWABLE_BIT(x);                                      \
-      return x;                                                 \
-    }                                                           \
-                                                                \
-    const C_TYPE* p_x = CONST_DEREF(x);                         \
-    r_obj* out = KEEP(r_alloc_vector(R_TYPE, size));            \
-    C_TYPE* p_out = DEREF(out);                                 \
-                                                                \
-    r_ssize cpy_size = (size > x_size) ? x_size : size;         \
-    r_memcpy(p_out, p_x, cpy_size * sizeof(C_TYPE));            \
-                                                                \
-    FREE(1);                                                    \
-    return out;                                                 \
+#define RESIZE(R_TYPE, C_TYPE, CONST_DEREF, DEREF)                  \
+  do {                                                              \
+    r_ssize old_size = r_length(x);                                 \
+    if (old_size == new_size) {                                     \
+      return x;                                                     \
+    }                                                               \
+    if (!ALTREP(x) && new_size < old_size) {                        \
+      return vec_shrink(x, new_size, old_size);                     \
+    }                                                               \
+                                                                    \
+    const C_TYPE* p_x = CONST_DEREF(x);                             \
+    r_obj* out = KEEP(r_alloc_vector(R_TYPE, new_size));            \
+    C_TYPE* p_out = DEREF(out);                                     \
+                                                                    \
+    r_ssize cpy_size = (new_size > old_size) ? old_size : new_size; \
+    r_memcpy(p_out, p_x, cpy_size * sizeof(C_TYPE));                \
+                                                                    \
+    FREE(1);                                                        \
+    return out;                                                     \
   } while (0)
 
-#define RESIZE_BARRIER(R_TYPE, CONST_DEREF, SET)                \
-  do {                                                          \
-    r_ssize x_size = r_length(x);                               \
-    if (x_size == size) {                                       \
-      return x;                                                 \
-    }                                                           \
-    if (!ALTREP(x) && size < x_size) {                          \
-      SETLENGTH(x, size);                                       \
-      SET_TRUELENGTH(x, x_size);                                \
-      SET_GROWABLE_BIT(x);                                      \
-      return x;                                                 \
-    }                                                           \
-                                                                \
-    r_obj* const * p_x = CONST_DEREF(x);                        \
-    r_obj* out = KEEP(r_alloc_vector(R_TYPE, size));            \
-                                                                \
-    r_ssize cpy_size = (size > x_size) ? x_size : size;         \
-    for (r_ssize i = 0; i < cpy_size; ++i) {                    \
-      SET(out, i, p_x[i]);                                      \
-    }                                                           \
-                                                                \
-    FREE(1);                                                    \
-    return out;                                                 \
+#define RESIZE_BARRIER(R_TYPE, CONST_DEREF, SET)                    \
+  do {                                                              \
+    r_ssize old_size = r_length(x);                                 \
+    if (old_size == new_size) {                                     \
+      return x;                                                     \
+    }                                                               \
+    if (!ALTREP(x) && new_size < old_size) {                        \
+      return vec_shrink(x, new_size, old_size);                     \
+    }                                                               \
+                                                                    \
+    r_obj* const * p_x = CONST_DEREF(x);                            \
+    r_obj* out = KEEP(r_alloc_vector(R_TYPE, new_size));            \
+                                                                    \
+    r_ssize cpy_size = (new_size > old_size) ? old_size : new_size; \
+    for (r_ssize i = 0; i < cpy_size; ++i) {                        \
+      SET(out, i, p_x[i]);                                          \
+    }                                                               \
+                                                                    \
+    FREE(1);                                                        \
+    return out;                                                     \
   } while (0)
+
+// Assumption on older R: `size` smaller than `x_size`
+static inline
+r_obj* vec_shrink(r_obj* x, r_ssize new_size, r_ssize old_size) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  if (R_isResizable(x)) {
+    R_resizeVector(x, new_size);
+    return x;
+  } else {
+    return Rf_xlengthgets(x, new_size);
+  }
+#else
+  SETLENGTH(x, new_size);
+  SET_TRUELENGTH(x, old_size);
+  SET_GROWABLE_BIT(x);
+  return x;
+#endif
+}
 
 // Compared to `Rf_xlengthgets()` this does not initialise the new
 // extended locations with `NA`
-r_obj* r_lgl_resize(r_obj* x, r_ssize size) {
+r_obj* r_lgl_resize(r_obj* x, r_ssize new_size) {
   RESIZE(R_TYPE_logical, int, r_lgl_cbegin, r_lgl_begin);
 }
-r_obj* r_int_resize(r_obj* x, r_ssize size) {
+r_obj* r_int_resize(r_obj* x, r_ssize new_size) {
   RESIZE(R_TYPE_integer, int, r_int_cbegin, r_int_begin);
 }
-r_obj* r_dbl_resize(r_obj* x, r_ssize size) {
+r_obj* r_dbl_resize(r_obj* x, r_ssize new_size) {
   RESIZE(R_TYPE_double, double, r_dbl_cbegin, r_dbl_begin);
 }
-r_obj* r_cpl_resize(r_obj* x, r_ssize size) {
+r_obj* r_cpl_resize(r_obj* x, r_ssize new_size) {
   RESIZE(R_TYPE_complex, r_complex, r_cpl_cbegin, r_cpl_begin);
 }
-r_obj* r_raw_resize(r_obj* x, r_ssize size) {
+r_obj* r_raw_resize(r_obj* x, r_ssize new_size) {
   RESIZE(R_TYPE_raw, unsigned char, r_raw_cbegin, r_raw_begin);
 }
-r_obj* r_chr_resize(r_obj* x, r_ssize size) {
+r_obj* r_chr_resize(r_obj* x, r_ssize new_size) {
   RESIZE_BARRIER(R_TYPE_character, r_chr_cbegin, r_chr_poke);
 }
-r_obj* r_list_resize(r_obj* x, r_ssize size) {
+r_obj* r_list_resize(r_obj* x, r_ssize new_size) {
   RESIZE_BARRIER(R_TYPE_list, r_list_cbegin, r_list_poke);
 }
 

--- a/src/rlang/vec.h
+++ b/src/rlang/vec.h
@@ -184,35 +184,67 @@ void r_list_poke(r_obj* x, r_ssize i, r_obj* y) {
 
 static inline
 r_obj* r_alloc_vector(enum r_type type, r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(type, n);
+#else
   return Rf_allocVector(type, n);
+#endif
 }
 static inline
 r_obj* r_alloc_logical(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_logical, n);
+#else
   return Rf_allocVector(R_TYPE_logical, n);
+#endif
 }
 static inline
 r_obj* r_alloc_integer(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_integer, n);
+#else
   return Rf_allocVector(R_TYPE_integer, n);
+#endif
 }
 static inline
 r_obj* r_alloc_double(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_double, n);
+#else
   return Rf_allocVector(R_TYPE_double, n);
+#endif
 }
 static inline
 r_obj* r_alloc_complex(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_complex, n);
+#else
   return Rf_allocVector(R_TYPE_complex, n);
+#endif
 }
 static inline
 r_obj* r_alloc_raw(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_raw, n);
+#else
   return Rf_allocVector(R_TYPE_raw, n);
+#endif
 }
 static inline
 r_obj* r_alloc_character(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_character, n);
+#else
   return Rf_allocVector(R_TYPE_character, n);
+#endif
 }
 static inline
 r_obj* r_alloc_list(r_ssize n) {
+#if R_VERSION >= R_Version(4, 6, 0)
+  return R_allocResizableVector(R_TYPE_list, n);
+#else
   return Rf_allocVector(R_TYPE_list, n);
+#endif
 }
 
 static inline
@@ -404,30 +436,30 @@ char r_as_char(r_obj* x) {
   return r_arg_as_char(x, "x");
 }
 
-r_obj* r_lgl_resize(r_obj* x, r_ssize size);
-r_obj* r_int_resize(r_obj* x, r_ssize size);
-r_obj* r_dbl_resize(r_obj* x, r_ssize size);
-r_obj* r_cpl_resize(r_obj* x, r_ssize size);
-r_obj* r_raw_resize(r_obj* x, r_ssize size);
-r_obj* r_chr_resize(r_obj* x, r_ssize size);
-r_obj* r_list_resize(r_obj* x, r_ssize size);
+r_obj* r_lgl_resize(r_obj* x, r_ssize new_size);
+r_obj* r_int_resize(r_obj* x, r_ssize new_size);
+r_obj* r_dbl_resize(r_obj* x, r_ssize new_size);
+r_obj* r_cpl_resize(r_obj* x, r_ssize new_size);
+r_obj* r_raw_resize(r_obj* x, r_ssize new_size);
+r_obj* r_chr_resize(r_obj* x, r_ssize new_size);
+r_obj* r_list_resize(r_obj* x, r_ssize new_size);
 
 static inline
-r_obj* r_vec_resize0(enum r_type type, r_obj* x, r_ssize size) {
+r_obj* r_vec_resize0(enum r_type type, r_obj* x, r_ssize new_size) {
   switch (type) {
-  case R_TYPE_logical: return r_lgl_resize(x, size);
-  case R_TYPE_integer: return r_int_resize(x, size);
-  case R_TYPE_double: return r_dbl_resize(x, size);
-  case R_TYPE_complex: return r_cpl_resize(x, size);
-  case R_TYPE_raw: return r_raw_resize(x, size);
-  case R_TYPE_character: return r_chr_resize(x, size);
-  case R_TYPE_list: return r_list_resize(x, size);
+  case R_TYPE_logical: return r_lgl_resize(x, new_size);
+  case R_TYPE_integer: return r_int_resize(x, new_size);
+  case R_TYPE_double: return r_dbl_resize(x, new_size);
+  case R_TYPE_complex: return r_cpl_resize(x, new_size);
+  case R_TYPE_raw: return r_raw_resize(x, new_size);
+  case R_TYPE_character: return r_chr_resize(x, new_size);
+  case R_TYPE_list: return r_list_resize(x, new_size);
   default: r_stop_unimplemented_type(type);
   }
 }
 static inline
-r_obj* r_vec_resize(r_obj* x, r_ssize size) {
-  return r_vec_resize0(r_typeof(x), x, size);
+r_obj* r_vec_resize(r_obj* x, r_ssize new_size) {
+  return r_vec_resize0(r_typeof(x), x, new_size);
 }
 
 static inline

--- a/tests/testthat/test-c-api.R
+++ b/tests/testthat/test-c-api.R
@@ -860,10 +860,42 @@ test_that("can shrink vectors", {
   expect_equal(out, as.list(1:2))
 
   # Uses truelength to modify in place on recent R
-  if (getRversion() >= "3.4.0") {
+  if (getRversion() >= "3.4.0" && getRversion() < "4.6.0") {
     expect_equal(x_atomic, 1:2)
     expect_equal(x_list, as.list(1:2))
   }
+})
+
+test_that("can grow vectors allocated with vec_alloc()", {
+  x <- vec_alloc("integer", 3L)
+  x[1:3] <- 1:3
+  out <- vec_resize(x, 5)
+  expect_length(out, 5)
+  expect_equal(x, 1:3)
+  expect_equal(out[1:3], x)
+
+  x <- vec_alloc("list", 3L)
+  x[[1]] <- 1
+  x[[2]] <- 2
+  x[[3]] <- 3
+  out <- vec_resize(x, 5)
+  expect_length(out, 5)
+  expect_equal(x[[1]], 1)
+  expect_equal(out[1:3], x[1:3])
+})
+
+test_that("can shrink vectors allocated with vec_alloc()", {
+  x_atomic <- vec_alloc("integer", 3L)
+  x_atomic[1:3] <- 1:3
+  out <- vec_resize(x_atomic, 2)
+  expect_equal(out, 1:2)
+
+  x_list <- vec_alloc("list", 3L)
+  x_list[[1]] <- 1
+  x_list[[2]] <- 2
+  x_list[[3]] <- 3
+  out <- vec_resize(x_list, 2)
+  expect_equal(out, list(1, 2))
 })
 
 test_that("can grow and shrink dynamic arrays", {


### PR DESCRIPTION
In resize functions:
- On newer R, use new API to shrink if input is a shrinkable vector. Otherwise, use `xlengthgets()`.
- On older R, keep using unofficial API as before.

In alloc functions:
- Create shrinkable vectors by default. I don't think there's any downside, apart from making it easier to cause destructive side effects at R level? But we're already careful about that, and there's already plenty of ways to commit such side effects.
