### PR TITLE
Set dll exports

### DIFF
--- a/src/rlang-win.def
+++ b/src/rlang-win.def
@@ -1,0 +1,3 @@
+LIBRARY rlang.dll
+EXPORTS
+ R_init_rlang


### PR DESCRIPTION
R-exts: https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Creating-shared-objects-1

Follows https://github.com/r-lib/xml2/pull/473 and https://github.com/Rdatatable/data.table/pull/7607.

As noted there, it's not clear this is really needed, but it does follow the practice of [other packages like {Matrix}](https://github.com/search?q=org%3Acran%20path%3A%2Fwin%5C.def%2F&type=code), and signals clear intent.

----

I got here looking around at `r-lib` repos with `$(C_VISIBILITY)` declarations; I would add the equivalent file to all those repos if we think it's not a waste of time :)

https://github.com/search?q=org%3Ar-lib+%2F%5B%24%5D%5B%28%5DC_VISIBILITY%2F&type=code