### PR TITLE
doc: enhance `parent` argument usage in try_fetch

### DIFF
--- a/R/cnd-handlers.R
+++ b/R/cnd-handlers.R
@@ -97,12 +97,21 @@ environment(hnd_prompt_install) <- baseenv()
 #'     ```
 #'
 #' -   **Rethrow conditions**, e.g. using `abort(msg, parent = cnd)`.
-#'     See the `parent` argument of [abort()]. This is typically done to
+#'     The `parent` argument of [abort()], [warn()], and [inform()]
+#'     can be used to chain conditions. This is typically done to
 #'     add information to low-level errors about the high-level context
 #'     in which they occurred.
 #'
 #'     ```
 #'     try_fetch(1 + "", error = function(cnd) abort("Failed.", parent = cnd))
+#'
+#'     try_fetch(
+#'       1 + "",
+#'       error = function(cnd) {
+#'         warn("Failed. Returning 1", parent = cnd)
+#'         1L
+#'       }
+#'     )
 #'     ```
 #'
 #' -   **Inspect conditions**, for instance to log data about warnings


### PR DESCRIPTION
This PR closes #1868.

Currently, the docs make it seem that the `parent` argument is only useful for `abort()`. This is my attempt at making it clear that the conditions can be mixed—e.g. use `warn()` with an error.

I've tried to clarify that the `parent` argument can be used to chain conditions together. I've also added an example that shows you can use `parent` with `warn()`.

