### PR TITLE
`r_env_get()` is actually in `env-binding.c/h`

### DIFF
--- a/src/rlang/env.h
+++ b/src/rlang/env.h
@@ -48,8 +48,6 @@ bool r_is_namespace(r_obj* x) {
   return R_IsNamespaceEnv(x);
 }
 
-r_obj* r_env_get(r_obj* env, r_obj* sym);
-
 r_obj* r_env_until(r_obj* env, r_obj* sym, r_obj* last);
 
 r_obj* r_env_get_anywhere(r_obj* env, r_obj* sym);


### PR DESCRIPTION
Doubly defined in `env.h` and `env-binding.h`, but implemented in `env-binding.c`