### PR TITLE
Debug run on R-4.6 alpha

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -26,11 +26,13 @@ jobs:
           - {os: macos-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'next'}
           # use 4.0 or 4.1 to check with rtools40's older compiler
           - {os: windows-latest, r: 'oldrel-4'}
 
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
+          - {os: ubuntu-latest,  r: 'next'}
           - {os: ubuntu-latest,  r: 'oldrel-1'}
           - {os: ubuntu-latest,  r: 'oldrel-2'}
           - {os: ubuntu-latest,  r: 'oldrel-3'}


### PR DESCRIPTION
Note we see a bunch of errors on R-4.6-alpha that were not there in R-devel recently.

```
Saving _problems/test-dots-info-447.R
Saving _problems/test-dots-info-452.R
Saving _problems/test-dots-info-457.R
Saving _problems/test-dots-info-462.R
Saving _problems/test-dots-info-467.R
Saving _problems/test-dots-info-472.R
Saving _problems/test-dots-info-477.R
Saving _problems/test-nse-defuse-483.R
[ FAIL 8 | WARN 0 | SKIP 15 | PASS 4210 ]

══ Skipped tests (15) ══════════════════════════════════════════════════════════
• Can't set locale 'en_US.ISO8859-1' (3): 'test-env-binding.R:386:3',
  'test-env-binding.R:424:3', 'test-eval-tidy.R:320:3'
• Can't set locale 'ja_JP.SJIS' (1): 'test-utils.R:2:3'
• Disabled (1): 'test-call.R:322:3'
• Failing (1): 'test-env-binding.R:279:3'
• No UTF-8 marker with this version of libiconv. (4): 'test-deprecated.R:17:3',
  'test-encoding.R:2:3', 'test-encoding.R:19:3', 'test-nse-defuse.R:270:3'
• Not on Windows (1): 'test-encoding.R:28:3'
• has_private_accessors() is not TRUE (1): 'test-c-api.R:1132:3'
• profmem must be installed. (2): 'test-dots.R:394:3', 'test-dots.R:408:5'
• {S7} is not installed (1): 'test-standalone-obj-type.R:19:3'

══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-dots-info.R:447:3'): env_dots_exist() finds dots in parent env ──
Expected `fn(1)` to be TRUE.
Differences:
`actual`:   FALSE
`expected`: TRUE 

── Error ('test-dots-info.R:452:9'): env_dots_length() finds dots in parent env ──
Error in `env_dots_length()`: incorrect context: the current call has no '...' to look in
Backtrace:
     ▆
  1. ├─testthat::expect_equal(fn(1, 2, 3), 3L) at test-dots-info.R:453:3
  2. │ └─testthat::quasi_label(enquo(object), label) at testthat/R/expect-equality.R:66:3
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo)) at testthat/R/quasi-label.R:55:3
  4. └─rlang (local) fn(1, 2, 3) at rlang/R/eval.R:96:3
  5.   ├─base::local(env_dots_length()) at test-dots-info.R:452:9
  6.   │ └─base::eval.parent(substitute(eval(quote(expr), envir)))
  7.   │   └─base::eval(expr, p)
  8.   │     └─base::eval(expr, p)
  9.   └─base::eval(quote(env_dots_length()), new.env())
 10.     └─base::eval(quote(env_dots_length()), new.env())
 11.       └─rlang:::env_dots_length()
── Error ('test-dots-info.R:457:9'): env_dots_names() finds dots in parent env ──
Error in `env_dots_names()`: incorrect context: the current call has no '...' to look in
Backtrace:
     ▆
  1. ├─testthat::expect_equal(fn(a = 1, b = 2), c("a", "b")) at test-dots-info.R:458:3
  2. │ └─testthat::quasi_label(enquo(object), label) at testthat/R/expect-equality.R:66:3
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo)) at testthat/R/quasi-label.R:55:3
  4. └─rlang (local) fn(a = 1, b = 2) at rlang/R/eval.R:96:3
  5.   ├─base::local(env_dots_names()) at test-dots-info.R:457:9
  6.   │ └─base::eval.parent(substitute(eval(quote(expr), envir)))
  7.   │   └─base::eval(expr, p)
  8.   │     └─base::eval(expr, p)
  9.   └─base::eval(quote(env_dots_names()), new.env())
 10.     └─base::eval(quote(env_dots_names()), new.env())
 11.       └─rlang:::env_dots_names()
── Error ('test-dots-info.R:462:9'): env_dot_get() finds dots in parent env ────
Error in `env_dot_get(environment(), 1)`: ..1 used in an incorrect context, no ... to look in
Backtrace:
     ▆
  1. ├─testthat::expect_equal(fn(42), 42) at test-dots-info.R:463:3
  2. │ └─testthat::quasi_label(enquo(object), label) at testthat/R/expect-equality.R:66:3
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo)) at testthat/R/quasi-label.R:55:3
  4. └─rlang (local) fn(42) at rlang/R/eval.R:96:3
  5.   ├─base::local(env_dot_get(environment(), 1)) at test-dots-info.R:462:9
  6.   │ └─base::eval.parent(substitute(eval(quote(expr), envir)))
  7.   │   └─base::eval(expr, p)
  8.   │     └─base::eval(expr, p)
  9.   └─base::eval(quote(env_dot_get(environment(), 1)), new.env())
 10.     └─base::eval(quote(env_dot_get(environment(), 1)), new.env())
 11.       └─rlang:::env_dot_get(environment(), 1)
── Error ('test-dots-info.R:467:9'): env_dot_type() finds dots in parent env ───
Error in `env_dot_type(environment(), 1)`: ..1 used in an incorrect context, no ... to look in
Backtrace:
     ▆
  1. ├─testthat::expect_equal(fn(x), "delayed") at test-dots-info.R:468:3
  2. │ └─testthat::quasi_label(enquo(object), label) at testthat/R/expect-equality.R:66:3
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo)) at testthat/R/quasi-label.R:55:3
  4. └─rlang (local) fn(x) at rlang/R/eval.R:96:3
  5.   ├─base::local(env_dot_type(environment(), 1)) at test-dots-info.R:467:9
  6.   │ └─base::eval.parent(substitute(eval(quote(expr), envir)))
  7.   │   └─base::eval(expr, p)
  8.   │     └─base::eval(expr, p)
  9.   └─base::eval(quote(env_dot_type(environment(), 1)), new.env())
 10.     └─base::eval(quote(env_dot_type(environment(), 1)), new.env())
 11.       └─rlang:::env_dot_type(environment(), 1)
── Error ('test-dots-info.R:472:9'): env_dot_delayed_expr() finds dots in parent env ──
Error in `env_dot_delayed_expr(environment(), 1)`: ..1 used in an incorrect context, no ... to look in
Backtrace:
     ▆
  1. ├─testthat::expect_equal(fn(x + y), quote(x + y)) at test-dots-info.R:473:3
  2. │ └─testthat::quasi_label(enquo(object), label) at testthat/R/expect-equality.R:66:3
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo)) at testthat/R/quasi-label.R:55:3
  4. └─rlang (local) fn(x + y) at rlang/R/eval.R:96:3
  5.   ├─base::local(env_dot_delayed_expr(environment(), 1)) at test-dots-info.R:472:9
  6.   │ └─base::eval.parent(substitute(eval(quote(expr), envir)))
  7.   │   └─base::eval(expr, p)
  8.   │     └─base::eval(expr, p)
  9.   └─base::eval(quote(env_dot_delayed_expr(environment(), 1)), new.env())
 10.     └─base::eval(quote(env_dot_delayed_expr(environment(), 1)), new.env())
 11.       └─rlang:::env_dot_delayed_expr(environment(), 1)
── Error ('test-dots-info.R:477:9'): env_dot_delayed_env() finds dots in parent env ──
Error in `env_dot_delayed_env(environment(), 1)`: ..1 used in an incorrect context, no ... to look in
Backtrace:
     ▆
  1. ├─base::with(e, fn(x + 1)) at test-dots-info.R:479:3
  2. └─base::with.default(e, fn(x + 1))
  3.   └─base::eval(substitute(expr), data, enclos = parent.frame())
  4.     └─base::eval(substitute(expr), data, enclos = parent.frame())
  5.       └─rlang (local) fn(x + 1)
  6.         ├─base::local(env_dot_delayed_env(environment(), 1)) at test-dots-info.R:477:9
  7.         │ └─base::eval.parent(substitute(eval(quote(expr), envir)))
  8.         │   └─base::eval(expr, p)
  9.         │     └─base::eval(expr, p)
 10.         └─base::eval(quote(env_dot_delayed_env(environment(), 1)), new.env())
 11.           └─base::eval(quote(env_dot_delayed_env(environment(), 1)), new.env())
 12.             └─rlang:::env_dot_delayed_env(environment(), 1)
── Error ('test-nse-defuse.R:483:5'): enquos() works with lexically scoped dots ──
Error in `dot_call(capture_dots, frame_env = frame_env, named = named, ignore_empty = ignore_empty, unquote_names = unquote_names, homonyms = homonyms, check_assign = check_assign)`: incorrect context: the current call has no '...' to look in
Backtrace:
     ▆
  1. ├─testthat::expect_identical(capture("foo"), quos_list(quo("foo"))) at test-nse-defuse.R:485:3
  2. │ └─testthat::quasi_label(enquo(object), label) at testthat/R/expect-equality.R:105:3
  3. │   └─rlang::eval_bare(expr, quo_get_env(quo)) at testthat/R/quasi-label.R:55:3
  4. ├─rlang (local) capture("foo") at rlang/R/eval.R:96:3
  5. │ └─rlang::eval_bare(quote(enquos(...)), child_env(env())) at test-nse-defuse.R:483:5
  6. └─rlang::enquos(...) at rlang/R/eval.R:96:3
  7.   └─rlang:::endots(...) at rlang/R/nse-defuse.R:197:3
  8.     └─rlang:::map(...) at rlang/R/nse-defuse.R:482:3
  9.       └─base::lapply(.x, .f, ...) at rlang/R/standalone-purrr.R:38:3
 10.         └─rlang (local) FUN(X[[i]], ...)

[ FAIL 8 | WARN 0 | SKIP 15 | PASS 4210 ]
Error:
! Test failures.
Execution halted

Error: Error: R CMD check found ERRORs
Execution halted
1 error ✖ | 0 warnings ✔ | 1 note ✖
```