### PR TITLE
Fix double evaluation of active bindings in `env_get()` on old R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # rlang (development version)
 
+* Fixed `env_get()` issue causing double evaluation of active bindings on older R versions <= 4.4 (#1893).
+
+
 # rlang 1.2.0
 
 * rlang and tidyeval are now fully backed by official C APIs of R!

--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -186,16 +186,11 @@ r_obj* r_env_get(r_obj* env, r_obj* sym) {
 #if R_VERSION >= R_Version(4, 5, 0)
     return R_getVar(sym, env, FALSE);
 #else
-    // `Rf_findVarInFrame3()` evaluates active bindings via `BINDING_VALUE()`
-    // on R < 4.5, so skip `env_find()` to avoid evaluating them twice (#1893)
-    if (type != R_ENV_BINDING_TYPE_active) {
-        r_obj* value = env_find(env, sym);
-        if (r_typeof(value) == R_TYPE_dots) {
-            return value;
-        }
+    // `...` bindings must be returned as-is without `Rf_eval()`
+    if (sym == r_syms.dots) {
+        return env_find(env, sym);
     }
 
-    // Handles value, delayed, forced, and active bindings
     return Rf_eval(sym, env);
 #endif
 }

--- a/src/rlang/env-binding.c
+++ b/src/rlang/env-binding.c
@@ -186,9 +186,13 @@ r_obj* r_env_get(r_obj* env, r_obj* sym) {
 #if R_VERSION >= R_Version(4, 5, 0)
     return R_getVar(sym, env, FALSE);
 #else
-    r_obj* value = env_find(env, sym);
-    if (r_typeof(value) == R_TYPE_dots) {
-        return value;
+    // `Rf_findVarInFrame3()` evaluates active bindings via `BINDING_VALUE()`
+    // on R < 4.5, so skip `env_find()` to avoid evaluating them twice (#1893)
+    if (type != R_ENV_BINDING_TYPE_active) {
+        r_obj* value = env_find(env, sym);
+        if (r_typeof(value) == R_TYPE_dots) {
+            return value;
+        }
     }
 
     // Handles value, delayed, forced, and active bindings

--- a/tests/testthat/test-env-binding.R
+++ b/tests/testthat/test-env-binding.R
@@ -70,6 +70,21 @@ test_that("env_get() evaluates promises and active bindings", {
   expect_equal(env_get(e, "y"), 2)
 })
 
+test_that("env_get() evaluates active bindings only once (#1893)", {
+  n <- 0L
+  e <- env()
+  env_bind_active(e, x = function() { n <<- n + 1L; n })
+
+  out <- env_get(e, "x")
+  expect_equal(out, 1L)
+  expect_equal(n, 1L)
+
+  n <- 0L
+  out <- env_get_list(e, "x")
+  expect_equal(out, list(x = 1L))
+  expect_equal(n, 1L)
+})
+
 test_that("env_get_list() retrieves multiple bindings", {
   env <- env(foo = 1L, bar = 2L)
   expect_identical(env_get_list(env, c("foo", "bar")), list(foo = 1L, bar = 2L))


### PR DESCRIPTION
Closes #1893 