### PR TITLE
remove `check_name()` from news

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 * `ns_registry_env()` is defunct in R >= 4.6.0 for compliance with the C API of R.
 
 * New type-checking functions exported from rlang: `check_bool()`,
-  `check_string()`, `check_name()`, `check_number_decimal()`,
+  `check_string()`, `check_number_decimal()`,
   `check_number_whole()`, and `check_data_frame()`. These were
   previously only available via the `standalone-types-check.R`
   standalone file. `stop_input_type()` is also now exported.


### PR DESCRIPTION
fixes #1901 