### PR TITLE
docs: add cnd() to pkgdown reference index

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -182,6 +182,7 @@ reference:
 
 - subtitle: Conditions
   contents:
+  - cnd
   - rlang_error
   - cnd_message
   - format_error_bullets


### PR DESCRIPTION
Fixes #1900

## Problem

The `cnd()`, `error_cnd()`, `warning_cnd()`, and `message_cnd()` constructors are documented in `man/cnd.Rd` and exported in `NAMESPACE`, but were missing from the pkgdown reference index at https://rlang.r-lib.org/reference/index.html.

## Fix

Added `cnd` to the "Conditions" subsection in `_pkgdown.yml`.

## Validation

- YAML syntax validated with `yaml::yaml.load_file()`
- The `cnd` entry resolves to `man/cnd.Rd` which documents all four constructors
- `cnd_muffle` and `cnd_type` are intentionally omitted as they are marked `\keyword{internal}`

## Diff

Single line addition in `_pkgdown.yml`:
```yaml
- subtitle: Conditions
  contents:
+ - cnd
  - rlang_error
  - cnd_message
  - format_error_bullets
  - cnd_inherits
```