### PR TITLE
Fix backtrace links issues

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # rlang (development version)
 
-* Backtraces no longer emit `file://` hyperlinks for source files that don't exist on disk, such as the `R CMD INSTALL` staging directory recorded when a package is installed kept srcrefs. The location is shown as plain text instead (#1908).
+* Fixed backtrace links for `file://` URLs in srcrefs.
+
+* Backtraces no longer emit file hyperlinks for source files that don't exist on disk, such as the `R CMD INSTALL` staging directory recorded when a package is installed kept srcrefs. The location is shown as plain text instead (#1908).
 
 # rlang 1.3.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* Backtraces no longer emit `file://` hyperlinks for source files that don't exist on disk, such as the `R CMD INSTALL` staging directory recorded when a package is installed kept srcrefs. The location is shown as plain text instead (#1908).
+
 # rlang 1.3.0
 
 * `hash()` now uses its own walking strategy to make it independent of pecularities of the R serialiser. This fixes stability issues with function bytecode and shrinkable vectors on R 4.6.0 (#1681).

--- a/R/trace.R
+++ b/R/trace.R
@@ -875,8 +875,18 @@ src_loc <- function(srcref) {
   line <- srcref[[1]]
   column <- srcref[[5]]
 
+  loc <- paste0(file_trim, ":", line, ":", column)
+
+  # A hyperlink to a missing file is misleading in every terminal. Packages
+  # installed with kept srcrefs record the `R CMD INSTALL` staging directory,
+  # which is deleted right after installation, so the link would be dead
+  # (https://github.com/r-lib/rlang/issues/1908).
+  if (!file.exists(file)) {
+    return(loc)
+  }
+
   style_hyperlink(
-    paste0(file_trim, ":", line, ":", column),
+    loc,
     paste0("file://", normalizePath(file, mustWork = FALSE)),
     params = c(line = line, col = column)
   )

--- a/R/trace.R
+++ b/R/trace.R
@@ -877,6 +877,15 @@ src_loc <- function(srcref) {
 
   loc <- paste0(file_trim, ":", line, ":", column)
 
+  # `srcfile$filename` may be relative to the working directory in effect when
+  # the file was parsed, which `srcfile$wd` records. Resolve against it so the
+  # link points at the right file even when the current directory has changed
+  # since (e.g. testthat sources files then runs them from another directory).
+  wd <- srcfile$wd
+  if (is_string(wd) && !is_absolute_path(file)) {
+    file <- file.path(wd, file)
+  }
+
   # A hyperlink to a missing file is misleading in every terminal. Packages
   # installed with kept srcrefs record the `R CMD INSTALL` staging directory,
   # which is deleted right after installation, so the link would be dead
@@ -890,6 +899,10 @@ src_loc <- function(srcref) {
     paste0("file://", normalizePath(file, mustWork = FALSE)),
     params = c(line = line, col = column)
   )
+}
+
+is_absolute_path <- function(path) {
+  grepl("^(/|[A-Za-z]:|\\\\|~)", path)
 }
 
 trace_root <- function() {

--- a/R/trace.R
+++ b/R/trace.R
@@ -877,32 +877,52 @@ src_loc <- function(srcref) {
 
   loc <- paste0(file_trim, ":", line, ":", column)
 
+  # The displayed text stays as-is, but the hyperlink needs a real local path.
+  # Some sources record the filename as a `file://` URL rather than a plain
+  # path, so decode it first.
+  path <- path_from_file_url(file)
+
   # `srcfile$filename` may be relative to the working directory in effect when
   # the file was parsed, which `srcfile$wd` records. Resolve against it so the
   # link points at the right file even when the current directory has changed
   # since (e.g. testthat sources files then runs them from another directory).
   wd <- srcfile$wd
-  if (is_string(wd) && !is_absolute_path(file)) {
-    file <- file.path(wd, file)
+  if (is_string(wd) && !is_absolute_path(path)) {
+    path <- file.path(wd, path)
   }
 
   # A hyperlink to a missing file is misleading in every terminal. Packages
   # installed with kept srcrefs record the `R CMD INSTALL` staging directory,
   # which is deleted right after installation, so the link would be dead
   # (https://github.com/r-lib/rlang/issues/1908).
-  if (!file.exists(file)) {
+  if (!file.exists(path)) {
     return(loc)
   }
 
   style_hyperlink(
     loc,
-    paste0("file://", normalizePath(file, mustWork = FALSE)),
+    paste0("file://", normalizePath(path, mustWork = FALSE)),
     params = c(line = line, col = column)
   )
 }
 
 is_absolute_path <- function(path) {
   grepl("^(/|[A-Za-z]:|\\\\|~)", path)
+}
+
+path_from_file_url <- function(file) {
+  if (!grepl("^file://", file)) {
+    return(file)
+  }
+
+  path <- sub("^file://(localhost)?", "", file)
+
+  # `file:///C:/path` on Windows decodes to `/C:/path`; drop the leading slash.
+  if (grepl("^/[A-Za-z]:", path)) {
+    path <- sub("^/", "", path)
+  }
+
+  utils::URLdecode(path)
 }
 
 trace_root <- function() {

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -688,6 +688,21 @@ test_that("src_loc() hyperlinks files sourced from another directory (#1908)", {
   expect_match(src_loc(attr(env$f, "srcref")), "\033]8;", fixed = TRUE)
 })
 
+test_that("src_loc() decodes file:// URL filenames", {
+  rlang_cli_local_hyperlinks()
+
+  file <- withr::local_tempfile(fileext = ".R", lines = "x <- 1")
+  url <- paste0("file://", normalizePath(file))
+
+  srcfile <- srcfilecopy(url, "x <- 1")
+  srcref <- srcref(srcfile, c(1L, 1L, 1L, 6L, 1L, 6L))
+
+  # A `file://` URL filename must be decoded to a real path so the file is
+  # found and the link points at it, not `file://file:///...`.
+  expect_match(src_loc(srcref), "\033]8;", fixed = TRUE)
+  expect_no_match(src_loc(srcref), "file://file:", fixed = TRUE)
+})
+
 test_that("sibling streaks in tree backtraces", {
   f <- function(x) identity(identity(x))
   g <- function() f(f(h()))

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -673,6 +673,21 @@ test_that("src_loc() emits plain text for missing files (#1908)", {
   expect_match(src_loc(srcref), "exist\\.R:1:1")
 })
 
+test_that("src_loc() hyperlinks files sourced from another directory (#1908)", {
+  rlang_cli_local_hyperlinks()
+
+  dir <- withr::local_tempdir()
+  writeLines("f <- function() abort('foo')", file.path(dir, "code.R"))
+
+  env <- env()
+  withr::with_dir(dir, source("code.R", local = env, keep.source = TRUE))
+
+  # `srcfile$filename` is the relative "code.R", parsed from `dir`. Now that
+  # we're back in testthat's directory, resolution must use `srcfile$wd` for
+  # the link to point at the real file.
+  expect_match(src_loc(attr(env$f, "srcref")), "\033]8;", fixed = TRUE)
+})
+
 test_that("sibling streaks in tree backtraces", {
   f <- function(x) identity(identity(x))
   g <- function() f(f(h()))

--- a/tests/testthat/test-trace.R
+++ b/tests/testthat/test-trace.R
@@ -643,14 +643,17 @@ test_that("can format empty traces", {
 })
 
 test_that("backtrace is formatted with sources (#1396)", {
-  file <- tempfile("my_source", fileext = ".R")
-  with_srcref(
-    file = file,
-    "
-    f <- function() g()
-    g <- function() abort('foo')
-  "
+  # Keep the file on disk during `format()` so a live hyperlink is emitted.
+  # A hyperlink to a missing file is now suppressed (#1908).
+  file <- withr::local_tempfile(
+    pattern = "my_source",
+    lines = c(
+      "f <- function() g()",
+      "g <- function() abort('foo')"
+    ),
+    fileext = ".R"
   )
+  source(file, local = environment(), keep.source = TRUE)
   err <- catch_cnd(f(), "error")
 
   rlang_cli_local_hyperlinks()
@@ -658,6 +661,16 @@ test_that("backtrace is formatted with sources (#1396)", {
   lines <- format(err$trace)
   n_links <- sum(grepl("\033]8;.*my_source.*\\.R:", lines))
   expect_true(n_links > 0)
+})
+
+test_that("src_loc() emits plain text for missing files (#1908)", {
+  rlang_cli_local_hyperlinks()
+
+  srcfile <- srcfilecopy("/does/not/exist.R", "x <- 1")
+  srcref <- srcref(srcfile, c(1L, 1L, 1L, 6L, 1L, 6L))
+
+  expect_no_match(src_loc(srcref), "\033]8;", fixed = TRUE)
+  expect_match(src_loc(srcref), "exist\\.R:1:1")
 })
 
 test_that("sibling streaks in tree backtraces", {


### PR DESCRIPTION
Closes #1908 

- Don't emit terminal hyperlinks for files that don't exist

- Also fix an issue with `file://` srcref paths in Positron. This caused rlang to create `file://file://` URLs that couldn't be opened.