### PR TITLE
protect rotated ast root during injection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rlang (development version)
 
+* Fixed a use-after-free that could corrupt the result of `expr()` and other injection functions when `!!` injection required an operator precedence fixup of the AST and a garbage collection occurred during injection (#1910).
+
 * Fixed backtrace links for `file://` URLs in srcrefs.
 
 * Backtraces no longer emit file hyperlinks for source files that don't exist on disk, such as the `R CMD INSTALL` staging directory recorded when a package is installed kept srcrefs. The location is shown as plain text instead (#1908).

--- a/src/internal/ast-rotate.c
+++ b/src/internal/ast-rotate.c
@@ -315,9 +315,17 @@ static r_obj* maybe_rotate(
     // reuse it in the recursion
     initialise_rotation_info(info);
 
+    // After a rotation `op` is the detached upper pivot whose only
+    // reference is this C local, so protect it while the recursion
+    // below evaluates `!!` operands (#1910)
+    KEEP(op);
+
     // Recurse on the RHS of the upper pivot (which is now the new root)
     node_list_interp_fixup(op, NULL, env, info, false);
-    return maybe_rotate(op, env, info);
+    r_obj* out = maybe_rotate(op, env, info);
+
+    FREE(1);
+    return out;
 }
 
 /**

--- a/tests/testthat/test-nse-inject.R
+++ b/tests/testthat/test-nse-inject.R
@@ -148,6 +148,20 @@ test_that("lower pivot is correctly found (#1125)", {
   expect_equal_(expr(1 + !!2 * 3 * 4 + 5), expr(1 + 2 * 3 * 4 + 5))
 })
 
+test_that("rotated AST is protected from the GC during expansion (#1910)", {
+  f <- function() {
+    gc()
+    for (i in 1:200000) pairlist(i)
+    2
+  }
+  a <- 1
+  # Interpolate before the expectation so the injection is not done by
+  # the testthat-imported rlang, which may be a different installation
+  # in `load_all()` sessions
+  out <- expr(1 + !!a + !!f())
+  expect_identical(out, quote(1 + 1 + 2))
+})
+
 test_that("`!!` handles binary and unary `-` and `+`", {
   expect_identical_(expr(!!1 + 2), quote(1 + 2))
   expect_identical_(expr(!!1 - 2), quote(1 - 2))


### PR DESCRIPTION
Fixes #1910.

After a left rotation in `maybe_rotate()` (`src/internal/ast-rotate.c`), the new expression root is referenced only from a C local: the protect stack pins the old root, which has just become a *child* of the new one, and protection is only transitive downwards. The recursion that follows evaluates remaining `!!` operands via `r_eval()`, so a GC triggered by user code collects the new root's cons cells and the not-yet-expanded operands. See the issue for a deterministic reproducible example on CRAN rlang 1.3.0 and full analysis.

This PR protects the new root across the recursion. Each recursion level pins its current root, and the old root plus the unexpanded RHS chain are reachable from it. The second rotation branch is unchanged: it reattaches the pivot into the protected tree before recursing.

The regression test interpolates before calling `expect_identical()`: with the injection inline in the expectation, the interpolation would be performed by the rlang imported by testthat, which in `load_all()` sessions can be a different (installed) rlang than the package under test.

Verified: the new test fails against unfixed rlang 1.3.0 and passes with the fix; all other `test-nse-inject.R` expectations pass; an instrumented build confirms the rotated root survives a forced `R_gc()` in the previously unprotected window.