### PR TITLE
bump iterator state before pushing on sexp stack

### DIFF
--- a/src/rlang/walk.c
+++ b/src/rlang/walk.c
@@ -209,19 +209,9 @@ static bool sexp_next_incoming(
     bool has_attrib = sexp_has_attrib(child.type, child.x);
     enum sexp_iterator_type it_type = sexp_iterator_type(child.type, child.x);
 
-    if (it_type == SEXP_ITERATOR_TYPE_atomic && !has_attrib) {
-        child.p_state = NULL;
-        child.dir = R_SEXP_IT_DIRECTION_leaf;
-    } else {
-        init_incoming_stack_info(&child, it_type, has_attrib);
-
-        // Push incoming node on the stack so it can be visited again,
-        // either to descend its children or to visit it again on the
-        // outgoing trip
-        r_dyn_push_back(p_it->p_stack, &child);
-    }
-
-    // Bump state for next iteration
+    // Bump state for next iteration. This must be done before pushing
+    // `child` on the stack: the push may resize the stack and `p_info`
+    // points into the pre-resize buffer.
     if (state == SEXP_ITERATOR_STATE_elt) {
         ++p_info->v_arr;
         if (p_info->v_arr == p_info->v_arr_end) {
@@ -237,6 +227,18 @@ static bool sexp_next_incoming(
     // visit when `n > 0` and that the stack can be popped.
     if (*p_info->p_state == SEXP_ITERATOR_STATE_done) {
         p_info->dir = R_SEXP_IT_DIRECTION_outgoing;
+    }
+
+    if (it_type == SEXP_ITERATOR_TYPE_atomic && !has_attrib) {
+        child.p_state = NULL;
+        child.dir = R_SEXP_IT_DIRECTION_leaf;
+    } else {
+        init_incoming_stack_info(&child, it_type, has_attrib);
+
+        // Push incoming node on the stack so it can be visited again,
+        // either to descend its children or to visit it again on the
+        // outgoing trip
+        r_dyn_push_back(p_it->p_stack, &child);
     }
 
     r_ssize i = -1;


### PR DESCRIPTION
Fixes #1911.

`sexp_next_incoming()` (`src/rlang/walk.c`) receives `p_info` as a raw pointer into the traversal stack's dyn-array buffer. The child push could resize the stack — reallocating the buffer and dropping the old one's protection — after which the parent's state bump and incoming→outgoing flip were written through the stale pointer into the dead buffer. The live (copied) entry kept its pre-bump state, so the iterator revisited the same edge and re-traversed entire subtrees once depth exceeded the initial stack capacity of 256. It was also a latent use-after-free write, benign today only because no allocation happens between the resize and the writes.

This PR moves the state bump before the push. All reads of `p_info` used to build `child` happen earlier, so the reorder is behavior-preserving apart from the fix.

Since this code is only compiled under `RLANG_USE_PRIVATE_ACCESSORS` (and currently doesn't build on R >= 4.5, see the issue), there's no regression test in the default configuration. Verified in a flagged dev build with accessor stubs: before the fix, a depth-300 nested list yields 690 `sexp_iterate()` callback visits with 44 nodes visited twice as incoming; after the fix, exactly 601 visits (2n + 1) with no duplicates, and the depth-250 control is unchanged.