### PR TITLE
Pass call to ctxt_pronoun_get in .env subsetting methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rlang (development version)
 
+* `.env[[1]]` now fails with the intended "Must subset the context pronoun
+  with a string" error instead of `argument "call" is missing, with no
+  default`. The `$` and `[[` methods for the context pronoun now pass the
+  `call` argument to `ctxt_pronoun_get()`, like the data pronoun methods.
+
 * Fixed a use-after-free that could corrupt the result of `expr()` and other injection functions when `!!` injection required an operator precedence fixup of the AST and a garbage collection occurred during injection (#1910).
 
 * Fixed backtrace links for `file://` URLs in srcrefs.

--- a/R/eval-tidy.R
+++ b/R/eval-tidy.R
@@ -433,11 +433,11 @@ abort_data_pronoun <- function(nm, call) {
 
 #' @export
 `$.rlang_ctxt_pronoun` <- function(x, nm) {
-  ctxt_pronoun_get(x, nm)
+  ctxt_pronoun_get(x, nm, call = I(call("$", quote(.env), sym(nm))))
 }
 #' @export
 `[[.rlang_ctxt_pronoun` <- function(x, i, ...) {
-  ctxt_pronoun_get(x, i)
+  ctxt_pronoun_get(x, i, call = I(call("[[", quote(.env), substitute(i))))
 }
 ctxt_pronoun_get <- function(x, nm, call) {
   if (!is_string(nm)) {

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -468,7 +468,10 @@ test_that("the `.env` pronoun is not an environment", {
 })
 
 test_that("subsetting `.env` evaluates", {
-  expect_error(eval_tidy(quote(.env[[1]]), mtcars, env()), "Must subset the context pronoun with a string")
+  expect_error(
+    eval_tidy(quote(.env[[1]]), mtcars, env()),
+    "Must subset the context pronoun with a string"
+  )
   expect_error(eval_tidy(quote(.env[["cyl"]]), mtcars, env()), "not found")
   cyl <- "foo"
   expect_identical(eval_tidy(quote(.env$cyl), mtcars, env()), "foo")

--- a/tests/testthat/test-eval-tidy.R
+++ b/tests/testthat/test-eval-tidy.R
@@ -468,6 +468,7 @@ test_that("the `.env` pronoun is not an environment", {
 })
 
 test_that("subsetting `.env` evaluates", {
+  expect_error(eval_tidy(quote(.env[[1]]), mtcars, env()), "Must subset the context pronoun with a string")
   expect_error(eval_tidy(quote(.env[["cyl"]]), mtcars, env()), "not found")
   cyl <- "foo"
   expect_identical(eval_tidy(quote(.env$cyl), mtcars, env()), "foo")


### PR DESCRIPTION
`$.rlang_ctxt_pronoun` and `[[.rlang_ctxt_pronoun` in R/eval-tidy.R called `ctxt_pronoun_get()` without its required `call` argument:

```r
`$.rlang_ctxt_pronoun` <- function(x, nm) {
  ctxt_pronoun_get(x, nm)
}
```

`ctxt_pronoun_get()` passes `call` to `abort()` when the subscript is not a string. With a non-string subscript, `.env[[1]]` inside `eval_tidy()` therefore raised `argument "call" is missing, with no default` before `ctxt_pronoun_get()` could raise its own error.

Found during my most recent [ry](https://github.com/sims1253/ry) audit.
